### PR TITLE
Remove unused pick_ik dependency

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/package.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/package.xml
@@ -18,7 +18,6 @@
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_studio_behavior</exec_depend>
-  <exec_depend>pick_ik</exec_depend>
   <exec_depend>picknik_accessories</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>tf2_ros</exec_depend>


### PR DESCRIPTION
This should also keep us from pulling the moveit_core, moveit_msgs, and moveit_common binaries with rosdep