### PR TITLE
Keep joint jog jogging instead of hanging

### DIFF
--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/request_teleoperation.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/request_teleoperation.xml
@@ -34,7 +34,7 @@
                   <Control ID="Sequence">
                     <Action
                       ID="RetrieveJointStateParameter"
-                      timeout_sec="-1"
+                      timeout_sec="2"
                       joint_state="{target_joint_state}"
                     />
                     <SubTree


### PR DESCRIPTION
This PR stops joint jog from hanging when the race condition described in https://github.com/PickNikRobotics/moveit_studio/issues/9828 occurs simply by setting a timeout in a RetrieveJointStateParameter behavior. 

The race condition can still occur but the timeout prevents it from happening repeatedly.

## Testing
Add a delay to the changed RetrieveJointStateParameter behavior like shown to repro the race condition reliably.
![Screenshot 2024-12-18 at 9 48 40 AM](https://github.com/user-attachments/assets/8c055696-6e25-42d4-8b26-d6e39f110f94)
Then after switching from 'Waypoints' to 'Joint Jog' teleop modes, and manipulating a joint, you'll see an error from RetrieveJointStateParameter for timing out. Continuing to manipulate joints should then work.
