### PR TITLE
Update docker compose for GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,13 @@ ARG MOVEIT_STUDIO_BASE_IMAGE
 ARG USERNAME=studio-user
 ARG USER_UID=1000
 ARG USER_GID=1000
-ARG BASE=base
 
 ##################################################
 # Starting from the specified MoveIt Pro release #
 ##################################################
 # The image tag is specified in the argument itself.
 # hadolint ignore=DL3006
-FROM ${MOVEIT_STUDIO_BASE_IMAGE} AS base-base
+FROM ${MOVEIT_STUDIO_BASE_IMAGE} AS base
 
 # Create a non-root user
 ARG USERNAME
@@ -50,20 +49,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       /home/${USERNAME}/.ros && \
     chown -R $USER_UID:$USER_GID /home/${USERNAME} /opt/overlay_ws/
 
-FROM base-base AS base-nvidia
-ARG NVIDIA_DRIVER_PACKAGE
-ENV DEBIAN_FRONTEND=noninteractive
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
-   add-apt-repository ppa:graphics-drivers/ppa && \
-   apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends "${NVIDIA_DRIVER_PACKAGE}"
-
-ARG BASE
-# hadolint ignore=DL3006
-FROM base-${BASE} AS base
 # Install additional dependencies
 # You can also add any necessary apt-get install, pip install, etc. commands at this point.
 # NOTE: The /opt/overlay_ws folder contains MoveIt Pro binary packages and the source file.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,19 +6,17 @@
 services:
   # The base image that all MoveIt Pro services extend off of. Builds the user workspace.
   base:
-    build:
-      # List any arguments for building the user workspace here.
-      args:
-        # IMPORTANT: Optionally install Nvidia drivers for improved simulator performance with Nvidia GPUs.
-        # To do this you must
-        # 1. Uncomment the BASE and NVIDIA_DRIVER_PACKAGE build args below
-        # 2. Replace the 'nvidia-driver-555' apt package with the Nvidia driver version on your host, e.g. nvidia-driver-535, nvidia-driver-555. Use nvidia-smi on your host to determine the driver version.
-        # After rebuilding via `moveit_pro build` verify the drivers are active in your container by running `nvidia_smi` inside of `moveit_pro shell`.
-        # - BASE=nvidia
-        # - NVIDIA_DRIVER_PACKAGE=nvidia-driver-555
-
   # Starts the MoveIt Pro Agent and the Bridge between the Agent and the Web UI.
   agent_bridge:
+
+    # IMPORTANT: Enable Nvidia GPUs by uncommenting the lines below:
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]
 
   # Starts the robot drivers.
   drivers:


### PR DESCRIPTION
It seems that on my machine the instructions do not enable GPU support. Following them (uncommenting the `docker-compose.yaml` lines and `moveit_pro build`ing) I am unable to run `nvidia-smi` inside the container and no GPUs are found, but I do see the stage in which the nvidia drivers are installed when the image is built. If I leave the docker-compose file as it in in this PR (with the lines uncommented), I don't have to build anything differently and I can run `nvidia-smi` or `nvtop` and see my GPU is in use