### PR TITLE
fixed ur robot lighting issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/picknik_accessories"]
 	path = src/picknik_accessories
 	url = https://github.com/PickNikRobotics/picknik_accessories.git
+[submodule "src/external_dependencies/ur_description"]
+	path = src/external_dependencies/ur_description
+	url = https://github.com/PickNikRobotics/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
# Description

Removed the Blender lighting and camera artifacts to render the UR20, UR3, and UR5 (not e) bots correctly.

## Testing Instructions
Change the `picknik_ur_base_config config.yaml` to use the UR20 model and observe it looks normal.

Before:
![Screenshot from 2025-01-17 13-10-40](https://github.com/user-attachments/assets/c06fd6cf-172f-4817-9b47-5601a2b486c7)