### PR TITLE
Stop git from diff-ing mesh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.onnx filter=lfs diff=lfs merge=lfs -text
+*.stl binary -diff
+*.dae binary -diff


### PR DESCRIPTION
Sometimes my git commands hang for a while in this repo, I suspect the large number of mesh files could be a culprit. This change keeps git from running diffs on .dae and .stl files