### PR TITLE
Add clang format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,79 @@
+---
+BasedOnStyle:  Google
+ColumnLimit:    120
+MaxEmptyLinesToKeep: 1
+
+# Allow us to adhere to https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
+IncludeBlocks: Preserve
+SortIncludes: true
+
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: None
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+ExperimentalAutoDetectBinPacking: false
+ObjCSpaceBeforeProtocolList: true
+Cpp11BracedListStyle: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+
+PenaltyExcessCharacter: 50
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 1000
+PenaltyBreakFirstLessLess: 10
+PenaltyBreakString: 100
+PenaltyReturnTypeOnItsOwnLine: 50
+
+SpacesBeforeTrailingComments: 2
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+IncludeBlocks: Preserve
+...

--- a/src/example_behaviors/include/example_behaviors/example_add_two_ints_service_client.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_add_two_ints_service_client.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <moveit_studio_behavior_interface/service_client_behavior_base.hpp>
 #include <example_interfaces/srv/add_two_ints.hpp>
+#include <moveit_studio_behavior_interface/service_client_behavior_base.hpp>
 
 using moveit_studio::behaviors::BehaviorContext;
 using moveit_studio::behaviors::ServiceClientBehaviorBase;
@@ -13,7 +13,7 @@ class ExampleAddTwoIntsServiceClient final : public ServiceClientBehaviorBase<Ad
 {
 public:
   ExampleAddTwoIntsServiceClient(const std::string& name, const BT::NodeConfiguration& config,
-                          const std::shared_ptr<BehaviorContext>& shared_resources);
+                                 const std::shared_ptr<BehaviorContext>& shared_resources);
 
   /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
   static BT::PortsList providedPorts();

--- a/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <Eigen/Core>
 #include <behaviortree_cpp/action_node.h>
 #include <behaviortree_cpp/bt_factory.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
+#include <spdlog/spdlog.h>
+#include <yaml-cpp/yaml.h>
+#include <Eigen/Core>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit_studio_behavior/utils/trajectory_utils.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>
 #include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 #include <moveit_task_constructor_msgs/msg/solution.hpp>
-#include <spdlog/spdlog.h>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
-#include <yaml-cpp/yaml.h>
 
 namespace example_behaviors
 {
@@ -29,11 +29,13 @@ namespace example_behaviors
  * | sampling_rate     | Input         | int                                                     |
  * | joint_trajectory  | Output        | trajectory_msgs::msg::JointTrajectory                   |
  */
-class ExampleConvertMtcSolutionToJointTrajectory final : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
+class ExampleConvertMtcSolutionToJointTrajectory final
+  : public moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>
 {
 public:
-  ExampleConvertMtcSolutionToJointTrajectory(const std::string& name, const BT::NodeConfiguration& config,
-                                      const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+  ExampleConvertMtcSolutionToJointTrajectory(
+      const std::string& name, const BT::NodeConfiguration& config,
+      const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   static BT::PortsList providedPorts();
 

--- a/src/example_behaviors/include/example_behaviors/example_delayed_message.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_delayed_message.hpp
@@ -12,7 +12,8 @@
 namespace example_behaviors
 {
 /**
- * @brief ExampleDelayedMessage will use FailureLoggerROS to log a "Hello World" message after the duration specified on the input port
+ * @brief ExampleDelayedMessage will use FailureLoggerROS to log a "Hello World" message after the duration specified on
+ * the input port
  */
 class ExampleDelayedMessage : public moveit_studio::behaviors::SharedResourcesNode<BT::StatefulActionNode>
 {
@@ -34,7 +35,7 @@ public:
    * the initialize() function is called, so these classes should not be used within the constructor.
    */
   ExampleDelayedMessage(const std::string& name, const BT::NodeConfiguration& config,
-                 const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                        const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   /**
    * @brief Implementation of the required providedPorts() function for the delayed_message Behavior.

--- a/src/example_behaviors/include/example_behaviors/example_fibonacci_action_client.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_fibonacci_action_client.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <moveit_studio_behavior_interface/action_client_behavior_base.hpp>
 #include <example_interfaces/action/fibonacci.hpp>
+#include <moveit_studio_behavior_interface/action_client_behavior_base.hpp>
 
 using moveit_studio::behaviors::ActionClientBehaviorBase;
 using moveit_studio::behaviors::BehaviorContext;
@@ -13,7 +13,7 @@ class ExampleFibonacciActionClient final : public ActionClientBehaviorBase<Fibon
 {
 public:
   ExampleFibonacciActionClient(const std::string& name, const BT::NodeConfiguration& config,
-                        const std::shared_ptr<BehaviorContext>& shared_resources);
+                               const std::shared_ptr<BehaviorContext>& shared_resources);
 
   /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
   static BT::PortsList providedPorts();

--- a/src/example_behaviors/include/example_behaviors/example_get_string_from_topic.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_get_string_from_topic.hpp
@@ -12,7 +12,7 @@ class ExampleGetStringFromTopic final : public GetMessageFromTopicBehaviorBase<s
 {
 public:
   ExampleGetStringFromTopic(const std::string& name, const BT::NodeConfiguration& config,
-                     const std::shared_ptr<BehaviorContext>& shared_resources);
+                            const std::shared_ptr<BehaviorContext>& shared_resources);
 
   /** @brief Implementation of the required providedPorts() function for the hello_world Behavior. */
   static BT::PortsList providedPorts();

--- a/src/example_behaviors/include/example_behaviors/example_hello_world.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_hello_world.hpp
@@ -26,7 +26,7 @@ public:
    * the initialize() function is called, so these classes should not be used within the constructor.
    */
   ExampleHelloWorld(const std::string& name, const BT::NodeConfiguration& config,
-             const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   /**
    * @brief Implementation of the required providedPorts() function for the hello_world Behavior.
@@ -48,9 +48,9 @@ public:
   /**
    * @brief Implementation of BT::SyncActionNode::tick() for ExampleHelloWorld.
    * @details This function is where the Behavior performs its work when the behavior tree is being run.
-   * Since ExampleHelloWorld is derived from BT::SyncActionNode, it is very important that its tick() function always finishes
-   * very quickly. If tick() blocks before returning, it will block execution of the entire behavior tree, which may
-   * have undesirable consequences for other Behaviors that require a fast update rate to work correctly.
+   * Since ExampleHelloWorld is derived from BT::SyncActionNode, it is very important that its tick() function always
+   * finishes very quickly. If tick() blocks before returning, it will block execution of the entire behavior tree,
+   * which may have undesirable consequences for other Behaviors that require a fast update rate to work correctly.
    * @return BT::NodeStatus::RUNNING, BT::NodeStatus::SUCCESS, or BT::NodeStatus::FAILURE depending on the result of the
    * work done in this function.
    */

--- a/src/example_behaviors/include/example_behaviors/example_ndt_registration.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_ndt_registration.hpp
@@ -3,9 +3,8 @@
 #include <behaviortree_cpp/action_node.h>
 
 // This header includes the SharedResourcesNode type
-#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 #include <moveit_studio_behavior_interface/async_behavior_base.hpp>
-
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 
 namespace example_behaviors
 {
@@ -17,17 +16,25 @@ class ExampleNDTRegistration : public moveit_studio::behaviors::AsyncBehaviorBas
 public:
   /**
    * @brief Constructor for the behavior.
-   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
-   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @details An important limitation is that the members of the base Behavior class are not instantiated until after the initialize() function is called, so these classes should not be used within the constructor.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in
+   * the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
    */
-  ExampleNDTRegistration(const std::string& name, const BT::NodeConfiguration& config, const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+  ExampleNDTRegistration(const std::string& name, const BT::NodeConfiguration& config,
+                         const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   /**
    * @brief Implementation of the required providedPorts() function for the Behavior.
-   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function must return an empty BT::PortsList.
-   * This function returns a list of ports with their names and port info, which is used internally by the behavior tree.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
    * @return See ndt_registration.cpp for port list and description.
    */
   static BT::PortsList providedPorts();

--- a/src/example_behaviors/include/example_behaviors/example_publish_color_rgba.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_publish_color_rgba.hpp
@@ -16,7 +16,7 @@ class ExamplePublishColorRGBA final : public moveit_studio::behaviors::SharedRes
 {
 public:
   ExamplePublishColorRGBA(const std::string& name, const BT::NodeConfiguration& config,
-                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                          const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   static BT::PortsList providedPorts();
 

--- a/src/example_behaviors/include/example_behaviors/example_ransac_registration.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_ransac_registration.hpp
@@ -3,9 +3,8 @@
 #include <behaviortree_cpp/action_node.h>
 
 // This header includes the SharedResourcesNode type
-#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 #include <moveit_studio_behavior_interface/async_behavior_base.hpp>
-
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 
 namespace example_behaviors
 {
@@ -17,17 +16,25 @@ class ExampleRANSACRegistration : public moveit_studio::behaviors::AsyncBehavior
 public:
   /**
    * @brief Constructor for the behavior.
-   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
-   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @details An important limitation is that the members of the base Behavior class are not instantiated until after the initialize() function is called, so these classes should not be used within the constructor.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in
+   * the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
    */
-  ExampleRANSACRegistration(const std::string& name, const BT::NodeConfiguration& config, const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+  ExampleRANSACRegistration(const std::string& name, const BT::NodeConfiguration& config,
+                            const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   /**
    * @brief Implementation of the required providedPorts() function for the Behavior.
-   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function must return an empty BT::PortsList.
-   * This function returns a list of ports with their names and port info, which is used internally by the behavior tree.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
    * @return See ransac_registration.cpp for port list and description.
    */
   static BT::PortsList providedPorts();

--- a/src/example_behaviors/include/example_behaviors/example_sam2_segmentation.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_sam2_segmentation.hpp
@@ -11,7 +11,6 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <tl_expected/expected.hpp>
 
-
 namespace example_behaviors
 {
 /**
@@ -20,39 +19,44 @@ namespace example_behaviors
 class ExampleSAM2Segmentation : public moveit_studio::behaviors::AsyncBehaviorBase
 {
 public:
-/**
+  /**
    * @brief Constructor for the ExampleSAM2Segmentation behavior.
-   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @details An important limitation is that the members of the base Behavior class are not instantiated until after the initialize() function is called, so these classes should not be used within the constructor.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
    */
- ExampleSAM2Segmentation(const std::string& name, const BT::NodeConfiguration& config,
-                                     const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+  ExampleSAM2Segmentation(const std::string& name, const BT::NodeConfiguration& config,
+                          const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
- /**
-  * @brief Implementation of the required providedPorts() function for the Behavior.
-  * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function must return an empty BT::PortsList.
-  * This function returns a list of ports with their names and port info, which is used internally by the behavior tree.
-  * @return List of ports for the behavior.
-  */
- static BT::PortsList providedPorts();
+  /**
+   * @brief Implementation of the required providedPorts() function for the Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
+   * @return List of ports for the behavior.
+   */
+  static BT::PortsList providedPorts();
 
- /**
-  * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
-  * subcategory, in the MoveIt Studio Developer Tool.
-  * @return A BT::KeyValueVector containing the Behavior metadata.
-  */
- static BT::KeyValueVector metadata();
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
 
 protected:
   tl::expected<bool, std::string> doWork() override;
 
-
 private:
- std::unique_ptr<moveit_pro_ml::SAM2> sam2_;
- moveit_pro_ml::ONNXImage onnx_image_;
- sensor_msgs::msg::Image mask_image_msg_;
- moveit_studio_vision_msgs::msg::Mask2D mask_msg_;
+  std::unique_ptr<moveit_pro_ml::SAM2> sam2_;
+  moveit_pro_ml::ONNXImage onnx_image_;
+  sensor_msgs::msg::Image mask_image_msg_;
+  moveit_studio_vision_msgs::msg::Mask2D mask_msg_;
 
   /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
   std::shared_future<tl::expected<bool, std::string>>& getFuture() override
@@ -62,6 +66,5 @@ private:
 
   /** @brief Classes derived from AsyncBehaviorBase must have this shared_future as a class member */
   std::shared_future<tl::expected<bool, std::string>> future_;
-
 };
 }  // namespace example_behaviors

--- a/src/example_behaviors/include/example_behaviors/example_setup_mtc_pick_from_pose.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_setup_mtc_pick_from_pose.hpp
@@ -21,7 +21,7 @@ class ExampleSetupMtcPickFromPose final : public moveit_studio::behaviors::Share
 {
 public:
   ExampleSetupMtcPickFromPose(const std::string& name, const BT::NodeConfiguration& config,
-                       const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                              const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   static BT::PortsList providedPorts();
 

--- a/src/example_behaviors/include/example_behaviors/example_setup_mtc_place_from_pose.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_setup_mtc_place_from_pose.hpp
@@ -21,7 +21,7 @@ class ExampleSetupMtcPlaceFromPose final : public moveit_studio::behaviors::Shar
 {
 public:
   ExampleSetupMtcPlaceFromPose(const std::string& name, const BT::NodeConfiguration& config,
-                        const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                               const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   static BT::PortsList providedPorts();
 

--- a/src/example_behaviors/include/example_behaviors/example_setup_mtc_wave_hand.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_setup_mtc_wave_hand.hpp
@@ -3,10 +3,10 @@
 #pragma once
 
 #include <behaviortree_cpp/action_node.h>
-#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
+#include <moveit_studio_behavior_interface/async_behavior_base.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>
-#include <moveit_studio_behavior_interface/async_behavior_base.hpp>
+#include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 
 namespace example_behaviors
 {
@@ -39,7 +39,7 @@ public:
    * behavior tree factory when this Behavior is created within a new behavior tree.
    */
   ExampleSetupMTCWaveHand(const std::string& name, const BT::NodeConfiguration& config,
-                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+                          const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
   /**
    * @brief Implementation of the required providedPorts() function for the ExampleSetupMTCWaveHand Behavior.

--- a/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
+++ b/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
@@ -27,14 +27,11 @@ BT::PortsList ExampleConvertMtcSolutionToJointTrajectory::providedPorts()
   return {
     BT::InputPort<moveit_task_constructor_msgs::msg::Solution>(kPortIDSolution, "{mtc_solution}",
                                                                "MoveIt Task Constructor solution."),
-    BT::InputPort<std::string>(kPortIDJointGroup, "manipulator",
-                               "Joint group name used in the MTC solution."),
-    BT::InputPort<double>(kPortIDVelocityScalingFactor, 1.0,
-                          "Velocity scaling factor for trajectory generation."),
+    BT::InputPort<std::string>(kPortIDJointGroup, "manipulator", "Joint group name used in the MTC solution."),
+    BT::InputPort<double>(kPortIDVelocityScalingFactor, 1.0, "Velocity scaling factor for trajectory generation."),
     BT::InputPort<double>(kPortIDAccelerationScalingFactor, 1.0,
                           "Acceleration scaling factor for trajectory generation."),
-    BT::InputPort<int>(kPortIDSamplingRate, 100,
-                       "Sampling rate for trajectory generation."),
+    BT::InputPort<int>(kPortIDSamplingRate, 100, "Sampling rate for trajectory generation."),
     BT::OutputPort<trajectory_msgs::msg::JointTrajectory>(kPortIDJointTrajectory, "{joint_trajectory_msg}",
                                                           "Resulting joint trajectory."),
   };
@@ -43,7 +40,8 @@ BT::PortsList ExampleConvertMtcSolutionToJointTrajectory::providedPorts()
 BT::KeyValueVector ExampleConvertMtcSolutionToJointTrajectory::metadata()
 {
   return { { "subcategory", "Motion Planning" },
-           { "description", "Extracts joint space trajectories from an MTC solution and adds time parameterization using TOTG." } };
+           { "description",
+             "Extracts joint space trajectories from an MTC solution and adds time parameterization using TOTG." } };
 }
 
 BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
@@ -58,7 +56,9 @@ BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
   const auto sampling_rate = getInput<int>(kPortIDSamplingRate);
 
   // Check that the required input data port was set
-  if (const auto error = maybe_error(solution, joint_group_name, velocity_scaling_factor, acceleration_scaling_factor, sampling_rate); error)
+  if (const auto error =
+          maybe_error(solution, joint_group_name, velocity_scaling_factor, acceleration_scaling_factor, sampling_rate);
+      error)
   {
     spdlog::error("Failed to get required value from input data port: {}", error.value());
     return BT::NodeStatus::FAILURE;
@@ -90,8 +90,8 @@ BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
   const auto& waypoints = extractJointPositions(solution.value());
 
   // Use trajectory_utils.hpp to create a trajectory
-  auto trajectory_result = createTrajectoryFromWaypoints(
-      *joint_model_group, waypoints, velocity_scaling_factor.value(), acceleration_scaling_factor.value(), sampling_rate.value());
+  auto trajectory_result = createTrajectoryFromWaypoints(*joint_model_group, waypoints, velocity_scaling_factor.value(),
+                                                         acceleration_scaling_factor.value(), sampling_rate.value());
 
   if (!trajectory_result)
   {
@@ -108,7 +108,8 @@ BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
   return BT::NodeStatus::SUCCESS;
 }
 
-const std::vector<Eigen::VectorXd>& ExampleConvertMtcSolutionToJointTrajectory::extractJointPositions(const moveit_task_constructor_msgs::msg::Solution& solution)
+const std::vector<Eigen::VectorXd>& ExampleConvertMtcSolutionToJointTrajectory::extractJointPositions(
+    const moveit_task_constructor_msgs::msg::Solution& solution)
 {
   static std::vector<Eigen::VectorXd> waypoints;
   waypoints.clear();
@@ -123,8 +124,7 @@ const std::vector<Eigen::VectorXd>& ExampleConvertMtcSolutionToJointTrajectory::
       continue;
     }
 
-    spdlog::info("Processing sub-trajectory {} with {} points.",
-                 sub_traj_idx, joint_traj.points.size());
+    spdlog::info("Processing sub-trajectory {} with {} points.", sub_traj_idx, joint_traj.points.size());
 
     for (const auto& point : joint_traj.points)
     {

--- a/src/example_behaviors/src/example_delayed_message.cpp
+++ b/src/example_behaviors/src/example_delayed_message.cpp
@@ -2,8 +2,9 @@
 
 namespace example_behaviors
 {
-ExampleDelayedMessage::ExampleDelayedMessage(const std::string& name, const BT::NodeConfiguration& config,
-                               const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+ExampleDelayedMessage::ExampleDelayedMessage(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
   : moveit_studio::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
 {
 }

--- a/src/example_behaviors/src/example_fibonacci_action_client.cpp
+++ b/src/example_behaviors/src/example_fibonacci_action_client.cpp
@@ -55,7 +55,8 @@ tl::expected<Fibonacci::Goal, std::string> ExampleFibonacciActionClient::createG
   return example_interfaces::build<Fibonacci::Goal>().order(order.value());
 }
 
-tl::expected<bool, std::string> ExampleFibonacciActionClient::processResult(const std::shared_ptr<Fibonacci::Result> result)
+tl::expected<bool, std::string>
+ExampleFibonacciActionClient::processResult(const std::shared_ptr<Fibonacci::Result> result)
 {
   std::stringstream stream;
   for (const auto& value : result->sequence)

--- a/src/example_behaviors/src/example_get_string_from_topic.cpp
+++ b/src/example_behaviors/src/example_get_string_from_topic.cpp
@@ -6,7 +6,7 @@
 namespace example_behaviors
 {
 ExampleGetStringFromTopic::ExampleGetStringFromTopic(const std::string& name, const BT::NodeConfiguration& config,
-                                       const std::shared_ptr<BehaviorContext>& shared_resources)
+                                                     const std::shared_ptr<BehaviorContext>& shared_resources)
   : GetMessageFromTopicBehaviorBase<std_msgs::msg::String>(name, config, shared_resources)
 {
 }

--- a/src/example_behaviors/src/example_hello_world.cpp
+++ b/src/example_behaviors/src/example_hello_world.cpp
@@ -3,7 +3,7 @@
 namespace example_behaviors
 {
 ExampleHelloWorld::ExampleHelloWorld(const std::string& name, const BT::NodeConfiguration& config,
-                       const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+                                     const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
   : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
 {
 }

--- a/src/example_behaviors/src/example_publish_color_rgba.cpp
+++ b/src/example_behaviors/src/example_publish_color_rgba.cpp
@@ -2,8 +2,9 @@
 
 namespace example_behaviors
 {
-ExamplePublishColorRGBA::ExamplePublishColorRGBA(const std::string& name, const BT::NodeConfiguration& config,
-                                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+ExamplePublishColorRGBA::ExamplePublishColorRGBA(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
   : moveit_studio::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
   , publisher_{ shared_resources_->node->create_publisher<std_msgs::msg::ColorRGBA>("/my_topic", rclcpp::QoS(1)) }
 {

--- a/src/example_behaviors/src/example_ransac_registration.cpp
+++ b/src/example_behaviors/src/example_ransac_registration.cpp
@@ -1,26 +1,25 @@
-#include <example_behaviors/example_ransac_registration.hpp>
+#include <pcl/features/fpfh.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/filters/approximate_voxel_grid.h>
+#include <pcl/keypoints/uniform_sampling.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl/registration/ndt.h>
-#include <tl_expected/expected.hpp>
+#include <pcl/registration/sample_consensus_prerejective.h>
+#include <pcl/search/kdtree.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <example_behaviors/example_ransac_registration.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <moveit_studio_behavior_interface/async_behavior_base.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <moveit_studio_vision/common/get_all_indices.hpp>
+#include <moveit_studio_vision/common/select_point_indices.hpp>
+#include <moveit_studio_vision/pointcloud/point_cloud_tools.hpp>
+#include <moveit_studio_vision_msgs/msg/mask3_d.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tl_expected/expected.hpp>
-#include <moveit_studio_vision_msgs/msg/mask3_d.hpp>
-#include <pcl_conversions/pcl_conversions.h>
-#include <moveit_studio_vision/common/get_all_indices.hpp>
-#include <moveit_studio_vision/common/select_point_indices.hpp>
-#include <moveit_studio_vision/pointcloud/point_cloud_tools.hpp>
-#include <pcl/filters/approximate_voxel_grid.h>
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <pcl/features/normal_3d.h>
-#include <pcl/features/fpfh.h>
-#include <pcl/keypoints/uniform_sampling.h>
-#include <pcl/registration/sample_consensus_prerejective.h>
-#include <pcl/search/kdtree.h>
 
 namespace example_behaviors
 {
@@ -33,8 +32,9 @@ getFilteredPointCloudFromMessage(const sensor_msgs::msg::PointCloud2& cloud_msg)
   const auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
   pcl::fromROSMsg(cloud_msg, *cloud);
 
-  const pcl::PointIndices valid_indices = moveit_studio::selectPointIndices(*cloud, moveit_studio::point_cloud_tools::getAllIndices(cloud),
-                                                             moveit_studio::NeitherNanNorNearZeroPointValidator<pcl::PointXYZRGB>);
+  const pcl::PointIndices valid_indices =
+      moveit_studio::selectPointIndices(*cloud, moveit_studio::point_cloud_tools::getAllIndices(cloud),
+                                        moveit_studio::NeitherNanNorNearZeroPointValidator<pcl::PointXYZRGB>);
   auto filtered_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
   pcl::copyPointCloud(*cloud, valid_indices, *filtered_cloud);
 
@@ -50,7 +50,6 @@ ExampleRANSACRegistration::ExampleRANSACRegistration(
 {
 }
 
-
 BT::PortsList ExampleRANSACRegistration::providedPorts()
 {
   return { BT::InputPort<sensor_msgs::msg::PointCloud2>("base_point_cloud", "{point_cloud}",
@@ -63,18 +62,12 @@ BT::PortsList ExampleRANSACRegistration::providedPorts()
                               "from the actual transform, but it may take longer to complete."),
            BT::InputPort<double>("transformation_epsilon", 0.001,
                                  "Minimum transformation difference for termination condition <double>"),
-           BT::InputPort<double>("step_size", 0.1,
-                                 "Maximum step size for More-Thuente line search <double>"),
-           BT::InputPort<double>("resolution", 1.0,
-                                 "Resolution of NDT grid structure (VoxelGridCovariance) <double>"),
-           BT::InputPort<double>("inlier_threshold", 1.0,
-                                 "Inlier threshold for RANSAC <double>"),
-           BT::InputPort<double>("uniform_sampling_radius", 0.02,
-                                 "Radius for uniform sampling of keypoints <double>"),
-           BT::InputPort<int>("k_search", 10,
-                              "Number of nearest neighbors to use for normal estimation <int>"),
-           BT::InputPort<double>("feature_radius", 0.05,
-                                 "Radius for feature estimation <double>"),
+           BT::InputPort<double>("step_size", 0.1, "Maximum step size for More-Thuente line search <double>"),
+           BT::InputPort<double>("resolution", 1.0, "Resolution of NDT grid structure (VoxelGridCovariance) <double>"),
+           BT::InputPort<double>("inlier_threshold", 1.0, "Inlier threshold for RANSAC <double>"),
+           BT::InputPort<double>("uniform_sampling_radius", 0.02, "Radius for uniform sampling of keypoints <double>"),
+           BT::InputPort<int>("k_search", 10, "Number of nearest neighbors to use for normal estimation <int>"),
+           BT::InputPort<double>("feature_radius", 0.05, "Radius for feature estimation <double>"),
            BT::OutputPort<geometry_msgs::msg::PoseStamped>("target_pose_in_base_frame", "{target_pose}",
                                                            "The pose of the target point cloud relative to the frame "
                                                            "of the base point cloud.") };
@@ -82,13 +75,13 @@ BT::PortsList ExampleRANSACRegistration::providedPorts()
 
 BT::KeyValueVector ExampleRANSACRegistration::metadata()
 {
-  return { {"subcategory", "Perception - 3D Point Cloud"}, {"description", "Finds the pose of a target point cloud relative to the base frame of a base point cloud using the Normal Distributions Transform (NDT) algorithm"} };
+  return { { "subcategory", "Perception - 3D Point Cloud" },
+           { "description", "Finds the pose of a target point cloud relative to the base frame of a base point cloud "
+                            "using the Normal Distributions Transform (NDT) algorithm" } };
 }
-
 
 tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
 {
-
   const auto base_point_cloud_msg = getInput<sensor_msgs::msg::PointCloud2>("base_point_cloud");
   const auto target_point_cloud_msg = getInput<sensor_msgs::msg::PointCloud2>("target_point_cloud");
   const auto max_iterations = getInput<int>("max_iterations");
@@ -98,9 +91,13 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
   const auto k_search = getInput<int>("k_search");
   const auto feature_radius = getInput<double>("feature_radius");
 
-  if (const auto error = moveit_studio::behaviors::maybe_error(base_point_cloud_msg, target_point_cloud_msg, max_iterations, transformation_epsilon, inlier_threshold, uniform_sampling_radius, k_search, feature_radius); error)
+  if (const auto error = moveit_studio::behaviors::maybe_error(base_point_cloud_msg, target_point_cloud_msg,
+                                                               max_iterations, transformation_epsilon, inlier_threshold,
+                                                               uniform_sampling_radius, k_search, feature_radius);
+      error)
   {
-    RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Failed to get required value from input data port: %s", error.value().c_str());
+    RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Failed to get required value from input data port: %s",
+                 error.value().c_str());
     return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
   }
 
@@ -134,7 +131,8 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
   normal_est.compute(*target_normals);
 
   // Logging normals
-  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Computed %ld base normals and %ld target normals", base_normals->size(), target_normals->size());
+  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Computed %ld base normals and %ld target normals", base_normals->size(),
+               target_normals->size());
 
   // Keypoint selection
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr base_keypoints(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -150,7 +148,8 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
   uniform_sampling.filter(*target_keypoints);
 
   // Logging keypoints
-  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Selected %ld base keypoints and %ld target keypoints", base_keypoints->size(), target_keypoints->size());
+  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Selected %ld base keypoints and %ld target keypoints",
+               base_keypoints->size(), target_keypoints->size());
 
   // Estimating normals for keypoints
   pcl::PointCloud<pcl::Normal>::Ptr base_keypoint_normals(new pcl::PointCloud<pcl::Normal>);
@@ -198,7 +197,8 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
   fpfh_est.compute(*target_features);
 
   // Logging features
-  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Computed %ld base features and %ld target features", base_features->size(), target_features->size());
+  RCLCPP_ERROR(rclcpp::get_logger("Logger"), "Computed %ld base features and %ld target features",
+               base_features->size(), target_features->size());
 
   // RANSAC alignment
   pcl::SampleConsensusPrerejective<pcl::PointXYZRGB, pcl::PointXYZRGB, pcl::FPFHSignature33> align;
@@ -218,7 +218,8 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
 
   if (!align.hasConverged())
   {
-    RCLCPP_ERROR(rclcpp::get_logger("Logger"), "RANSAC could not converge to a transform that aligns both point clouds");
+    RCLCPP_ERROR(rclcpp::get_logger("Logger"),
+                 "RANSAC could not converge to a transform that aligns both point clouds");
     return tl::make_unexpected("RANSAC could not converge to a transform that aligns both point clouds");
   }
 
@@ -230,6 +231,5 @@ tl::expected<bool, std::string> ExampleRANSACRegistration::doWork()
 
   return true;
 }
-
 
 }  // namespace example_behaviors

--- a/src/example_behaviors/src/example_sam2_segmentation.cpp
+++ b/src/example_behaviors/src/example_sam2_segmentation.cpp
@@ -14,129 +14,128 @@
 
 namespace
 {
-  constexpr auto kPortImage = "image";
-  constexpr auto kPortImageDefault = "{image}";
-  constexpr auto kPortPoint = "pixel_coords";
-  constexpr auto kPortPointDefault = "{pixel_coords}";
-  constexpr auto kPortMasks = "masks2d";
-  constexpr auto kPortMasksDefault = "{masks2d}";
+constexpr auto kPortImage = "image";
+constexpr auto kPortImageDefault = "{image}";
+constexpr auto kPortPoint = "pixel_coords";
+constexpr auto kPortPointDefault = "{pixel_coords}";
+constexpr auto kPortMasks = "masks2d";
+constexpr auto kPortMasksDefault = "{masks2d}";
 
-  constexpr auto kImageInferenceWidth = 1024;
-  constexpr auto kImageInferenceHeight = 1024;
-} // namespace
+constexpr auto kImageInferenceWidth = 1024;
+constexpr auto kImageInferenceHeight = 1024;
+}  // namespace
 
 namespace example_behaviors
 {
-  // Convert a ROS image message to the ONNX image format used by the SAM 2 model
-  void set_onnx_image_from_ros_image(const sensor_msgs::msg::Image& image_msg,
-                                                       moveit_pro_ml::ONNXImage& onnx_image)
+// Convert a ROS image message to the ONNX image format used by the SAM 2 model
+void set_onnx_image_from_ros_image(const sensor_msgs::msg::Image& image_msg, moveit_pro_ml::ONNXImage& onnx_image)
+{
+  onnx_image.shape = { 1, image_msg.height, image_msg.width, 3 };
+  onnx_image.data.resize(image_msg.height * image_msg.width * 3);
+  const int stride = image_msg.encoding != "rgb8" ? 3 : 4;
+  for (size_t i = 0; i < onnx_image.data.size(); i += stride)
   {
-    onnx_image.shape = {1, image_msg.height, image_msg.width, 3};
-    onnx_image.data.resize(image_msg.height * image_msg.width * 3);
-    const int stride = image_msg.encoding != "rgb8" ? 3: 4;
-    for (size_t i = 0; i < onnx_image.data.size(); i+=stride)
-    {
-      onnx_image.data[i] = static_cast<float>(image_msg.data[i]) / 255.0f;
-      onnx_image.data[i+1] = static_cast<float>(image_msg.data[i+1]) / 255.0f;
-      onnx_image.data[i+2] = static_cast<float>(image_msg.data[i+2]) / 255.0f;
-    }
+    onnx_image.data[i] = static_cast<float>(image_msg.data[i]) / 255.0f;
+    onnx_image.data[i + 1] = static_cast<float>(image_msg.data[i + 1]) / 255.0f;
+    onnx_image.data[i + 2] = static_cast<float>(image_msg.data[i + 2]) / 255.0f;
+  }
+}
+
+// Converts a single channel ONNX image mask to a ROS mask message.
+void set_ros_mask_from_onnx_mask(const moveit_pro_ml::ONNXImage& onnx_image, sensor_msgs::msg::Image& mask_image_msg,
+                                 moveit_studio_vision_msgs::msg::Mask2D& mask_msg)
+{
+  mask_image_msg.height = static_cast<uint32_t>(onnx_image.shape[0]);
+  mask_image_msg.width = static_cast<uint32_t>(onnx_image.shape[1]);
+  mask_image_msg.encoding = "mono8";
+  mask_image_msg.data.resize(mask_image_msg.height * mask_image_msg.width);
+  mask_image_msg.step = mask_image_msg.width;
+  for (size_t i = 0; i < onnx_image.data.size(); ++i)
+  {
+    mask_image_msg.data[i] = onnx_image.data[i] > 0.5 ? 255 : 0;
+  }
+  mask_msg.pixels = mask_image_msg;
+  mask_msg.x = 0;
+  mask_msg.y = 0;
+}
+
+ExampleSAM2Segmentation::ExampleSAM2Segmentation(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : moveit_studio::behaviors::AsyncBehaviorBase(name, config, shared_resources)
+{
+  const std::filesystem::path package_path = ament_index_cpp::get_package_share_directory("example_behaviors");
+  const std::filesystem::path encoder_onnx_file = package_path / "models" / "sam2_hiera_large_encoder.onnx";
+  const std::filesystem::path decoder_onnx_file = package_path / "models" / "decoder.onnx";
+  sam2_ = std::make_unique<moveit_pro_ml::SAM2>(encoder_onnx_file, decoder_onnx_file);
+}
+
+BT::PortsList ExampleSAM2Segmentation::providedPorts()
+{
+  return { BT::InputPort<sensor_msgs::msg::Image>(kPortImage, kPortImageDefault, "The Image to run segmentation on."),
+           BT::InputPort<std::vector<geometry_msgs::msg::PointStamped>>(kPortPoint, kPortPointDefault,
+                                                                        "The input points, as a vector of "
+                                                                        "<code>geometry_msgs/PointStamped</code> "
+                                                                        "messages to be used for segmentation."),
+
+           BT::OutputPort<std::vector<moveit_studio_vision_msgs::msg::Mask2D>>(
+               kPortMasks, kPortMasksDefault,
+               "The masks contained in a vector of <code>moveit_studio_vision_msgs::msg::Mask2D</code> messages.") };
+}
+
+tl::expected<bool, std::string> ExampleSAM2Segmentation::doWork()
+{
+  const auto ports =
+      moveit_studio::behaviors::getRequiredInputs(getInput<sensor_msgs::msg::Image>(kPortImage),
+                                                  getInput<std::vector<geometry_msgs::msg::PointStamped>>(kPortPoint));
+
+  // Check that all required input data ports were set.
+  if (!ports.has_value())
+  {
+    auto error_message = fmt::format("Failed to get required values from input data ports:\n{}", ports.error());
+    return tl::make_unexpected(error_message);
+  }
+  const auto& [image_msg, points_2d] = ports.value();
+
+  if (image_msg.encoding != "rgb8" && image_msg.encoding != "rgba8")
+  {
+    auto error_message =
+        fmt::format("Invalid image message format. Expected `(rgb8, rgba8)` got :\n{}", image_msg.encoding);
+    return tl::make_unexpected(error_message);
   }
 
-  // Converts a single channel ONNX image mask to a ROS mask message.
-  void set_ros_mask_from_onnx_mask(const moveit_pro_ml::ONNXImage& onnx_image, sensor_msgs::msg::Image& mask_image_msg, moveit_studio_vision_msgs::msg::Mask2D& mask_msg)
+  // Create ONNX formatted image tensor from ROS image
+  set_onnx_image_from_ros_image(image_msg, onnx_image_);
+
+  std::vector<moveit_pro_ml::PointPrompt> point_prompts;
+  for (auto const& point : points_2d)
   {
-    mask_image_msg.height = static_cast<uint32_t>(onnx_image.shape[0]);
-    mask_image_msg.width = static_cast<uint32_t>(onnx_image.shape[1]);
-    mask_image_msg.encoding = "mono8";
-    mask_image_msg.data.resize(mask_image_msg.height * mask_image_msg.width);
-    mask_image_msg.step = mask_image_msg.width;
-    for (size_t i = 0; i < onnx_image.data.size(); ++i)
-    {
-      mask_image_msg.data[i] = onnx_image.data[i] > 0.5 ? 255: 0;
-    }
-    mask_msg.pixels = mask_image_msg;
-    mask_msg.x = 0;
-    mask_msg.y = 0;
+    // Assume all points are the same label
+    point_prompts.push_back({ { kImageInferenceWidth * static_cast<float>(point.point.x),
+                                kImageInferenceHeight * static_cast<float>(point.point.y) },
+                              { 1.0f } });
   }
 
-  ExampleSAM2Segmentation::ExampleSAM2Segmentation(const std::string& name, const BT::NodeConfiguration& config,
-                                     const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
-    : moveit_studio::behaviors::AsyncBehaviorBase(name, config, shared_resources)
+  try
   {
+    const auto masks = sam2_->predict(onnx_image_, point_prompts);
 
-    const std::filesystem::path package_path = ament_index_cpp::get_package_share_directory("example_behaviors");
-    const std::filesystem::path encoder_onnx_file = package_path / "models" / "sam2_hiera_large_encoder.onnx";
-    const std::filesystem::path decoder_onnx_file = package_path / "models" / "decoder.onnx";
-    sam2_ = std::make_unique<moveit_pro_ml::SAM2>(encoder_onnx_file, decoder_onnx_file);
+    mask_image_msg_.header = image_msg.header;
+    set_ros_mask_from_onnx_mask(masks, mask_image_msg_, mask_msg_);
+
+    setOutput<std::vector<moveit_studio_vision_msgs::msg::Mask2D>>(kPortMasks, { mask_msg_ });
+  }
+  catch (const std::invalid_argument& e)
+  {
+    return tl::make_unexpected(fmt::format("Invalid argument: {}", e.what()));
   }
 
-  BT::PortsList ExampleSAM2Segmentation::providedPorts()
-  {
-    return {
-      BT::InputPort<sensor_msgs::msg::Image>(kPortImage, kPortImageDefault,
-                                             "The Image to run segmentation on."),
-      BT::InputPort<std::vector<geometry_msgs::msg::PointStamped>>(kPortPoint, kPortPointDefault,
-                                                                   "The input points, as a vector of <code>geometry_msgs/PointStamped</code> messages to be used for segmentation."),
+  return true;
+}
 
-  BT::OutputPort<std::vector<moveit_studio_vision_msgs::msg::Mask2D>>(kPortMasks, kPortMasksDefault,
-                                                                   "The masks contained in a vector of <code>moveit_studio_vision_msgs::msg::Mask2D</code> messages.")
-    };
-  }
-
-  tl::expected<bool, std::string> ExampleSAM2Segmentation::doWork()
-  {
-    const auto ports = moveit_studio::behaviors::getRequiredInputs(getInput<sensor_msgs::msg::Image>(kPortImage),
-                                                                   getInput<std::vector<
-                                                                     geometry_msgs::msg::PointStamped>>(kPortPoint));
-
-    // Check that all required input data ports were set.
-    if (!ports.has_value())
-    {
-      auto error_message = fmt::format("Failed to get required values from input data ports:\n{}", ports.error());
-      return tl::make_unexpected(error_message);
-    }
-    const auto& [image_msg, points_2d] = ports.value();
-
-    if (image_msg.encoding != "rgb8" && image_msg.encoding != "rgba8")
-    {
-      auto error_message = fmt::format("Invalid image message format. Expected `(rgb8, rgba8)` got :\n{}", image_msg.encoding);
-      return tl::make_unexpected(error_message);
-    }
-
-    // Create ONNX formatted image tensor from ROS image
-    set_onnx_image_from_ros_image(image_msg, onnx_image_);
-
-    std::vector<moveit_pro_ml::PointPrompt> point_prompts;
-    for (auto const& point : points_2d)
-    {
-      // Assume all points are the same label
-      point_prompts.push_back({{kImageInferenceWidth*static_cast<float>(point.point.x), kImageInferenceHeight*static_cast<float>(point.point.y)}, {1.0f}});
-    }
-
-    try
-    {
-      const auto masks = sam2_->predict(onnx_image_, point_prompts);
-
-      mask_image_msg_.header = image_msg.header;
-      set_ros_mask_from_onnx_mask(masks, mask_image_msg_, mask_msg_);
-
-      setOutput<std::vector<moveit_studio_vision_msgs::msg::Mask2D>>(kPortMasks, {mask_msg_});
-    }
-    catch (const std::invalid_argument& e)
-    {
-      return tl::make_unexpected(fmt::format("Invalid argument: {}", e.what()));
-    }
-
-    return true;
-  }
-
-  BT::KeyValueVector ExampleSAM2Segmentation::metadata()
-  {
-    return {
-      {
-        "description",
-        "Segments a ROS image message using the provided points represented as a vector of <code>geometry_msgs/PointStamped</code> messages."
-      }
-    };
-  }
-} // namespace example_behaviors
+BT::KeyValueVector ExampleSAM2Segmentation::metadata()
+{
+  return { { "description", "Segments a ROS image message using the provided points represented as a vector of "
+                            "<code>geometry_msgs/PointStamped</code> messages." } };
+}
+}  // namespace example_behaviors

--- a/src/example_behaviors/src/example_setup_mtc_pick_from_pose.cpp
+++ b/src/example_behaviors/src/example_setup_mtc_pick_from_pose.cpp
@@ -1,16 +1,16 @@
 #include <example_behaviors/example_setup_mtc_pick_from_pose.hpp>
 
 #include <behaviortree_cpp/bt_factory.h>
-#include <moveit/task_constructor/stages.h>
 #include <moveit/task_constructor/solvers.h>
+#include <moveit/task_constructor/stages.h>
 #include <moveit/task_constructor/task.h>
+#include <yaml-cpp/yaml.h>
 #include <moveit_msgs/msg/collision_object.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>
 #include <moveit_studio_common/utils/yaml_parsing_tools.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <yaml-cpp/yaml.h>
 
 namespace
 {

--- a/src/example_behaviors/src/example_setup_mtc_place_from_pose.cpp
+++ b/src/example_behaviors/src/example_setup_mtc_place_from_pose.cpp
@@ -1,16 +1,16 @@
 #include <example_behaviors/example_setup_mtc_place_from_pose.hpp>
 
 #include <behaviortree_cpp/bt_factory.h>
-#include <moveit/task_constructor/stages.h>
 #include <moveit/task_constructor/solvers.h>
+#include <moveit/task_constructor/stages.h>
 #include <moveit/task_constructor/task.h>
+#include <yaml-cpp/yaml.h>
 #include <moveit_msgs/msg/collision_object.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>
 #include <moveit_studio_common/utils/yaml_parsing_tools.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <yaml-cpp/yaml.h>
 
 namespace
 {

--- a/src/example_behaviors/src/example_setup_mtc_wave_hand.cpp
+++ b/src/example_behaviors/src/example_setup_mtc_wave_hand.cpp
@@ -20,8 +20,9 @@ const rclcpp::Logger kLogger = rclcpp::get_logger("WaveHello");
 
 namespace example_behaviors
 {
-ExampleSetupMTCWaveHand::ExampleSetupMTCWaveHand(const std::string& name, const BT::NodeConfiguration& config,
-                                   const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+ExampleSetupMTCWaveHand::ExampleSetupMTCWaveHand(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
   : moveit_studio::behaviors::AsyncBehaviorBase(name, config, shared_resources)
 {
 }

--- a/src/example_behaviors/src/register_behaviors.cpp
+++ b/src/example_behaviors/src/register_behaviors.cpp
@@ -2,19 +2,19 @@
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
 
-#include <example_behaviors/example_hello_world.hpp>
+#include <example_behaviors/example_add_two_ints_service_client.hpp>
 #include <example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp>
 #include <example_behaviors/example_delayed_message.hpp>
-#include <example_behaviors/example_setup_mtc_wave_hand.hpp>
-#include <example_behaviors/example_add_two_ints_service_client.hpp>
 #include <example_behaviors/example_fibonacci_action_client.hpp>
 #include <example_behaviors/example_get_string_from_topic.hpp>
-#include <example_behaviors/example_publish_color_rgba.hpp>
-#include <example_behaviors/example_setup_mtc_pick_from_pose.hpp>
-#include <example_behaviors/example_setup_mtc_place_from_pose.hpp>
+#include <example_behaviors/example_hello_world.hpp>
 #include <example_behaviors/example_ndt_registration.hpp>
+#include <example_behaviors/example_publish_color_rgba.hpp>
 #include <example_behaviors/example_ransac_registration.hpp>
 #include <example_behaviors/example_sam2_segmentation.hpp>
+#include <example_behaviors/example_setup_mtc_pick_from_pose.hpp>
+#include <example_behaviors/example_setup_mtc_place_from_pose.hpp>
+#include <example_behaviors/example_setup_mtc_wave_hand.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -27,21 +27,30 @@ public:
                          const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
   {
     moveit_studio::behaviors::registerBehavior<ExampleHelloWorld>(factory, "ExampleHelloWorld", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleConvertMtcSolutionToJointTrajectory>(factory, "ExampleConvertMtcSolutionToJointTrajectory", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleDelayedMessage>(factory, "ExampleDelayedMessage", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleSetupMTCWaveHand>(factory, "ExampleSetupMTCWaveHand", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleGetStringFromTopic>(factory, "ExampleGetStringFromTopic", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleAddTwoIntsServiceClient>(factory, "ExampleAddTwoIntsServiceClient",
+    moveit_studio::behaviors::registerBehavior<ExampleConvertMtcSolutionToJointTrajectory>(
+        factory, "ExampleConvertMtcSolutionToJointTrajectory", shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleDelayedMessage>(factory, "ExampleDelayedMessage",
+                                                                      shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleSetupMTCWaveHand>(factory, "ExampleSetupMTCWaveHand",
                                                                         shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleGetStringFromTopic>(factory, "ExampleGetStringFromTopic",
+                                                                          shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleAddTwoIntsServiceClient>(
+        factory, "ExampleAddTwoIntsServiceClient", shared_resources);
     moveit_studio::behaviors::registerBehavior<ExampleFibonacciActionClient>(factory, "ExampleFibonacciActionClient",
-                                                                      shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExamplePublishColorRGBA>(factory, "ExamplePublishColorRGBA", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleSetupMtcPickFromPose>(factory, "ExampleSetupMtcPickFromPose", shared_resources);
+                                                                             shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExamplePublishColorRGBA>(factory, "ExamplePublishColorRGBA",
+                                                                        shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleSetupMtcPickFromPose>(factory, "ExampleSetupMtcPickFromPose",
+                                                                            shared_resources);
     moveit_studio::behaviors::registerBehavior<ExampleSetupMtcPlaceFromPose>(factory, "ExampleSetupMtcPlaceFromPose",
-                                                                      shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleNDTRegistration>(factory, "ExampleNDTRegistration", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleRANSACRegistration>(factory, "ExampleRANSACRegistration", shared_resources);
-    moveit_studio::behaviors::registerBehavior<ExampleSAM2Segmentation>(factory, "ExampleSAM2Segmentation", shared_resources);
+                                                                             shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleNDTRegistration>(factory, "ExampleNDTRegistration",
+                                                                       shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleRANSACRegistration>(factory, "ExampleRANSACRegistration",
+                                                                          shared_resources);
+    moveit_studio::behaviors::registerBehavior<ExampleSAM2Segmentation>(factory, "ExampleSAM2Segmentation",
+                                                                        shared_resources);
   }
 };
 }  // namespace example_behaviors

--- a/src/example_behaviors/test/test_behavior_plugins.cpp
+++ b/src/example_behaviors/test/test_behavior_plugins.cpp
@@ -23,26 +23,29 @@ TEST(BehaviorTests, test_load_behavior_plugins)
     ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
   }
   // Test that ClassLoader is able to find and instantiate each Behavior using the package's plugin description info.
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "ExampleAddTwoIntsServiceClient",
+                                                    BT::NodeConfiguration()));
   EXPECT_NO_THROW(
-      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleAddTwoIntsServiceClient", BT::NodeConfiguration()));
-  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "ExampleDelayedMessage", BT::NodeConfiguration()));
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleDelayedMessage", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "ExampleFibonacciActionClient", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "ExampleGetStringFromTopic", BT::NodeConfiguration()));
   EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "ExampleHelloWorld", BT::NodeConfiguration()));
-  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "ExamplePublishColorRGBA", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExamplePublishColorRGBA", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "ExampleSetupMtcPickFromPose", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "ExampleSetupMtcPlaceFromPose", BT::NodeConfiguration()));
-  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "ExampleSetupMTCWaveHand", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
-    (void)factory.instantiateTreeNode("test_behavior_name", "ExampleNDTRegistration", BT::NodeConfiguration()));
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleSetupMTCWaveHand", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
-    (void)factory.instantiateTreeNode("test_behavior_name", "ExampleRANSACRegistration", BT::NodeConfiguration()));
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleNDTRegistration", BT::NodeConfiguration()));
   EXPECT_NO_THROW(
-    (void)factory.instantiateTreeNode("test_behavior_name", "ExampleSAM2Segmentation", BT::NodeConfiguration()));
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleRANSACRegistration", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "ExampleSAM2Segmentation", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)

--- a/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/include/moveit_studio_kinova_pstop_manager/mock_kinova_client.hpp
+++ b/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/include/moveit_studio_kinova_pstop_manager/mock_kinova_client.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <rclcpp/rclcpp.hpp>
-#include <example_interfaces/srv/trigger.hpp>
 #include <example_interfaces/msg/bool.hpp>
+#include <example_interfaces/srv/trigger.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace moveit_studio::kinova_pstop_manager
 {

--- a/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/include/moveit_studio_kinova_pstop_manager/protective_stop_manager_node.hpp
+++ b/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/include/moveit_studio_kinova_pstop_manager/protective_stop_manager_node.hpp
@@ -10,12 +10,12 @@
 #pragma once
 
 #include <controller_manager_msgs/srv/switch_controller.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <std_srvs/srv/trigger.hpp>
-#include <moveit_studio_agent_msgs/msg/fault_status.hpp>
-#include <std_msgs/msg/bool.hpp>
 #include <example_interfaces/msg/bool.hpp>
 #include <example_interfaces/srv/trigger.hpp>
+#include <moveit_studio_agent_msgs/msg/fault_status.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 namespace moveit_studio::kinova_pstop_manager
 {

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/include/trigger_pstop_reset_service/trigger_pstop_reset_service.hpp
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/include/trigger_pstop_reset_service/trigger_pstop_reset_service.hpp
@@ -12,67 +12,72 @@ using PStopService = std_srvs::srv::Trigger;
 class TriggerPStopResetService : public moveit_studio::behaviors::ServiceClientBehaviorBase<PStopService>
 {
 public:
-/**
+  /**
    * @brief Constructor for the trigger_pstop_reset_service behavior.
-   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
-   * @details An important limitation is that the members of the base Behavior class are not instantiated until after the initialize() function is called, so these classes should not be used within the constructor.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
    */
- TriggerPStopResetService(const std::string& name, const BT::NodeConfiguration& config,
- const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
+  TriggerPStopResetService(const std::string& name, const BT::NodeConfiguration& config,
+                           const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources);
 
- /**
-  * @brief Implementation of the required providedPorts() function for the trigger_pstop_reset_service Behavior.
-  * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function must return an empty BT::PortsList.
-  * This function returns a list of ports with their names and port info, which is used internally by the behavior tree.
-  * @return trigger_pstop_reset_service does not use expose any ports, so this function returns an empty list.
-  */
- static BT::PortsList providedPorts();
+  /**
+   * @brief Implementation of the required providedPorts() function for the trigger_pstop_reset_service Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
+   * @return trigger_pstop_reset_service does not use expose any ports, so this function returns an empty list.
+   */
+  static BT::PortsList providedPorts();
 
- /**
-  * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
-  * subcategory, in the MoveIt Studio Developer Tool.
-  * @return A BT::KeyValueVector containing the Behavior metadata.
-  */
- static BT::KeyValueVector metadata();
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
 
 private:
- /**
- * @brief Specify the name of the service that will be called by the behaviors
- * @return Returns the name of the service. If not successful, returns an error message.
- */
- tl::expected<std::string, std::string> getServiceName() override;
- /**
- * @brief Sets the timeout for the service response.
- * @details If the timeout expires before a response is received, the behavior will fail. A negative duration indicates no timeout.
- * @return Returns the service response timeout duration.
- */
- tl::expected<std::chrono::duration<double>, std::string> getResponseTimeout() override;
- /**
- * @brief Create a service request.
- * @return Returns a service request message. If not successful, returns an error message.
- */
- tl::expected<std_srvs::srv::Trigger::Request, std::string> createRequest() override;
- /**
- * @brief Determines if the service request succeeded or failed based on the response message.
- * @param response Response message received from the service server.
- * @return Returns true if the response indicates success. If not successful, returns an error message.
- */
- tl::expected<bool, std::string> processResponse(const std_srvs::srv::Trigger::Response&) override;
+  /**
+   * @brief Specify the name of the service that will be called by the behaviors
+   * @return Returns the name of the service. If not successful, returns an error message.
+   */
+  tl::expected<std::string, std::string> getServiceName() override;
+  /**
+   * @brief Sets the timeout for the service response.
+   * @details If the timeout expires before a response is received, the behavior will fail. A negative duration
+   * indicates no timeout.
+   * @return Returns the service response timeout duration.
+   */
+  tl::expected<std::chrono::duration<double>, std::string> getResponseTimeout() override;
+  /**
+   * @brief Create a service request.
+   * @return Returns a service request message. If not successful, returns an error message.
+   */
+  tl::expected<std_srvs::srv::Trigger::Request, std::string> createRequest() override;
+  /**
+   * @brief Determines if the service request succeeded or failed based on the response message.
+   * @param response Response message received from the service server.
+   * @return Returns true if the response indicates success. If not successful, returns an error message.
+   */
+  tl::expected<bool, std::string> processResponse(const std_srvs::srv::Trigger::Response&) override;
 
- /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
- std::shared_future<tl::expected<bool, std::string>>& getFuture() override;
+  /** @brief Classes derived from AsyncBehaviorBase must implement getFuture() so that it returns a shared_future class member */
+  std::shared_future<tl::expected<bool, std::string>>& getFuture() override;
 
- /**
- * @brief Holds a copy of the service name specified by the input port.
- */
- std::string service_name_;
+  /**
+   * @brief Holds a copy of the service name specified by the input port.
+   */
+  std::string service_name_;
 
- /**
-  * @brief Holds the result of calling the service asynchronously.
-  */
- std::shared_future<tl::expected<bool, std::string>> future_;
-
-  
+  /**
+   * @brief Holds the result of calling the service asynchronously.
+   */
+  std::shared_future<tl::expected<bool, std::string>> future_;
 };
 }  // namespace trigger_pstop_reset_service

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/src/register_behaviors.cpp
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/src/register_behaviors.cpp
@@ -11,11 +11,12 @@ namespace trigger_pstop_reset_service
 class TriggerPStopResetServiceBehaviorsLoader : public moveit_studio::behaviors::SharedResourcesNodeLoaderBase
 {
 public:
-  void registerBehaviors(BT::BehaviorTreeFactory& factory,
-    [[maybe_unused]] const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
+  void registerBehaviors(
+      BT::BehaviorTreeFactory& factory,
+      [[maybe_unused]] const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources) override
   {
-    moveit_studio::behaviors::registerBehavior<TriggerPStopResetService>(factory, "TriggerPStopResetService", shared_resources);
-    
+    moveit_studio::behaviors::registerBehavior<TriggerPStopResetService>(factory, "TriggerPStopResetService",
+                                                                         shared_resources);
   }
 };
 }  // namespace trigger_pstop_reset_service

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/src/trigger_pstop_reset_service.cpp
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/src/trigger_pstop_reset_service.cpp
@@ -3,78 +3,70 @@
 
 namespace
 {
-    constexpr auto kDefaultPStopServiceName = "/recover_from_protective_stop";
-    constexpr auto kPortServiceName = "service_name";
-}// namespace
+constexpr auto kDefaultPStopServiceName = "/recover_from_protective_stop";
+constexpr auto kPortServiceName = "service_name";
+}  // namespace
 
 namespace trigger_pstop_reset_service
 {
-    TriggerPStopResetService::TriggerPStopResetService(const std::string& name, const BT::NodeConfiguration& config,
-                                                       const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>&
-                                                       shared_resources)
-        : ServiceClientBehaviorBase<PStopService>(name, config, shared_resources)
-    {
-    }
+TriggerPStopResetService::TriggerPStopResetService(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_studio::behaviors::BehaviorContext>& shared_resources)
+  : ServiceClientBehaviorBase<PStopService>(name, config, shared_resources)
+{
+}
 
-    tl::expected<std::string, std::string> TriggerPStopResetService::getServiceName()
-    {
-        // Get service name from the input port.
-        const auto service_name = getInput<std::string>(kPortServiceName);
-        // Check that the port has a value on it, if not, return an error.
-        if (const auto error = moveit_studio::behaviors::maybe_error(service_name))
-        {
-            return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
-        }
+tl::expected<std::string, std::string> TriggerPStopResetService::getServiceName()
+{
+  // Get service name from the input port.
+  const auto service_name = getInput<std::string>(kPortServiceName);
+  // Check that the port has a value on it, if not, return an error.
+  if (const auto error = moveit_studio::behaviors::maybe_error(service_name))
+  {
+    return tl::make_unexpected("Failed to get required value from input data port: " + error.value());
+  }
 
-        service_name_ = service_name.value();
-        return service_name_;
-    }
+  service_name_ = service_name.value();
+  return service_name_;
+}
 
-    tl::expected<std::chrono::duration<double>, std::string> TriggerPStopResetService::getResponseTimeout()
-    {
-        // Create timeout for service call.
-        return std::chrono::duration<double>{2.0};
-    }
+tl::expected<std::chrono::duration<double>, std::string> TriggerPStopResetService::getResponseTimeout()
+{
+  // Create timeout for service call.
+  return std::chrono::duration<double>{ 2.0 };
+}
 
-    tl::expected<std_srvs::srv::Trigger::Request, std::string> TriggerPStopResetService::createRequest()
-    {
-        // Create request message.
-        return PStopService::Request{};
-    }
+tl::expected<std_srvs::srv::Trigger::Request, std::string> TriggerPStopResetService::createRequest()
+{
+  // Create request message.
+  return PStopService::Request{};
+}
 
-    tl::expected<bool, std::string> TriggerPStopResetService::processResponse(
-        const std_srvs::srv::Trigger::Response& trigger_response)
-    {
-        // If the service response could not be processed, returns an error message, otherwise, return true to indicate success.
-        return trigger_response.success
-                   ? tl::expected<bool, std::string>(true)
-                   : tl::make_unexpected(
-                       "Failed to call P-Stop service `" + service_name_ + "`: " + trigger_response.message);
-    }
+tl::expected<bool, std::string>
+TriggerPStopResetService::processResponse(const std_srvs::srv::Trigger::Response& trigger_response)
+{
+  // If the service response could not be processed, returns an error message, otherwise, return true to indicate success.
+  return trigger_response.success ?
+             tl::expected<bool, std::string>(true) :
+             tl::make_unexpected("Failed to call P-Stop service `" + service_name_ + "`: " + trigger_response.message);
+}
 
-    std::shared_future<tl::expected<bool, std::string>>& TriggerPStopResetService::getFuture()
-    {
-        return future_;
-    }
+std::shared_future<tl::expected<bool, std::string>>& TriggerPStopResetService::getFuture()
+{
+  return future_;
+}
 
+BT::PortsList TriggerPStopResetService::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortServiceName, kDefaultPStopServiceName,
+                                      "Name of the service to send a request to.") };
+}
 
-    BT::PortsList TriggerPStopResetService::providedPorts()
-    {
-        return {
-            BT::InputPort<std::string>(kPortServiceName, kDefaultPStopServiceName,
-                                       "Name of the service to send a request to.")
-        };
-    }
-
-    BT::KeyValueVector TriggerPStopResetService::metadata()
-    {
-        return {
-            {
-                "description",
-                std::string(
-                    "Resets the UR P-stop status by calling the reset service named service name specified by the input port named `")
-                .append(kPortServiceName).append("`.")
-            }
-        };
-    }
-} // namespace trigger_pstop_reset_service
+BT::KeyValueVector TriggerPStopResetService::metadata()
+{
+  return { { "description", std::string("Resets the UR P-stop status by calling the reset service named service name "
+                                        "specified by the input port named `")
+                                .append(kPortServiceName)
+                                .append("`.") } };
+}
+}  // namespace trigger_pstop_reset_service

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/test/test_behavior_plugins.cpp
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/behaviors/test/test_behavior_plugins.cpp
@@ -19,13 +19,14 @@ TEST(BehaviorTests, test_load_behavior_plugins)
 
   BT::BehaviorTreeFactory factory;
   {
-    auto plugin_instance = class_loader.createUniqueInstance("trigger_pstop_reset_service::TriggerPStopResetServiceBehaviorsLoader");
+    auto plugin_instance =
+        class_loader.createUniqueInstance("trigger_pstop_reset_service::TriggerPStopResetServiceBehaviorsLoader");
     ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
   }
 
   // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
   EXPECT_NO_THROW(
-    (void)factory.instantiateTreeNode("test_behavior_name", "TriggerPStopResetService", BT::NodeConfiguration()));
+      (void)factory.instantiateTreeNode("test_behavior_name", "TriggerPStopResetService", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Add clang-format file to ensure that consistent formatting rules are used. Without it, depending on your local setup different style files might be used.