### PR TITLE
Fix 'Segment Point Cloud from Clicked Point' objective to use core SAM2 segmentation behavior

### DIFF
--- a/src/lab_sim/objectives/run_sam2_onnx.xml
+++ b/src/lab_sim/objectives/run_sam2_onnx.xml
@@ -11,31 +11,77 @@
   >
     <Control ID="Sequence">
       <Action ID="ClearSnapshot" />
-      <Action ID="GetImage" topic_name="/wrist_camera/color" />
+      <Action
+        ID="GetImage"
+        topic_name="/wrist_camera/color"
+        timeout_sec="5.000000"
+        message_out="{image}"
+      />
       <Action
         ID="GetPointsFromUser"
         point_prompts="Select the object to be segmented;"
         point_names="Point1;"
         view_name="/wrist_camera/color"
+        pixel_coords="{pixel_coords}"
       />
-      <Action ID="ExampleSAM2Segmentation" />
-      <Action ID="GetPointCloud" topic_name="/wrist_camera/points" />
+      <Action
+        ID="GetMasks2DFromPointQuery"
+        image="{image}"
+        pixel_coords="{pixel_coords}"
+        masks2d="{masks2d}"
+        decoder_model_path="~/user_ws/src/example_behaviors/models/decoder.onnx"
+        encoder_model_path="~/user_ws/src/example_behaviors/models/sam2_hiera_large_encoder.onnx"
+      />
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        timeout_sec="5.000000"
+        message_out="{point_cloud}"
+      />
       <Action
         ID="GetCameraInfo"
         topic_name="/wrist_camera/camera_info"
         message_out="{camera_info}"
         timeout_sec="5.000000"
       />
-      <Action ID="GetMasks3DFromMasks2D" />
-      <Decorator ID="ForEach" vector_in="{masks3d}" out="{mask3d}">
-        <Action ID="GetPointCloudFromMask3D" point_cloud="{point_cloud}" />
+      <Action
+        ID="GetMasks3DFromMasks2D"
+        camera_info="{camera_info}"
+        masks2d="{masks2d}"
+        point_cloud="{point_cloud}"
+        masks3d="{masks3d}"
+      />
+      <Decorator
+        ID="ForEach"
+        vector_in="{masks3d}"
+        out="{mask3d}"
+        index="{index}"
+      >
+        <Action
+          ID="GetPointCloudFromMask3D"
+          point_cloud="{point_cloud}"
+          mask3d="{mask3d}"
+          point_cloud_fragment="{point_cloud_fragment}"
+        />
       </Decorator>
-      <Action ID="SendPointCloudToUI" point_cloud="{point_cloud_fragment}" />
-      <Action ID="PublishPointCloud" point_cloud="{point_cloud_fragment}" />
-      <Action ID="SwitchUIPrimaryView" />
+      <Action
+        ID="SendPointCloudToUI"
+        point_cloud="{point_cloud_fragment}"
+        pcd_topic="/pcd_pointcloud_captures"
+      />
+      <Action
+        ID="PublishPointCloud"
+        point_cloud="{point_cloud_fragment}"
+        point_cloud_topic="/my_point_cloud"
+      />
+      <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization" />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Segment Point Cloud from Clicked Point" />
+    <SubTree ID="Segment Point Cloud from Clicked Point">
+      <MetadataFields>
+        <Metadata runnable="true" />
+      </MetadataFields>
+    </SubTree>
   </TreeNodesModel>
 </root>


### PR DESCRIPTION
Fixes use of lab_sim objective that references the unbuilt `ExampleSAM2Segmentation` example_behavior to use core `GetMasks2DFromPointQuery` behavior with the example_ws decoder/encoder models.

This fix should probably be in multiple tags.

## To test
Run the lab_sim "Segment Point Cloud from Clicked Point" objective and it should now succeed in running instead of failing due to the missing manifest for ExampleSAM2Segmentation behavior.