### PR TITLE
plumb keep_orientation_link_names through subtrees

### DIFF
--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -23,6 +23,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
       <SubTree
         ID="Move to Waypoint"
@@ -36,6 +37,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
       <!--We force success as the gripper closes, since we are commanding a position it will never reach (fingers fully closed)-->
       <Decorator ID="ForceSuccess">
@@ -55,6 +57,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
       <SubTree
         ID="Move to Waypoint"
@@ -69,6 +72,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
       <SubTree
         ID="Move to Waypoint"
@@ -83,6 +87,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
       <SubTree ID="Open Gripper" />
       <SubTree
@@ -98,6 +103,7 @@
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
         link_padding="0.01"
         velocity_scale_factor="1.0"
+        keep_orientation_link_names="grasp_link"
       />
     </Control>
   </BehaviorTree>
@@ -107,9 +113,6 @@
       <inout_port name="place" default="" />
       <inout_port name="pre_pick" default="" />
       <inout_port name="pre_place" default="" />
-      <MetadataFields>
-        <Metadata runnable="false" />
-      </MetadataFields>
       <MetadataFields>
         <Metadata runnable="false" />
       </MetadataFields>

--- a/src/lab_sim/objectives/constrained_pick_place.xml
+++ b/src/lab_sim/objectives/constrained_pick_place.xml
@@ -18,6 +18,9 @@
         acceleration_scale_factor="1.0"
         link_padding="0.01"
         keep_orientation="false"
+        controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+        keep_orientation_tolerance="0.05"
+        keep_orientation_link_names="grasp_link"
       />
       <SubTree ID="Open Gripper" />
       <SubTree

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/move_to_joint_state.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/move_to_joint_state.xml
@@ -4,6 +4,16 @@
     ID="Move to Joint State"
     _description="Plan and execute motion to a set of joint angles specified in a ROS message type."
     _subtreeOnly="true"
+    acceleration_scale_factor="1.0"
+    controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+    controller_names="joint_trajectory_controller"
+    joint_group_name="manipulator"
+    keep_orientation="false"
+    keep_orientation_tolerance="0.05"
+    link_padding="0.01"
+    target_joint_state="{target_joint_state}"
+    velocity_scale_factor="1.0"
+    keep_orientation_link_names="grasp_link"
   >
     <Control ID="Sequence">
       <Action ID="ActivateControllers" controller_names="{controller_names}" />
@@ -16,32 +26,42 @@
         acceleration_scale_factor="{acceleration_scale_factor}"
         velocity_scale_factor="{velocity_scale_factor}"
         planning_group_name="{joint_group_name}"
+        keep_orientation_link_names="{keep_orientation_link_names}"
+        max_iterations="5000"
+        trajectory_sampling_rate="100"
+        joint_trajectory_msg="{joint_trajectory_msg}"
       />
       <Action
         ID="ExecuteFollowJointTrajectory"
         execute_follow_joint_trajectory_action_name="{controller_action_server}"
+        goal_duration_tolerance="-1.000000"
+        goal_position_tolerance="0.000000"
+        goal_time_tolerance="0.000000"
+        joint_trajectory_msg="{joint_trajectory_msg}"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Move to Joint State">
-      <input_port name="target_joint_state" default="{target_joint_state}" />
-      <input_port name="joint_group_name" default="manipulator" />
-      <input_port name="link_padding" default="0.01" />
-      <input_port name="keep_orientation_tolerance" default="0.05" />
-      <input_port name="keep_orientation" default="false" />
-      <input_port name="velocity_scale_factor" default="1.0" />
       <input_port name="acceleration_scale_factor" default="1.0" />
-      <input_port
-        name="controller_names"
-        default="joint_trajectory_controller"
-      />
       <input_port
         name="controller_action_server"
         default="/joint_trajectory_controller/follow_joint_trajectory"
       />
+      <input_port
+        name="controller_names"
+        default="joint_trajectory_controller"
+      />
+      <input_port name="joint_group_name" default="manipulator" />
+      <input_port name="keep_orientation" default="false" />
+      <input_port name="keep_orientation_tolerance" default="0.05" />
+      <input_port name="link_padding" default="0.01" />
+      <input_port name="target_joint_state" default="{target_joint_state}" />
+      <input_port name="velocity_scale_factor" default="1.0" />
+      <input_port name="keep_orientation_link_names" default="grasp_link" />
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/move_to_waypoint.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/move_to_waypoint.xml
@@ -4,6 +4,14 @@
     ID="Move to Waypoint"
     _description="Plan and execute motion to a MoveIt Pro-created named Waypoint, which is saved in joint space to the file system."
     _subtreeOnly="true"
+    acceleration_scale_factor="1.0"
+    controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+    controller_names="/joint_trajectory_controller"
+    joint_group_name="manipulator"
+    keep_orientation="false"
+    keep_orientation_tolerance="0.05"
+    link_padding="0.01"
+    velocity_scale_factor="1.0"
   >
     <Control ID="Sequence" name="root">
       <Action
@@ -24,26 +32,28 @@
         controller_names="{controller_names}"
         joint_group_name="{joint_group_name}"
         controller_action_server="{controller_action_server}"
+        keep_orientation_link_names="{keep_orientation_link_names}"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Move to Waypoint">
-      <input_port name="waypoint_name" default="" />
-      <input_port name="joint_group_name" default="manipulator" />
-      <input_port name="link_padding" default="0.01" />
-      <input_port name="keep_orientation_tolerance" default="0.05" />
-      <input_port name="keep_orientation" default="false" />
-      <input_port name="velocity_scale_factor" default="1.0" />
       <input_port name="acceleration_scale_factor" default="1.0" />
-      <input_port
-        name="controller_names"
-        default="/joint_trajectory_controller"
-      />
       <input_port
         name="controller_action_server"
         default="/joint_trajectory_controller/follow_joint_trajectory"
       />
+      <input_port
+        name="controller_names"
+        default="/joint_trajectory_controller"
+      />
+      <input_port name="joint_group_name" default="manipulator" />
+      <input_port name="keep_orientation" default="false" />
+      <input_port name="keep_orientation_tolerance" default="0.05" />
+      <inout_port name="keep_orientation_link_names" default="grasp_link" />
+      <input_port name="link_padding" default="0.01" />
+      <input_port name="velocity_scale_factor" default="1.0" />
+      <input_port name="waypoint_name" default="" />
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>


### PR DESCRIPTION
Exposes the `keep_orientation_link_names` port used in planning Behaviors via the `Move To Waypoint` subtree, so that it's more visibly exposed to users.
This is also referenced from the docs: https://github.com/PickNikRobotics/moveit_pro/pull/10632