### PR TITLE
turn the realsense camera into a box

### DIFF
--- a/src/lab_sim/description/picknik_ur.xacro
+++ b/src/lab_sim/description/picknik_ur.xacro
@@ -103,15 +103,21 @@
   </joint>
   <link name="wrist_mounted_camera_link">
     <visual>
-      <origin
-        rpy="1.5707963267948966 0 1.5707963267948966"
-        xyz="0.00987 -0.02 0"
-      />
+      <origin rpy="0 0 0" xyz="0 -0.02 0" />
       <geometry>
-        <mesh filename="package://realsense2_description/meshes/d415.stl" />
+        <box size="0.02005 0.099 0.023" />
       </geometry>
       <material name="rs_aluminum">
         <color rgba="0.5 0.5 0.5 1.0" />
+      </material>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0.010525 -0.02 0" />
+      <geometry>
+        <box size="0.001 0.099 0.023" />
+      </geometry>
+      <material name="black">
+        <color rgba="0.0 0.0 0.0 1.0" />
       </material>
     </visual>
     <collision>

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/description/robotiq_2f_85_gripper.urdf
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/description/robotiq_2f_85_gripper.urdf
@@ -79,14 +79,23 @@
     <visual>
       <origin rpy="1.5707963267948966 0 1.5707963267948966" xyz="0.00987 -0.02 0"/>
       <geometry>
-        <mesh filename="package://realsense2_description/meshes/d415.stl"/>
+        <box size="0.02005 0.099 0.023" />
       </geometry>
       <material name="rs_aluminum">
-        <color rgba="0.5 0.5 0.5 1.0"/>
+        <color rgba="0.5 0.5 0.5 1.0" />
+      </material>
+    </visual>
+    <visual>
+      <origin rpy="1.5707963267948966 0 1.5707963267948966" xyz="0.020395 -0.02 0"/>
+      <geometry>
+        <box size="0.001 0.099 0.023" />
+      </geometry>
+      <material name="black">
+        <color rgba="0.0 0.0 0.0 1.0" />
       </material>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 -0.02 0"/>
+      <origin rpy="1.5707963267948966 0 1.5707963267948966" xyz="0.020395 -0.02 0"/>
       <geometry>
         <box size="0.02005 0.099 0.023"/>
       </geometry>


### PR DESCRIPTION
Depends on https://github.com/PickNikRobotics/picknik_accessories/pull/25
Closes https://github.com/PickNikRobotics/moveit_pro/issues/10823

Removes the d415.stl mesh we use directly in a couple of xacros and makes it a box instead, with another thin black box in the front for better visuals. This is how it looks like in `lab_sim`:

![Screenshot from 2025-02-20 10-55-25](https://github.com/user-attachments/assets/6a0c2918-40ea-4b3e-a7cc-a3bd15f67f52)

