### PR TITLE
fix(user_ws): GPU inferencing and acceleration now properly working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,6 +230,28 @@ ARG USERNAME
 ARG USER_WS=/home/${USERNAME}/user_ws
 ENV USER_WS=${USER_WS}
 
+#########################################
+# ENABLE GPU INFERENCE BY UNCOMMENTING  #
+# #######################################
+# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+#     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+#     apt-get update && apt-get install wget -y -q --no-install-recommends && \
+#     wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
+#     dpkg -i cuda-keyring_1.1-1_all.deb && \
+#     apt-get update && \
+#     apt-get install -q -y \
+#       libcudnn9-cuda-12 \
+#       libcudnn9-dev-cuda-12 \
+#       libcublas-12-6 \
+#       cuda-cudart-12-6 \
+#       libcurand-12-6 \
+#       libcufft-12-6 \
+#       libnvinfer10 \
+#       libnvinfer-plugin10 \
+#       libnvonnxparsers10 \
+#       libtree
+# ENV LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/onnxruntime/capi:/usr/lib/x86_64-linux-gnu:/usr/local/cuda-12.6/targets/x86_64-linux/lib:$LD_LIBRARY_PATH
+
 # Compile the workspace
 WORKDIR $USER_WS
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
 
   # Starts the MoveIt Pro Agent and the Bridge between the Agent and the Web UI.
   agent_bridge:
-    # IMPORTANT: Enable Nvidia GPUs by uncommenting the lines below:
+    # IMPORTANT: Enable Nvidia GPU ACCELERATION by uncommenting the lines below:
     # runtime: nvidia
     # deploy:
     #     resources:
@@ -22,7 +22,7 @@ services:
     #             capabilities: [gpu, compute, utility,graphics, video]
   # Starts the robot drivers.
   drivers:
-    # IMPORTANT: Enable Nvidia GPUs by uncommenting the lines below:
+    # IMPORTANT: Enable Nvidia GPU ACCELERATION by uncommenting the lines below:
     # runtime: nvidia
     # deploy:
     #     resources:


### PR DESCRIPTION
# Description
This PR adds functional GPU Acceleration and GPU Inference to the example_ws for 7.0-7.3. This PR will become obsolete in 7.4, as a script will handle most of this, but customers are excited to use these features now.

# Notes
For the Dockerfile changes, I directly integrate a known working TensorRT NVIDIA provided image for a few reasons:
1. The first time `docker pull` between these steps and the original `apt-update` [gdoc steps](https://docs.google.com/document/d/1Q4mdK88R2m8w8evjl74TgB01sS0DP8NI0wXzO_wlRHg/edit?usp=sharing) take about the same amount of time (the docker pull seemed faster). However, if you change anything in the Dockerfile above the `apt-update` steps, this whole process runs again. By integrating a separate image, as long as the image has not been pruned off the system, which a user has to intentionally do, this step only takes a while **once**.
2. Copying over the files is faster than installing every time (since we run apt update) and thus results in faster consecutive build times, and only increasing our docker image with the parts that moveit_pro actually uses.
3. The `TensorRT` image provides all the libraries for both `cudnn` AND `TensorRT` which the original `apt-update` instructions did not, causing the `libnvinfer_plugin.so` library to not be found, breaking the `TensorRT` acceleration (though not technically causing an error)

# Linked PRs
Full documentation at this pr: https://github.com/PickNikRobotics/moveit_pro/pull/10884