### PR TITLE
update-breakpoint-topic

### DIFF
--- a/src/grinding_sim/objectives/move_to_loaded_pose.xml
+++ b/src/grinding_sim/objectives/move_to_loaded_pose.xml
@@ -13,7 +13,10 @@
         output="{target_pose}"
         file_path="approach_pose.yaml"
       />
-      <Action ID="BreakpointSubscriber" breakpoint_topic="/studio_breakpoint" />
+      <Action
+        ID="BreakpointSubscriber"
+        breakpoint_topic="/moveit_pro_breakpoint"
+      />
       <SubTree
         ID="Move to Pose"
         _collapsed="false"


### PR DESCRIPTION
updates breakpoint topic name to `/moveit_pro_breakpoint` to stop referencing `studio`

Does this need to happen anywhere else? I did a search in this repo and could only find it in one file. 

sister PR to edit code and docs: https://github.com/PickNikRobotics/moveit_pro/pull/10963