### PR TITLE
lab_sim: don't activate servo controller at startup

### DIFF
--- a/src/lab_sim/config/config.yaml
+++ b/src/lab_sim/config/config.yaml
@@ -69,10 +69,10 @@ ros2_control:
     - "force_torque_sensor_broadcaster"
     - "robotiq_gripper_controller"
     - "joint_state_broadcaster"
-    - "servo_controller"
     - "joint_trajectory_controller"
   # Load but do not start these controllers so they can be activated later if needed.
   controllers_inactive_at_startup:
+    - "servo_controller"
     - "joint_trajectory_admittance_controller"
     - "velocity_force_controller"
   # Any controllers here will not be spawned by MoveIt Pro.


### PR DESCRIPTION
The servo_controller and the JTC claim the same joints so they can't both be activated on startup.