### PR TITLE
hangar_sim: rotate grasp link 180 deg

### DIFF
--- a/src/hangar_sim/description/vacuum_urdf.xacro
+++ b/src/hangar_sim/description/vacuum_urdf.xacro
@@ -50,7 +50,7 @@
     <joint name="vacuum_base_grasp_link_joint" type="fixed">
       <parent link="vacuum_base"/>
       <child link="grasp_link"/>
-      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.093 0.159"/>
+      <origin rpy="0.0 0.0 3.1415" xyz="0.0 0.093 0.159"/>
     </joint>
 
   </xacro:macro>


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/moveit_pro/issues/10927

Tested by running hangar_sim and veryfing that:
* Pose jog arrows are aligned with camera view, i.e. left moves left
* Objective to move boxes still works
