### PR TITLE
[11079] Ridgeback getting stuck on plane in `hangar_sim`

### DIFF
--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -199,7 +199,7 @@ local_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
-        inflation_radius: 0.20
+        inflation_radius: 0.50
       voxel_layer:
         plugin: "nav2_costmap_2d::VoxelLayer"
         enabled: True
@@ -264,7 +264,7 @@ global_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
-        inflation_radius: 0.20
+        inflation_radius: 0.50
       always_send_full_costmap: True
 
 map_server:


### PR DESCRIPTION
## Description
Resolves PicknikRobotics/moveit_pro#11079

Navigating to various places in `hangar_sim` can cause the ridgeback to fail because it gets too close to obstacles.
The inflation radius was set to 0.3 meters, but the ridgeback documentation shows the largest width of the base is 0.96 meters https://clearpathrobotics.com/ridgeback-indoor-robot-platform/. 
![image](https://github.com/user-attachments/assets/40414070-8e4b-451c-bc18-9d8f5893e99d)
I set the new inflation radius to 0.5 meters to give a little buffer. 

## Testing
Send the robot from a place near the plane to a place where it will have to go around the plane using the "Navigate to Clicked Point" objective.

![navigatetoclicked](https://github.com/user-attachments/assets/e82347d3-ee87-4f74-9f37-4cf7a08cb8d7)
