### PR TITLE
Remove duplicate REST API launch from configs

### DIFF
--- a/src/fanuc_sim/launch/agent_bridge.launch.xml
+++ b/src/fanuc_sim/launch/agent_bridge.launch.xml
@@ -3,7 +3,4 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share moveit_studio_rest_api)/launch/rest_api.launch.xml"
-  />
 </launch>

--- a/src/grinding_sim/launch/agent_bridge.launch.xml
+++ b/src/grinding_sim/launch/agent_bridge.launch.xml
@@ -3,7 +3,4 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share moveit_studio_rest_api)/launch/rest_api.launch.xml"
-  />
 </launch>

--- a/src/hangar_sim/launch/agent_bridge.launch.xml
+++ b/src/hangar_sim/launch/agent_bridge.launch.xml
@@ -3,9 +3,6 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share moveit_studio_rest_api)/launch/rest_api.launch.xml"
-  />
   <!--  <node-->
   <!--    pkg="hangar_sim"-->
   <!--    exec="odometry_joint_state_publisher.py"-->

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/launch/agent_bridge.launch.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/launch/agent_bridge.launch.xml
@@ -3,7 +3,4 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share moveit_studio_rest_api)/launch/rest_api.launch.xml"
-  />
 </launch>

--- a/src/moveit_pro_kinova_configs/kinova_sim/launch/agent_bridge.launch.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/launch/agent_bridge.launch.xml
@@ -2,7 +2,4 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share moveit_studio_rest_api)/launch/rest_api.launch.xml"
-  />
 </launch>


### PR DESCRIPTION
This is a holdover from.. idk when, but rest_api.launch.xml is already invoked by the underlying agent_bridge.launch.xml in the core codebase, so this is definitely unnecessary.