### PR TITLE
Add valid default for container base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 
 # Specify the MoveIt Pro release to build on top of.
-ARG MOVEIT_STUDIO_BASE_IMAGE
+ARG MOVEIT_STUDIO_BASE_IMAGE=picknikciuser/moveit-studio:${STUDIO_DOCKER_TAG:-main}
 ARG USERNAME=studio-user
 ARG USER_UID=1000
 ARG USER_GID=1000


### PR DESCRIPTION
This is the default used by the wrapper script that calls this, so I've copied it here so that it stops throwing annoying warnings and should work out-of-box when building this Dockerfile without the launch script.

Closes PickNikRobotics/moveit_pro#11438.