### PR TITLE
fix linear joints range and joint teleoperate

### DIFF
--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -74,7 +74,7 @@
     <parent link="world" />
     <child link="virtual_rail_link_1" />
     <origin xyz="0 0 0" rpy="0 0 0" />
-    <limit effort="1000.0" lower="-100.0" upper="100.0" velocity="0.175" acceleration="10.0"/>
+    <limit effort="1000.0" lower="-20.0" upper="20.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>
 
@@ -85,7 +85,7 @@
     <parent link="virtual_rail_link_1" />
     <child link="virtual_rail_link_2" />
     <origin xyz="0 0 0" rpy="0 0 0" />
-    <limit effort="1000.0" lower="-100.0" upper="100.0" velocity="0.175" acceleration="10.0"/>
+    <limit effort="1000.0" lower="-5.0" upper="55.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>
 

--- a/src/hangar_sim/objectives/interpolate_to_joint_state.xml
+++ b/src/hangar_sim/objectives/interpolate_to_joint_state.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Interpolate to Joint State">
+  <BehaviorTree
+    ID="Interpolate to Joint State"
+    _description="Move to a specified joint state using joint interpolation"
+    _subtreeOnly="true"
+  >
+    <Control ID="Sequence">
+      <Action
+        ID="InitializeMTCTask"
+        task_id="interpolate_to_joint_state"
+        controller_names="{controller_names}"
+        task="{interpolate_to_waypoint_task}"
+      />
+      <Action ID="SetupMTCCurrentState" task="{interpolate_to_waypoint_task}" />
+      <Action
+        ID="SetupMTCInterpolateToJointState"
+        joint_state="{target_joint_state}"
+        name="SetupMTCInterpolateToJointState_First"
+        planning_group_name="manipulator"
+        task="{interpolate_to_waypoint_task}"
+      />
+      <Action
+        ID="PlanMTCTask"
+        solution="{interpolate_to_waypoint_solution}"
+        task="{interpolate_to_waypoint_task}"
+      />
+      <Action
+        ID="ExecuteMTCTask"
+        solution="{interpolate_to_waypoint_solution}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Interpolate to Joint State">
+      <input_port name="target_joint_state" default="{target_joint_state}" />
+      <input_port
+        name="controller_names"
+        default="/joint_trajectory_controller"
+      />
+      <MetadataFields>
+        <Metadata subcategory="Motion - Execute" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
Set the virtual linear joints range, in `hangar_sim`, to the size of the map, and fix joint jog by overriding `Interpolate to Joint State` to not list the robotiq controllers, which are not available in this config.

Closes https://github.com/PickNikRobotics/moveit_pro/issues/11537

To test, go to Teleoperate -> Joint Jog and move the slider of the linear joints. Check that the limits match roughly with the dimensions of the map. It should also move to the commanded value (assuming it's feasible)