### PR TITLE
Rename hangar_sim training objectives

### DIFF
--- a/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
+++ b/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Draw Picknik">
+<root BTCPP_format="4" main_tree_to_execute="Cartesian Draw Geometry From File">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Draw Picknik"
+    ID="Cartesian Draw Geometry From File"
     _description="Training example that shows how to load a Cartesian path from a file and execute the path"
     _favorite="false"
     _subtreeOnly="false"
@@ -69,7 +69,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Draw Picknik">
+    <SubTree ID="Cartesian Draw Geometry From File">
       <MetadataFields>
         <Metadata runnable="true" />
         <Metadata subcategory="Training Examples" />

--- a/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
+++ b/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <root
   BTCPP_format="4"
   main_tree_to_execute="Cartesian Path with Collision Checking"
@@ -8,7 +7,6 @@
     ID="Cartesian Path with Collision Checking"
     _description="An example of planning and executing a straight line path with base and arm motion"
     _favorite="false"
-    _subtreeOnly="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <SubTree
@@ -45,11 +43,6 @@
         vector="{pose_stamped_vector}"
       />
       <Action
-        ID="VisualizePath"
-        marker_lifetime="0.000000"
-        path="{pose_stamped_vector}"
-      />
-      <Action
         ID="PlanCartesianPath"
         acceleration_scale_factor="1.000000"
         blending_radius="0.020000"
@@ -83,14 +76,6 @@
           solution="{debug_solution}"
         />
       </Control>
-      <Action
-        ID="ExecuteFollowJointTrajectory"
-        execute_follow_joint_trajectory_action_name="/joint_trajectory_controller/follow_joint_trajectory"
-        goal_duration_tolerance="-1.000000"
-        goal_position_tolerance="0.000000"
-        goal_time_tolerance="0.000000"
-        joint_trajectory_msg="{joint_trajectory_msg}"
-      />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
+++ b/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Generate coverage path">
+<root
+  BTCPP_format="4"
+  main_tree_to_execute="Cartesian Path with Collision Checking"
+>
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Generate coverage path"
-    _description="A training example that plans and executes a coverage path with base and arm motion"
+    ID="Cartesian Path with Collision Checking"
+    _description="An example of planning and executing a straight line path with base and arm motion"
     _favorite="false"
     _subtreeOnly="false"
   >
@@ -16,18 +19,18 @@
         controller_names="/joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
-        keep_orientation_link_names="grasp_link"
         keep_orientation_tolerance="0.05"
         link_padding="0.0"
         velocity_scale_factor="1.0"
         waypoint_name="Look at Plane"
+        keep_orientation_link_names="grasp_link"
       />
       <Action
         ID="CreateStampedPose"
         reference_frame="grasp_link"
         stamped_pose="{stamped_pose}"
         orientation_xyzw="0;0;0;1"
-        position_xyz="0;-0.5;1"
+        position_xyz="0;0;5"
       />
       <Action
         ID="VisualizePose"
@@ -37,12 +40,9 @@
         pose="{stamped_pose}"
       />
       <Action
-        ID="GenerateCoveragePath"
-        vector_of_poses="{pose_stamped_vector}"
-        bottom_right_corner="{stamped_pose}"
-        height="0.5"
-        stride_distance="0.1"
-        width="0.5"
+        ID="AddPoseStampedToVector"
+        input="{stamped_pose}"
+        vector="{pose_stamped_vector}"
       />
       <Action
         ID="VisualizePath"
@@ -59,11 +59,30 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
         path="{pose_stamped_vector}"
         planning_group_name="manipulator"
-        position_only="false"
+        position_only="true"
         tip_link="grasp_link"
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Control ID="Fallback">
+        <Action
+          ID="ValidateTrajectory"
+          cartesian_space_step="0.020000"
+          debug_solution="{debug_solution}"
+          joint_space_step="0.100000"
+          joint_trajectory_msg="{joint_trajectory_msg}"
+          planning_group_name="manipulator"
+          planning_scene_msg="{planning_scene}"
+        />
+        <Action
+          ID="WaitForUserTrajectoryApproval"
+          solution="{debug_solution}"
+        />
+      </Control>
       <Action
         ID="ExecuteFollowJointTrajectory"
         execute_follow_joint_trajectory_action_name="/joint_trajectory_controller/follow_joint_trajectory"
@@ -75,7 +94,11 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Generate coverage path">
+    <SubTree ID="Cartesian Path with Collision Checking">
+      <MetadataFields>
+        <Metadata subcategory="Training Examples" />
+        <Metadata runnable="true" />
+      </MetadataFields>
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
+++ b/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Follow Path">
+<root BTCPP_format="4" main_tree_to_execute="Cartesian Plan Simple Square">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Follow Path"
-    _description="An example of planning and executing a straight line path with base and arm motion"
+    ID="Cartesian Plan Simple Square"
+    _description="Training example that shows how to create a path from poses and execute the path"
     _favorite="false"
     _subtreeOnly="false"
   >
@@ -16,18 +16,18 @@
         controller_names="/joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
+        keep_orientation_link_names="grasp_link"
         keep_orientation_tolerance="0.05"
         link_padding="0.0"
         velocity_scale_factor="1.0"
         waypoint_name="Look at Plane"
-        keep_orientation_link_names="grasp_link"
       />
       <Action
         ID="CreateStampedPose"
         reference_frame="grasp_link"
         stamped_pose="{stamped_pose}"
         orientation_xyzw="0;0;0;1"
-        position_xyz="0;0;5"
+        position_xyz="0;0;0.4"
       />
       <Action
         ID="VisualizePose"
@@ -35,6 +35,54 @@
         marker_name="pose"
         marker_size="0.100000"
         pose="{stamped_pose}"
+      />
+      <Action
+        ID="AddPoseStampedToVector"
+        input="{stamped_pose}"
+        vector="{pose_stamped_vector}"
+      />
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{stamped_pose}"
+        orientation_xyzw="0;0;0;1"
+        position_xyz="0;-0.4;0.4"
+      />
+      <Action
+        ID="AddPoseStampedToVector"
+        input="{stamped_pose}"
+        vector="{pose_stamped_vector}"
+      />
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{stamped_pose}"
+        orientation_xyzw="0;0;0;1"
+        position_xyz="0.4;-0.4;0.4"
+      />
+      <Action
+        ID="AddPoseStampedToVector"
+        input="{stamped_pose}"
+        vector="{pose_stamped_vector}"
+      />
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{stamped_pose}"
+        orientation_xyzw="0;0;0;1"
+        position_xyz="0.4;0;0.4"
+      />
+      <Action
+        ID="AddPoseStampedToVector"
+        input="{stamped_pose}"
+        vector="{pose_stamped_vector}"
+      />
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{stamped_pose}"
+        orientation_xyzw="0;0;0;1"
+        position_xyz="0;0;0.4"
       />
       <Action
         ID="AddPoseStampedToVector"
@@ -56,30 +104,13 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
         path="{pose_stamped_vector}"
         planning_group_name="manipulator"
-        position_only="true"
+        position_only="false"
         tip_link="grasp_link"
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action
-        ID="GetCurrentPlanningScene"
-        planning_scene_msg="{planning_scene}"
-      />
-      <Control ID="Fallback">
-        <Action
-          ID="ValidateTrajectory"
-          cartesian_space_step="0.020000"
-          debug_solution="{debug_solution}"
-          joint_space_step="0.100000"
-          joint_trajectory_msg="{joint_trajectory_msg}"
-          planning_group_name="manipulator"
-          planning_scene_msg="{planning_scene}"
-        />
-        <Action
-          ID="WaitForUserTrajectoryApproval"
-          solution="{debug_solution}"
-        />
-      </Control>
+      <Action ID="IsUserAvailable" />
+      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteFollowJointTrajectory"
         execute_follow_joint_trajectory_action_name="/joint_trajectory_controller/follow_joint_trajectory"
@@ -91,11 +122,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Follow Path">
-      <MetadataFields>
-        <Metadata subcategory="Training Examples" />
-        <Metadata runnable="true" />
-      </MetadataFields>
+    <SubTree ID="Cartesian Plan Simple Square">
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/find_and_spray_plane.xml
+++ b/src/hangar_sim/objectives/find_and_spray_plane.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Find and Spray Plane">
+<root BTCPP_format="4" main_tree_to_execute="Find and Spray Plane">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Find and Spray Plane"
+    ID="Find and Spray Plane"
     _description="Finds the plane then generates and executes a coverage path"
     _favorite="false"
     _subtreeOnly="false"
@@ -82,7 +82,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Find and Spray Plane">
+    <SubTree ID="Find and Spray Plane">
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/generate_grid_pattern_on_airplane.xml
+++ b/src/hangar_sim/objectives/generate_grid_pattern_on_airplane.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Spray Plane">
+<root BTCPP_format="4" main_tree_to_execute="Generate Grid Pattern on Airplane">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Spray Plane"
-    _description="An example of computing and executing a coverage path for spraying the plane"
+    ID="Generate Grid Pattern on Airplane"
+    _description="A training example that plans and executes a coverage path with base and arm motion"
     _favorite="false"
     _subtreeOnly="false"
   >
@@ -16,18 +16,18 @@
         controller_names="/joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
+        keep_orientation_link_names="grasp_link"
         keep_orientation_tolerance="0.05"
         link_padding="0.0"
         velocity_scale_factor="1.0"
         waypoint_name="Look at Plane"
-        keep_orientation_link_names="grasp_link"
       />
       <Action
         ID="CreateStampedPose"
         reference_frame="grasp_link"
         stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;.707;.707"
-        position_xyz="1;-0.5;1"
+        orientation_xyzw="0;0;0;1"
+        position_xyz="0;-0.5;1"
       />
       <Action
         ID="VisualizePose"
@@ -40,9 +40,9 @@
         ID="GenerateCoveragePath"
         vector_of_poses="{pose_stamped_vector}"
         bottom_right_corner="{stamped_pose}"
-        stride_distance="0.5"
-        width="0.6"
-        height="5"
+        height="0.5"
+        stride_distance="0.1"
+        width="0.5"
       />
       <Action
         ID="VisualizePath"
@@ -64,7 +64,6 @@
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteFollowJointTrajectory"
         execute_follow_joint_trajectory_action_name="/joint_trajectory_controller/follow_joint_trajectory"
@@ -76,7 +75,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Spray Plane">
+    <SubTree ID="Generate Grid Pattern on Airplane">
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/mobile_scan_and_plan.xml
+++ b/src/hangar_sim/objectives/mobile_scan_and_plan.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Draw Square">
+<root BTCPP_format="4" main_tree_to_execute="Mobile Scan and Plan">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Draw Square"
-    _description="Training example that shows how to create a path from poses and execute the path"
+    ID="Mobile Scan and Plan"
+    _description="An example of computing and executing a coverage path for spraying the plane"
     _favorite="false"
     _subtreeOnly="false"
   >
@@ -16,18 +16,18 @@
         controller_names="/joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
-        keep_orientation_link_names="grasp_link"
         keep_orientation_tolerance="0.05"
         link_padding="0.0"
         velocity_scale_factor="1.0"
         waypoint_name="Look at Plane"
+        keep_orientation_link_names="grasp_link"
       />
       <Action
         ID="CreateStampedPose"
         reference_frame="grasp_link"
         stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;0;1"
-        position_xyz="0;0;0.4"
+        orientation_xyzw="0;0;.707;.707"
+        position_xyz="1;-0.5;1"
       />
       <Action
         ID="VisualizePose"
@@ -37,57 +37,12 @@
         pose="{stamped_pose}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{pose_stamped_vector}"
-      />
-      <Action
-        ID="CreateStampedPose"
-        reference_frame="grasp_link"
-        stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;0;1"
-        position_xyz="0;-0.4;0.4"
-      />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{pose_stamped_vector}"
-      />
-      <Action
-        ID="CreateStampedPose"
-        reference_frame="grasp_link"
-        stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;0;1"
-        position_xyz="0.4;-0.4;0.4"
-      />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{pose_stamped_vector}"
-      />
-      <Action
-        ID="CreateStampedPose"
-        reference_frame="grasp_link"
-        stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;0;1"
-        position_xyz="0.4;0;0.4"
-      />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{pose_stamped_vector}"
-      />
-      <Action
-        ID="CreateStampedPose"
-        reference_frame="grasp_link"
-        stamped_pose="{stamped_pose}"
-        orientation_xyzw="0;0;0;1"
-        position_xyz="0;0;0.4"
-      />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{pose_stamped_vector}"
+        ID="GenerateCoveragePath"
+        vector_of_poses="{pose_stamped_vector}"
+        bottom_right_corner="{stamped_pose}"
+        stride_distance="0.5"
+        width="0.6"
+        height="5"
       />
       <Action
         ID="VisualizePath"
@@ -109,7 +64,6 @@
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action ID="IsUserAvailable" />
       <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteFollowJointTrajectory"
@@ -122,7 +76,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Draw Square">
+    <SubTree ID="Mobile Scan and Plan">
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/move_forward_2m.xml
+++ b/src/hangar_sim/objectives/move_forward_2m.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Solution - Move Forward 2m">
+<root BTCPP_format="4" main_tree_to_execute="Move Forward 2m">
   <!--//////////-->
   <BehaviorTree
-    ID="Solution - Move Forward 2m"
+    ID="Move Forward 2m"
     _description="A training example that moves to a 3D pose using base and arm motion"
     _favorite="false"
     _subtreeOnly="false"
@@ -31,7 +31,7 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Solution - Move Forward 2m">
+    <SubTree ID="Move Forward 2m">
       <MetadataFields>
         <Metadata subcategory="Training Examples" />
         <Metadata runnable="true" />


### PR DESCRIPTION
Rename training Objectives to not contain "Solution - X"
Removes VisualizePath and  the execution Behavior at the end of `Cartesian Path with Collision Checking`

Closes https://github.com/PickNikRobotics/moveit_pro/issues/11623
