### PR TITLE
Update Kinova 'Move To Pose' subtree to use remapped {target_pose} instead of calling 'RetrievePoseParameter' behavior

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_to_pose.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_to_pose.xml
@@ -2,55 +2,33 @@
 <root BTCPP_format="4" main_tree_to_execute="Move to Pose">
   <BehaviorTree
     ID="Move to Pose"
-    _description="Uses inverse kinematics to move the robot to a set gripper position"
+    _description="Plan and execute motion to a Cartesian coordinate pose in a ROS message type, using inverse kinematics."
   >
-    <Control ID="Fallback" name="root">
-      <Control ID="Sequence">
-        <Action
-          ID="RetrievePoseParameter"
-          timeout_sec="-1"
-          pose="{target_pose}"
-        />
-        <Action
-          ID="InitializeMTCTask"
-          task_id="move_to_pose"
-          controller_names="/joint_trajectory_controller"
-          task="{move_to_pose_task}"
-        />
-        <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />
-        <Action
-          ID="SetupMTCPlanToPose"
-          ik_frame="grasp_link"
-          planning_group_name="manipulator"
-          target_pose="{target_pose}"
-          task="{move_to_pose_task}"
-        />
-        <Action
-          ID="PlanMTCTask"
-          solution="{move_to_pose_solution}"
-          task="{move_to_pose_task}"
-        />
-        <SubTree
-          ID="Wait for Trajectory Approval if User Available"
-          solution="{move_to_pose_solution}"
-        />
-        <Action ID="ExecuteMTCTask" solution="{move_to_pose_solution}" />
-        <Action
-          ID="PublishEmpty"
-          topic="/studio_ui/motion_ended"
-          queue_size="1"
-          use_best_effort="false"
-        />
-      </Control>
-      <Control ID="Sequence">
-        <Action
-          ID="PublishEmpty"
-          topic="/studio_ui/motion_ended"
-          queue_size="1"
-          use_best_effort="false"
-        />
-        <Action ID="AlwaysFailure" />
-      </Control>
+    <Control ID="Sequence">
+      <Action
+        ID="InitializeMTCTask"
+        task_id="move_to_pose"
+        controller_names="/joint_trajectory_controller"
+        task="{move_to_pose_task}"
+      />
+      <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />
+      <Action
+        ID="SetupMTCPlanToPose"
+        ik_frame="grasp_link"
+        planning_group_name="manipulator"
+        target_pose="{target_pose}"
+        task="{move_to_pose_task}"
+      />
+      <Action
+        ID="PlanMTCTask"
+        solution="{move_to_pose_solution}"
+        task="{move_to_pose_task}"
+      />
+      <SubTree
+        ID="Wait for Trajectory Approval if User Available"
+        solution="{move_to_pose_solution}"
+      />
+      <Action ID="ExecuteMTCTask" solution="{move_to_pose_solution}" />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
@@ -62,8 +40,9 @@
       />
       <input_port name="planning_group_name" default="manipulator" />
       <input_port name="ik_frame" default="grasp_link" />
-      <input_port name="target_pose" default="{hole_object}" />
+      <input_port name="target_pose" default="{target_pose}" />
       <MetadataFields>
+        <Metadata runnable="false" />
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>
     </SubTree>


### PR DESCRIPTION
Not sure how this got out of sync, but this updates "Move to Pose" so that
- It doesn't unnecessarily call "RetrievePoseParameter" - the pose should be passed in via the port remap, not be expected to be retrieved from the UI in a Teleoperation context.
- Deletes some other behaviors that are no longer used in the "core" version of "Move to Pose"

For 8.0 we should decide if we are migrating all the configs to use the core objectives, including "Move to Pose", and make sure those objectives expose the needed port remaps, such as `planning_group_name` and `ik_frame`.

## To test
Run kinova_sim and space_satellite_sim and make sure the teleoperation modes like imarker still work.