### PR TITLE
Make docker build context smaller

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+build
+install


### PR DESCRIPTION
When I was testing this on the v7.6.1 branch the build context went from 5.86GB down to 2.52.

Closes https://github.com/PickNikRobotics/moveit_pro/issues/11854