### PR TITLE
Make some subtrees non-runnable to prevent users from accidentally putting planning scene into an irrecoverable state.

### DIFF
--- a/src/factory_sim/config/config.yaml
+++ b/src/factory_sim/config/config.yaml
@@ -43,7 +43,7 @@ hardware:
     urdf_params:
         # Use "mock", "mujoco", or "real"
       - hardware_interface: "mujoco"
-      - mujoco_viewer: "true"
+      - mujoco_viewer: "false"
 
 # Sets ROS global params for launch.
 # [Optional]

--- a/src/factory_sim/objectives/pick_up_tool.xml
+++ b/src/factory_sim/objectives/pick_up_tool.xml
@@ -93,7 +93,7 @@
     <SubTree ID="Pick Up Tool">
       <MetadataFields>
         <Metadata subcategory="Grasping" />
-        <Metadata runnable="true" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -80,7 +80,7 @@
   <TreeNodesModel>
     <SubTree ID="Place Tool in Tool Holder">
       <MetadataFields>
-        <Metadata runnable="true" />
+        <Metadata runnable="false" />
         <Metadata subcategory="Grasping" />
       </MetadataFields>
     </SubTree>


### PR DESCRIPTION
Bug fixes from #224
- Make some subtrees non-runnable to prevent users from accidentally putting planning scene into an irrecoverable state.
- Do not launch mujoco viewer by default to better support low end hardware.

