### PR TITLE
Point to main hash for moveit_pro_lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,4 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: PickNikRobotics/moveit_pro_lint@add-composite-action
+      - uses: PickNikRobotics/moveit_pro_lint@bdb0383e8309937dd1d9ac88d875d28af2e3fc55


### PR DESCRIPTION
to fix CI failure [here](https://github.com/PickNikRobotics/moveit_pro_example_ws/actions/runs/14522246034/job/40745697844?pr=224)