### PR TITLE
[11402] Add Application ML category

### DIFF
--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Move Boxes to Loading Zone">
+<root BTCPP_format="4" main_tree_to_execute="ML Move Boxes to Loading Zone">
   <!--//////////-->
   <BehaviorTree
-    ID="Move Boxes to Loading Zone"
+    ID="ML Move Boxes to Loading Zone"
     _description="Move all of the boxes into the loading zone using ML perception."
     _favorite="true"
   >
@@ -52,10 +52,10 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Move Boxes to Loading Zone">
+    <SubTree ID="ML Move Boxes to Loading Zone">
       <MetadataFields>
         <Metadata runnable="true" />
-        <Metadata subcategory="Application - Advanced Examples" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/ml_grasp_object_from_text_prompt.xml
+++ b/src/lab_sim/objectives/ml_grasp_object_from_text_prompt.xml
@@ -1,7 +1,8 @@
-<root BTCPP_format="4" main_tree_to_execute="Grasp Object from Text Prompt">
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="ML Grasp Object from Text Prompt">
   <!--//////////-->
   <BehaviorTree
-    ID="Grasp Object from Text Prompt"
+    ID="ML Grasp Object from Text Prompt"
     _description="Captures and segments objects from a point cloud based on a text prompt. Then grasps the first object returned from the segmentation."
     _favorite="true"
   >
@@ -20,6 +21,7 @@
         link_padding="0.01"
         velocity_scale_factor="1.0"
         waypoint_name="Above Pick Cube"
+        seed="0"
       />
       <SubTree
         ID="Segment Point Cloud from Text Prompt Subtree"
@@ -71,6 +73,7 @@
           task_id="grasp"
           controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
           task="{mtc_task}"
+          trajectory_monitoring="false"
         />
         <Action
           ID="SetupMTCCurrentState"
@@ -119,14 +122,15 @@
         link_padding="0.01"
         velocity_scale_factor="1.0"
         waypoint_name="Above Pick Cube"
+        seed="0"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Grasp Object from Text Prompt">
+    <SubTree ID="ML Grasp Object from Text Prompt">
       <MetadataFields>
         <Metadata runnable="true" />
-        <Metadata subcategory="Application - Advanced Examples" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/ml_segment_image_from_text_prompt.xml
+++ b/src/lab_sim/objectives/ml_segment_image_from_text_prompt.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Segment Image from Text Prompt">
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="ML Segment Image from Text Prompt">
   <!--//////////-->
   <BehaviorTree
-    ID="Segment Image from Text Prompt"
+    ID="ML Segment Image from Text Prompt"
     _description="Run text based segmentation and visualize he masks."
     _favorite="true"
   >
@@ -27,10 +27,10 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Segment Image from Text Prompt">
+    <SubTree ID="ML Segment Image from Text Prompt">
       <MetadataFields>
         <Metadata runnable="true" />
-        <Metadata subcategory="Application - Advanced Examples" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/ml_segment_point_cloud_from_clicked_point.xml
+++ b/src/lab_sim/objectives/ml_segment_point_cloud_from_clicked_point.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <root
   BTCPP_format="4"
-  main_tree_to_execute="Segment Point Cloud from Clicked Point"
+  main_tree_to_execute="ML Segment Point Cloud from Clicked Point"
 >
   <!--//////////-->
   <BehaviorTree
-    ID="Segment Point Cloud from Clicked Point"
+    ID="ML Segment Point Cloud from Clicked Point"
     _description="Captures a point cloud and requests the user to click on three objects in the image to be segmented. The point cloud is then filtered to only include the selected objects."
     _favorite="true"
   >
@@ -24,10 +24,10 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Segment Point Cloud from Clicked Point">
+    <SubTree ID="ML Segment Point Cloud from Clicked Point">
       <MetadataFields>
         <Metadata runnable="true" />
-        <Metadata subcategory="Application - Advanced Examples" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/ml_segment_point_cloud_from_text_prompt.xml
+++ b/src/lab_sim/objectives/ml_segment_point_cloud_from_text_prompt.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root
   BTCPP_format="4"
-  main_tree_to_execute="Segment Point Cloud from Text Prompt"
+  main_tree_to_execute="ML Segment Point Cloud from Text Prompt"
 >
   <!--//////////-->
   <BehaviorTree
-    ID="Segment Point Cloud from Text Prompt"
+    ID="ML Segment Point Cloud from Text Prompt"
     _description="Captures a point cloud and requests the user to click an object in the image to be segmented. The point cloud is then filtered to only include the selected object."
     _favorite="true"
   >
@@ -32,10 +32,10 @@
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Segment Point Cloud from Text Prompt">
+    <SubTree ID="ML Segment Point Cloud from Text Prompt">
       <MetadataFields>
         <Metadata runnable="true" />
-        <Metadata subcategory="Application - Advanced Examples" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>


### PR DESCRIPTION
`hangar_sim`
Should the three objectives under `Perception - ML` also have `ML` prepended to them or was https://github.com/PickNikRobotics/moveit_pro/issues/11402 meant to only rename the ones that were already in the "Application" subcategory?
![image](https://github.com/user-attachments/assets/122b3b6c-f535-475e-90cb-6949073378b8)

`lab_sim`
![image](https://github.com/user-attachments/assets/766cfb59-34fa-41fa-a413-6ee944bbcf5e)

