### PR TITLE
restart PoseJog if groups change

### DIFF
--- a/src/grinding_sim/objectives/request_teleoperation.xml
+++ b/src/grinding_sim/objectives/request_teleoperation.xml
@@ -133,17 +133,23 @@
             </Decorator>
             <!--Cartesian and joint jogging-->
             <Control ID="Sequence" _while="teleop_mode == 2">
-              <Action
-                ID="ActivateControllers"
-                controller_names="{controllers}"
-              />
-              <Action
-                ID="PoseJog"
-                controller_names="{controllers}"
-                link_padding="0.010000"
-                planning_group_names="{planning_groups}"
-                stop_safety_factor="1.500000"
-              />
+              <Decorator ID="Repeat" num_cycles="-1">
+                <Control ID="Sequence">
+                  <Action
+                    ID="ActivateControllers"
+                    controller_names="{controllers}"
+                  />
+                  <Decorator ID="ForceSuccess">
+                    <Action
+                      ID="PoseJog"
+                      controller_names="{controllers}"
+                      link_padding="0.0"
+                      planning_group_names="{planning_groups}"
+                      stop_safety_factor="1.500000"
+                    />
+                  </Decorator>
+                </Control>
+              </Decorator>
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
               <Action

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -145,17 +145,23 @@
             </Decorator>
             <!--Cartesian and joint jogging-->
             <Control ID="Sequence" _while="teleop_mode == 2">
-              <Action
-                ID="ActivateControllers"
-                controller_names="velocity_force_controller"
-              />
-              <Action
-                ID="PoseJog"
-                controller_names="{controllers}"
-                link_padding="0.00000"
-                planning_group_names="{planning_groups}"
-                stop_safety_factor="1.500000"
-              />
+              <Decorator ID="Repeat" num_cycles="-1">
+                <Control ID="Sequence">
+                  <Action
+                    ID="ActivateControllers"
+                    controller_names="{controllers}"
+                  />
+                  <Decorator ID="ForceSuccess">
+                    <Action
+                      ID="PoseJog"
+                      controller_names="{controllers}"
+                      link_padding="0.0"
+                      planning_group_names="{planning_groups}"
+                      stop_safety_factor="1.500000"
+                    />
+                  </Decorator>
+                </Control>
+              </Decorator>
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
               <Action

--- a/src/lab_sim/objectives/request_teleoperation.xml
+++ b/src/lab_sim/objectives/request_teleoperation.xml
@@ -141,17 +141,23 @@
             </Decorator>
             <!--Cartesian and joint jogging-->
             <Control ID="Sequence" _while="teleop_mode == 2">
-              <Action
-                ID="ActivateControllers"
-                controller_names="velocity_force_controller"
-              />
-              <Action
-                ID="PoseJog"
-                controller_names="{controllers}"
-                link_padding="0.010000"
-                planning_group_names="{planning_groups}"
-                stop_safety_factor="1.500000"
-              />
+              <Decorator ID="Repeat" num_cycles="-1">
+                <Control ID="Sequence">
+                  <Action
+                    ID="ActivateControllers"
+                    controller_names="{controllers}"
+                  />
+                  <Decorator ID="ForceSuccess">
+                    <Action
+                      ID="PoseJog"
+                      controller_names="{controllers}"
+                      link_padding="0.0"
+                      planning_group_names="{planning_groups}"
+                      stop_safety_factor="1.500000"
+                    />
+                  </Decorator>
+                </Control>
+              </Decorator>
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
               <Action

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/request_teleoperation.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/request_teleoperation.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Request Teleoperation">
-  <!--The integer value used here for teleoperation mode comes from the moveit_studio_sdk_msgs/TeleoperationMode ROS message.-->
+  <!--The
+    integer value used here for teleoperation mode comes from the
+    moveit_studio_sdk_msgs/TeleoperationMode ROS message.-->
   <BehaviorTree
     ID="Request Teleoperation"
     _description="Handles the different variations of teleoperation from the web UI, with the option of interactive user prompts and choosing the initial mode. Should be used as a subtree with port remapping as part of an another Objective."
+    _favorite="false"
     _hardcoded="false"
-    enable_user_interaction="false"
-    initial_teleop_mode="3"
-    user_interaction_prompt="Teleoperate"
   >
     <Control ID="Sequence">
       <Action ID="Script" code="teleop_mode := 0" />
@@ -23,14 +23,8 @@
         />
         <Decorator ID="KeepRunningUntilFailure">
           <Control ID="Sequence">
-            <!--Closing and opening the gripper-->
-            <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 7">
-              <SubTree ID="Activate Vacuum" />
-            </Decorator>
-            <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 6">
-              <SubTree ID="Deactivate Vacuum" />
-            </Decorator>
-            <!--Joint sliders interpolate to joint state-->
+            <!--Joint
+                        sliders interpolate to joint state-->
             <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
               <Control ID="Sequence">
                 <Control ID="Fallback" name="root">
@@ -64,7 +58,8 @@
                 </Control>
               </Control>
             </Decorator>
-            <!--Interactive markers move to pose-->
+            <!--Interactive
+                        markers move to pose-->
             <Decorator ID="ForceSuccess" _while="teleop_mode == 4">
               <Control ID="Sequence">
                 <Control ID="Fallback" name="root">
@@ -98,7 +93,8 @@
                 </Control>
               </Control>
             </Decorator>
-            <!--Waypoint buttons move to joint state-->
+            <!--Waypoint
+                        buttons move to joint state-->
             <Decorator ID="ForceSuccess" _while="teleop_mode == 3">
               <Control ID="Sequence">
                 <Control ID="Fallback" name="root">
@@ -119,6 +115,7 @@
                       keep_orientation="false"
                       keep_orientation_tolerance="0.05"
                       link_padding="0.01"
+                      seed="0"
                       velocity_scale_factor="1.0"
                     />
                     <Action
@@ -173,13 +170,13 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Request Teleoperation">
+      <MetadataFields>
+        <Metadata subcategory="User Input" />
+        <Metadata runnable="false" />
+      </MetadataFields>
       <input_port name="enable_user_interaction" default="false" />
       <input_port name="initial_teleop_mode" default="3" />
-      <input_port name="user_interaction_prompt" default="Teleoperate" />
-      <MetadataFields>
-        <Metadata runnable="false" />
-        <Metadata subcategory="User Input" />
-      </MetadataFields>
+      <input_port name="user_interaction_prompt" default="" />
     </SubTree>
   </TreeNodesModel>
 </root>


### PR DESCRIPTION
Updates `request_teleoperation.xml`, in the configs that have it, to restart PoseJog when it fails (e.g. groups change).
Adds a `request_teleoperation.xml` to `multi_arm_sim`, because the default one from core doesn't work in that case (multi-arm sim doesn't support opening/closing individual arm grippers)
