### PR TITLE
Make MTC controllers pass-through, and change space to ; in controller list.

### DIFF
--- a/src/grinding_sim/objectives/move_to_pose.xml
+++ b/src/grinding_sim/objectives/move_to_pose.xml
@@ -29,6 +29,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Move to Pose">
+      <Metadata runnable="false" />
       <input_port name="target_pose" default="{target_pose}" />
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />

--- a/src/grinding_sim/objectives/move_to_pose_imarker.xml
+++ b/src/grinding_sim/objectives/move_to_pose_imarker.xml
@@ -47,6 +47,7 @@
     <SubTree ID="Move to Pose iMarker">
       <input_port name="target_pose" default="{target_pose}" />
       <MetadataFields>
+        <Metadata runnable="false" />
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>
     </SubTree>

--- a/src/hangar_sim/objectives/move_to_pose.xml
+++ b/src/hangar_sim/objectives/move_to_pose.xml
@@ -50,6 +50,7 @@
       <input_port name="target_pose" default="{target_pose}" />
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/request_teleoperation.xml
+++ b/src/lab_sim/objectives/request_teleoperation.xml
@@ -41,7 +41,7 @@
                       ID="Interpolate to Joint State"
                       _collapsed="false"
                       target_joint_state="{target_joint_state}"
-                      controller_names="/joint_trajectory_controller /robotiq_gripper_controller"
+                      controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
                     />
                     <Action
                       ID="PublishEmpty"
@@ -76,6 +76,7 @@
                       ID="Move to Pose"
                       _collapsed="false"
                       target_pose="{target_pose}"
+                      controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
                     />
                     <Action
                       ID="PublishEmpty"

--- a/src/lab_sim/objectives/request_teleoperation.xml
+++ b/src/lab_sim/objectives/request_teleoperation.xml
@@ -41,7 +41,7 @@
                       ID="Interpolate to Joint State"
                       _collapsed="false"
                       target_joint_state="{target_joint_state}"
-                      controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+                      controller_names="/joint_trajectory_controller"
                     />
                     <Action
                       ID="PublishEmpty"
@@ -76,7 +76,7 @@
                       ID="Move to Pose"
                       _collapsed="false"
                       target_pose="{target_pose}"
-                      controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+                      controller_names="/joint_trajectory_controller"
                     />
                     <Action
                       ID="PublishEmpty"


### PR DESCRIPTION
example_ws part of https://github.com/PickNikRobotics/moveit_pro/issues/12126.

Also requires https://github.com/PickNikRobotics/moveit_pro/pull/12127
 
Also fixed grinding_sim move_to_poses to be non-runnable.