### PR TITLE
Remove TransformPoseFromYaml

### DIFF
--- a/src/lab_sim/objectives/grasp_pose_tuning_with_april_tag.xml
+++ b/src/lab_sim/objectives/grasp_pose_tuning_with_april_tag.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Grasp Pose Tuning With April Tag">
   <!--//////////-->
   <BehaviorTree
@@ -94,10 +94,9 @@
         source_to_destination_pose="{relative_pose}"
       />
       <Action
-        ID="SavePoseToYaml"
+        ID="SavePoseStampedToYaml"
         message="{relative_pose}"
         yaml_filename="relative_grasp_pose"
-        namespace="RelativePose"
       />
       <!--Now that it is saved to yaml, it can be loaded as a grasp offset. Test with the "Grasp Pose Using Yaml" objective.-->
     </Control>

--- a/src/lab_sim/objectives/grasp_pose_using_yaml.xml
+++ b/src/lab_sim/objectives/grasp_pose_using_yaml.xml
@@ -67,16 +67,15 @@
       />
       <!--Load the gripper offset from yaml and combine with detected pose.-->
       <Action
-        ID="LoadObjectiveParameters"
-        parameters="{relative_pose_parameters}"
-        config_file_name="relative_grasp_pose.yaml"
+        ID="LoadPoseStampedFromYaml"
+        output="{relative_pose}"
+        file_path="relative_grasp_pose.yaml"
       />
       <Action
-        ID="TransformPoseFromYaml"
-        input_pose="{detection_pose}"
+        ID="TransformPoseWithPose"
+        input_pose="{relative_pose}"
         output_pose="{offset_pose}"
-        pose_parameters="{relative_pose_parameters}"
-        parameter_namespace="RelativePose"
+        transform_pose="{detection_pose}"
       />
       <Action
         ID="VisualizePose"

--- a/src/lab_sim/objectives/relative_grasp_pose.yaml
+++ b/src/lab_sim/objectives/relative_grasp_pose.yaml
@@ -1,4 +1,6 @@
-RelativePose:
+header:
+  frame_id: world
+pose:
   position:
     x: -0.0025512052998043211
     y: -0.0094682145455754485

--- a/src/lab_sim/objectives/take_picture_with_wrist_camera.xml
+++ b/src/lab_sim/objectives/take_picture_with_wrist_camera.xml
@@ -7,11 +7,6 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
-        ID="LoadObjectiveParameters"
-        config_file_name="apriltag_detection_config.yaml"
-        parameters="{wrist_camera_parameters}"
-      />
-      <Action
         ID="GetCameraInfo"
         topic_name="/wrist_camera/camera_info"
         message_out="{wrist_camera_info}"

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/pick_apriltag_labeled_object.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/pick_apriltag_labeled_object.xml
@@ -26,9 +26,9 @@
         avg_pose="{tag_pose}"
       />
       <Action
-        ID="LoadObjectiveParameters"
-        config_file_name="apriltag1_grasp_offset.yaml"
-        parameters="{pose_parameters}"
+        ID="LoadPoseStampedFromYaml"
+        output="{relative_pose}"
+        file_path="apriltag1_grasp_offset.yaml"
       />
       <Control ID="Sequence" name="GraspObject">
         <Action
@@ -38,11 +38,10 @@
           output_pose="{tag_pose_world}"
         />
         <Action
-          ID="TransformPoseFromYaml"
-          input_pose="{tag_pose_world}"
-          pose_parameters="{pose_parameters}"
-          parameter_namespace="GraspOffset"
+          ID="TransformPoseWithPose"
+          input_pose="{relative_pose}"
           output_pose="{grasp_pose}"
+          transform_pose="{tag_pose_world}"
         />
         <SubTree ID="Pick Object" grasp_pose="{grasp_pose}" />
       </Control>

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/teach_apriltag_grasp_offset.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/teach_apriltag_grasp_offset.xml
@@ -60,9 +60,8 @@
             source_to_destination_pose="{tag_to_user_grasp_pose}"
           />
           <Action
-            ID="SavePoseToYaml"
+            ID="SavePoseStampedToYaml"
             yaml_filename="apriltag1_grasp_offset"
-            namespace="GraspOffset"
             message="{tag_to_user_grasp_pose}"
           />
         </Control>

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_teach_reference.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_teach_reference.xml
@@ -42,9 +42,8 @@
         source_to_destination_pose="{tag_to_user_grasp_pose}"
       />
       <Action
-        ID="SavePoseToYaml"
+        ID="SavePoseStampedToYaml"
         yaml_filename="visual_servo_reference"
-        namespace="ServoReference"
         message="{tag_to_user_grasp_pose}"
       />
     </Control>

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_to_reference.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_to_reference.xml
@@ -9,9 +9,9 @@
   >
     <Control ID="Sequence">
       <Action
-        ID="LoadObjectiveParameters"
-        config_file_name="visual_servo_reference.yaml"
-        parameters="{servo_reference_parameters}"
+        ID="LoadPoseStampedFromYaml"
+        output="{relative_pose}"
+        file_path="visual_servo_reference.yaml"
       />
       <Action ID="ActivateControllers" controller_names="servo_controller" />
       <Control ID="Sequence">
@@ -32,11 +32,10 @@
           output_pose="{tag_pose_base}"
         />
         <Action
-          ID="TransformPoseFromYaml"
-          input_pose="{tag_pose_base}"
-          parameter_namespace="ServoReference"
-          pose_parameters="{servo_reference_parameters}"
+          ID="TransformPoseWithPose"
+          input_pose="{relative_pose}"
           output_pose="{reference_pose}"
+          transform_pose="{tag_pose_base}"
         />
       </Control>
       <Control ID="Parallel" success_count="1" failure_count="1">
@@ -72,11 +71,10 @@
         <Decorator ID="KeepRunningUntilFailure">
           <Control ID="Sequence">
             <Action
-              ID="TransformPoseFromYaml"
-              input_pose="{tag_pose_avg}"
-              parameter_namespace="ServoReference"
-              pose_parameters="{servo_reference_parameters}"
+              ID="TransformPoseWithPose"
+              input_pose="{relative_pose}"
               output_pose="{reference_pose}"
+              transform_pose="{tag_pose_avg}"
             />
           </Control>
         </Decorator>


### PR DESCRIPTION
Replaces `LoadObjectiveParameters` + `TransformPoseFromYaml` by  `LoadPoseStampedFromYaml` and `TransformPoseWithPose` in all the example configs

Requires https://github.com/PickNikRobotics/moveit_pro/pull/12185

Closes https://github.com/PickNikRobotics/moveit_pro/issues/12160