### PR TITLE
Set `runnable=false` in lab_sim subtrees where it was missing

### DIFF
--- a/src/lab_sim/objectives/load_mesh_as_green_poincloud.xml
+++ b/src/lab_sim/objectives/load_mesh_as_green_poincloud.xml
@@ -32,6 +32,7 @@
       <input_port name="initial_pose" default="{stamped_pose}" />
       <MetadataFields>
         <Metadata subcategory="Perception - 3D Point Cloud" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/load_mesh_as_red_pointcloud.xml
+++ b/src/lab_sim/objectives/load_mesh_as_red_pointcloud.xml
@@ -32,6 +32,7 @@
       <input_port name="initial_pose" default="{stamped_pose}" />
       <MetadataFields>
         <Metadata subcategory="Perception - 3D Point Cloud" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/plan_move_to_pose.xml
+++ b/src/lab_sim/objectives/plan_move_to_pose.xml
@@ -36,6 +36,7 @@
       />
       <MetadataFields>
         <Metadata subcategory="Motion - Planning" />
+        <Metadata runnable="false" />
       </MetadataFields>
     </SubTree>
   </TreeNodesModel>


### PR DESCRIPTION
A couple of subtrees were missing `runnable=false`