### PR TITLE
Don't activate the JTC at startup in hangar_sim

### DIFF
--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -96,11 +96,11 @@ ros2_control:
   controllers_active_at_startup:
     - "force_torque_sensor_broadcaster"
     - "joint_state_broadcaster"
-    - "joint_trajectory_controller"
     - "platform_velocity_controller"
     - "vacuum_gripper"
   # Load but do not start these controllers so they can be activated later if needed.
   controllers_inactive_at_startup:
+    - "joint_trajectory_controller"
     - "servo_controller"
     - "platform_velocity_controller_nav2"
     - "velocity_force_controller"


### PR DESCRIPTION
There is a race condition between the JTC and the
platform_velocity_controller during startup since the JTC attempts to claim some joints exported by the platform_velocity_controller. Activating them both at statup causes the JTC to fail to activate sometimes.