### PR TITLE
Update Pick from Pose subtree and usages

### DIFF
--- a/src/lab_sim/objectives/apriltag_pick_object.xml
+++ b/src/lab_sim/objectives/apriltag_pick_object.xml
@@ -69,16 +69,10 @@
         quaternion_xyzw="1;0;0;0"
         translation_xyz="0;0;0.01"
       />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{offset_pose}"
-        vector="{grasp_poses}"
-      />
       <SubTree
         ID="Pick from Pose"
         _collapsed="true"
-        grasp_pose="{object_pose}"
-        grasp_poses="{grasp_poses}"
+        grasp_pose="{offset_pose}"
         approach_distance="0.1"
         retract_xyz="0;0;-0.1"
       />

--- a/src/lab_sim/objectives/grasp_pose_using_yaml.xml
+++ b/src/lab_sim/objectives/grasp_pose_using_yaml.xml
@@ -84,16 +84,10 @@
         marker_size="0.100000"
         pose="{offset_pose}"
       />
-      <!--Now pick the cube using the offset_pose.-->
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{offset_pose}"
-        vector="{grasp_poses}"
-      />
       <SubTree
         ID="Pick from Pose"
         _collapsed="true"
-        grasp_poses="{grasp_poses}"
+        grasp_pose="{offset_pose}"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/pick_and_place_example.xml
+++ b/src/lab_sim/objectives/pick_and_place_example.xml
@@ -17,20 +17,15 @@
           orientation_xyzw="0;1;0;0"
           stamped_pose="{pick_place_pose}"
         />
-        <Action
-          ID="AddPoseStampedToVector"
-          input="{pick_place_pose}"
-          vector="{pick_place_poses}"
-        />
         <SubTree
           ID="Pick from Pose"
           _collapsed="true"
-          grasp_poses="{pick_place_poses}"
+          grasp_pose="{pick_place_pose}"
         />
         <SubTree
           ID="Place at Pose"
           _collapsed="true"
-          place_poses="{pick_place_poses}"
+          place_pose="{pick_place_pose}"
         />
       </Control>
     </Control>

--- a/src/lab_sim/objectives/pick_april_tag_object_with_approval.xml
+++ b/src/lab_sim/objectives/pick_april_tag_object_with_approval.xml
@@ -74,15 +74,10 @@
         quaternion_xyzw="1;0;0;0"
         translation_xyz="0;0;0.01"
       />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{grasp_pose}"
-        vector="{grasp_poses}"
-      />
       <SubTree
         ID="Pick from Pose With Approval"
         _collapsed="false"
-        grasp_poses="{grasp_poses}"
+        grasp_pose="{grasp_pose}"
         approach_distance="0.1"
         retract_xyz="0;0;-0.1"
       />

--- a/src/lab_sim/objectives/pick_from_pose.xml
+++ b/src/lab_sim/objectives/pick_from_pose.xml
@@ -38,6 +38,11 @@
         ignore_environment_collisions="false"
       />
       <Action
+        ID="AddPoseStampedToVector"
+        input="{grasp_pose}"
+        vector="{grasp_pose_vector}"
+      />
+      <Action
         ID="SetupMTCBatchPoseIK"
         end_effector_group="moveit_ee"
         end_effector_link="grasp_link"
@@ -45,7 +50,7 @@
         ik_timeout_s="0.01"
         max_ik_solutions="4"
         monitored_stage="current state"
-        target_poses="{grasp_poses}"
+        target_poses="{grasp_pose_vector}"
         task="{mtc_task}"
       />
       <Action ID="PlanMTCTask" solution="{mtc_solution}" task="{mtc_task}" />
@@ -97,9 +102,8 @@
         <Metadata subcategory="Application - Basic Examples" />
         <Metadata runnable="false" />
       </MetadataFields>
-
       <inout_port name="approach_distance" default="0.1" />
-      <inout_port name="grasp_poses" default="{grasp_poses}" />
+      <inout_port name="grasp_pose" default="{grasp_pose}" />
       <inout_port name="retract_xyz" default="0;0;-0.1" />
     </SubTree>
   </TreeNodesModel>

--- a/src/lab_sim/objectives/pick_from_pose_with_approval.xml
+++ b/src/lab_sim/objectives/pick_from_pose_with_approval.xml
@@ -38,6 +38,11 @@
         axis_frame="grasp_link"
       />
       <Action
+        ID="AddPoseStampedToVector"
+        input="{grasp_pose}"
+        vector="{grasp_pose_vector}"
+      />
+      <Action
         ID="SetupMTCBatchPoseIK"
         end_effector_group="moveit_ee"
         end_effector_link="grasp_link"
@@ -45,7 +50,7 @@
         ik_timeout_s="0.01"
         max_ik_solutions="4"
         monitored_stage="current state"
-        target_poses="{grasp_poses}"
+        target_poses="{grasp_pose_vector}"
         task="{mtc_task}"
       />
       <Action ID="PlanMTCTask" solution="{mtc_solution}" task="{mtc_task}" />
@@ -102,10 +107,9 @@
         <Metadata subcategory="Application - Basic Examples" />
         <Metadata runnable="false" />
       </MetadataFields>
-
-      <inout_port name="retract_xyz" default="0;0;-0.1" />
       <inout_port name="approach_distance" default="0.1" />
-      <inout_port name="grasp_poses" default="{grasp_poses}" />
+      <inout_port name="grasp_pose" default="{grasp_pose}" />
+      <inout_port name="retract_xyz" default="0;0;-0.1" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/pick_object.xml
+++ b/src/lab_sim/objectives/pick_object.xml
@@ -23,15 +23,10 @@
         marker_size="0.100000"
         pose="{stamped_pose}"
       />
-      <Action
-        ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
-        vector="{grasp_poses}"
-      />
       <SubTree
         ID="Pick from Pose"
         _collapsed="true"
-        grasp_poses="{grasp_poses}"
+        grasp_pose="{stamped_pose}"
         approach_distance="0.1"
         retract_xyz="0;0;-0.1"
       />

--- a/src/lab_sim/objectives/place_at_pose.xml
+++ b/src/lab_sim/objectives/place_at_pose.xml
@@ -12,6 +12,7 @@
         controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
+        trajectory_monitoring="false"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
@@ -37,6 +38,11 @@
         ignore_environment_collisions="false"
       />
       <Action
+        ID="AddPoseStampedToVector"
+        input="{place_pose}"
+        vector="{place_pose_vector}"
+      />
+      <Action
         ID="SetupMTCBatchPoseIK"
         end_effector_group="moveit_ee"
         end_effector_link="grasp_link"
@@ -44,7 +50,7 @@
         ik_timeout_s="0.01"
         max_ik_solutions="4"
         monitored_stage="current state"
-        target_poses="{place_poses}"
+        target_poses="{place_pose_vector}"
         task="{mtc_task}"
       />
       <Action ID="PlanMTCTask" solution="{mtc_solution}" task="{mtc_task}" />
@@ -96,10 +102,9 @@
         <Metadata subcategory="Application - Basic Examples" />
         <Metadata runnable="false" />
       </MetadataFields>
-
-      <inout_port name="retract_xyz" default="0;0;-0.1" />
       <inout_port name="approach_distance" default="0.1" />
-      <inout_port name="place_poses" default="{place_poses}" />
+      <inout_port name="place_pose" default="{place_pose}" />
+      <inout_port name="retract_xyz" default="0;0;-0.1" />
     </SubTree>
   </TreeNodesModel>
 </root>


### PR DESCRIPTION
* Simplify by adding the input pose to a vector in the subtree instead of requiring users to input a vector with a single pose.