### PR TITLE
Make all docker-compose services mappings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,16 +7,16 @@
 services:
 
   # The base image that all MoveIt Pro services extend off of. Builds the user workspace.
-  base:
+  base: {}
 
   # Starts the MoveIt Pro Agent and the Bridge between the Agent and the Web UI.
-  agent_bridge:
+  agent_bridge: {}
 
   # Starts the robot drivers.
-  drivers:
+  drivers: {}
 
   # Starts the web UI frontend.
-  web_ui:
+  web_ui: {}
 
   # Developer specific configuration when running `moveit_pro dev`.
-  dev:
+  dev: {}


### PR DESCRIPTION
It seems like in some version of docker-compose, the services must be followed by an empty curly bracket `{}` to be valid syntax or docker-compose will fail with an error message like `services must be a mapping`.