### PR TITLE
remove a couple of stray servo_kinematics config

### DIFF
--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -41,9 +41,6 @@ moveit_params:
   kinematics:
     package: "hangar_sim"
     path: "config/moveit/pose_ik_distance.yaml"
-  servo_kinematics:
-    package: "hangar_sim"
-    path: "config/moveit/pose_ik_speed.yaml"
   sensors_3d:
     package: "hangar_sim"
     path: "config/moveit/sensors_3d.yaml"

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
@@ -37,9 +37,6 @@ moveit_params:
   kinematics:
     package: "kinova_gen3_base_config"
     path: "config/moveit/pose_ik_distance.yaml"
-  servo_kinematics:
-    package: "kinova_gen3_base_config"
-    path: "config/moveit/pose_ik_speed.yaml"
   servo:
     package: "kinova_gen3_site_config"
     path: "config/moveit/kinova_gen3_servo.yaml"


### PR DESCRIPTION
The `servo_kinematics` config is no longer needed, since we use Pose Jog now.
There's a couple of configs that still declare it. This PR updates those configs
