### PR TITLE
12505 Remove link padding parameter from SetupMTCConnectWithTrajectory from hangar_sim

### DIFF
--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -227,7 +227,6 @@
                       planner_interface="pro_rrt"
                       planning_group_name="manipulator"
                       task="{task}"
-                      link_padding="0.0"
                     />
                     <Action
                       ID="SetupMTCMoveAlongFrameAxis"


### PR DESCRIPTION
Removes the `link_padding` parameter from the `SetupMTCConnectWithTrajectory` action in the `move_boxes_to_loading_zone_from_waypoint.xml` file.