### PR TITLE
Update VFC configs and migrate `ActivateControllers` -> `SwitchController`

### DIFF
--- a/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
+++ b/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
@@ -105,16 +105,8 @@ servo_controller:
 
 velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: base_link
+    # Joint group to control.
+    planning_group_name: manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: tool0
     # The frame where the force / torque sensor reading is given.

--- a/src/factory_sim/objectives/move_to_joint_state.xml
+++ b/src/factory_sim/objectives/move_to_joint_state.xml
@@ -5,7 +5,7 @@
     _description="Move to a specified joint state"
   >
     <Control ID="Sequence">
-      <Action ID="ActivateControllers" controller_names="{controller_names}" />
+      <Action ID="SwitchController" activate_controllers="{controller_names}" />
       <Action
         ID="PlanToJointGoal"
         joint_goal="{target_joint_state}"

--- a/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
@@ -5,7 +5,7 @@
     _description="Free space plan to an approach pose then free space plan to a target pose with optional orientation constraints. With orientation constraints the gripper will maintain its orientation relative to the world vertical axis when moving from the approach to target pose."
   >
     <Control ID="Sequence" name="Plan to approach then target">
-      <Action ID="ActivateControllers" controller_names="{controller_names}" />
+      <Action ID="SwitchController" activate_controllers="{controller_names}" />
       <Action
         ID="InitializeMTCTask"
         controller_names="{controller_names}"

--- a/src/factory_sim/objectives/request_teleoperation.xml
+++ b/src/factory_sim/objectives/request_teleoperation.xml
@@ -145,8 +145,8 @@
               <Decorator ID="Repeat" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
-                    ID="ActivateControllers"
-                    controller_names="{controllers}"
+                    ID="SwitchController"
+                    activate_controllers="{controllers}"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action

--- a/src/grinding_sim/config/control/ur20.ros2_control.yaml
+++ b/src/grinding_sim/config/control/ur20.ros2_control.yaml
@@ -123,16 +123,8 @@ servo_controller:
 
 velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - shoulder_pan_joint
-      - shoulder_lift_joint
-      - elbow_joint
-      - wrist_1_joint
-      - wrist_2_joint
-      - wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: base_link
+    # Joint group to control.
+    planning_group_name: manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: tool_tip
     sensor_frame: tool_tip

--- a/src/grinding_sim/objectives/request_teleoperation.xml
+++ b/src/grinding_sim/objectives/request_teleoperation.xml
@@ -136,8 +136,8 @@
               <Decorator ID="Repeat" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
-                    ID="ActivateControllers"
-                    controller_names="{controllers}"
+                    ID="SwitchController"
+                    activate_controllers="{controllers}"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action

--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -102,3 +102,4 @@ ros2_control:
     - "servo_controller"
     - "platform_velocity_controller_nav2"
     - "velocity_force_controller"
+    - "arm_only_velocity_force_controller"

--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -17,6 +17,8 @@ controller_manager:
       type: position_controllers/GripperActionController
     velocity_force_controller:
       type: velocity_force_controller/VelocityForceController
+    arm_only_velocity_force_controller:
+      type: velocity_force_controller/VelocityForceController
 
 vacuum_gripper:
   ros__parameters:
@@ -365,18 +367,8 @@ force_torque_sensor_broadcaster:
 
 velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will use.
-    # The joints must be in the same order as they appear in the kinematic chain.
-    joints:
-      - linear_x_joint
-      - linear_y_joint
-      - rotational_yaw_joint
-      - shoulder_pan_joint
-      - shoulder_lift_joint
-      - elbow_joint
-      - wrist_1_joint
-      - wrist_2_joint
-      - wrist_3_joint
+    # The joint group to control.
+    planning_group_name: manipulator
     # The joints that the controller will command.
     # The 'platform' joints are renamed to match the joint names exposed by the 'platform_velocity_controller', which
     # enables layered control of those joints.
@@ -392,8 +384,6 @@ velocity_force_controller:
       - wrist_3_joint
     # Command just velocity to support layering with the mobile base controller.
     command_interfaces: ["velocity"]
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: world
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: grasp_link
     # The frame where the force / torque sensor reading is given.
@@ -415,6 +405,58 @@ velocity_force_controller:
       - 2.0
       - 2.0
       - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+    # Maximum Cartesian-space velocities.
+    max_cartesian_velocity:
+      - 0.25
+      - 0.25
+      - 0.25
+      - 1.0
+      - 1.0
+      - 1.0
+    # Maximum Cartesian-space accelerations.
+    max_cartesian_acceleration:
+      - 2.0
+      - 2.0
+      - 2.0
+      - 4.0
+      - 4.0
+      - 4.0
+    # Rate in Hz at which the controller will publish the state.
+    state_publish_rate: 10
+    # Damping coefficient for the Jacobian damped least-squares inverse.
+    jacobian_damping: 0.002
+    # Timeout in seconds after which the controller will stop motion if no new commands are received.
+    command_timeout: 0.2
+    # Padding (in radians) to add to joint position limits as a safety margin.
+    joint_limit_position_tolerance: 0.02
+
+arm_only_velocity_force_controller:
+  ros__parameters:
+    # The joint group to control.
+    planning_group_name: arm_only
+    # Command just velocity to support layering with the mobile base controller.
+    command_interfaces: ["velocity"]
+    # The tip link of the kinematic chain, i.e. the frame that will be controlled.
+    ee_frame: grasp_link
+    # The frame where the force / torque sensor reading is given.
+    # (Needs to exist in the kinematic chain).
+    sensor_frame: tool0
+    # Maximum joint-space velocities.
+    max_joint_velocity:
+      - 1.0
+      - 1.0
+      - 1.0
+      - 1.0
+      - 1.0
+      - 1.0
+    # Maximum joint-space accelerations.
+    max_joint_acceleration:
       - 2.0
       - 2.0
       - 2.0

--- a/src/hangar_sim/config/moveit/pose_jog.yaml
+++ b/src/hangar_sim/config/moveit/pose_jog.yaml
@@ -1,4 +1,4 @@
 # Planning groups to use in PoseJog, and their corresponding VFC controllers.
 # The number of elements in `planning_groups` and `controllers` must match.
-planning_groups: ['manipulator']
-controllers: ['velocity_force_controller']
+planning_groups: ['manipulator', 'arm_only']
+controllers: ['velocity_force_controller', 'arm_only_velocity_force_controller']

--- a/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
+++ b/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
@@ -8,8 +8,8 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
-        ID="ActivateControllers"
-        controller_names="joint_trajectory_controller"
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
       />
       <Action
         ID="LoadPoseStampedVectorFromYaml"

--- a/src/hangar_sim/objectives/navigate_to_clicked_point.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point.xml
@@ -12,8 +12,8 @@
         stamped_pose="{start}"
       />
       <Action
-        ID="ActivateControllers"
-        controller_names="platform_velocity_controller_nav2"
+        ID="SwitchController"
+        activate_controllers="platform_velocity_controller_nav2"
       />
       <Action
         ID="GetPoseFromUser"

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -148,8 +148,13 @@
               <Decorator ID="Repeat" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
-                    ID="ActivateControllers"
-                    controller_names="{controllers}"
+                    ID="SwitchController"
+                    activate_asap="true"
+                    controller_list_action_name="/controller_manager/list_controllers"
+                    controller_switch_action_name="/controller_manager/switch_controller"
+                    strictness="2"
+                    timeout="0.000000"
+                    activate_controllers="{controllers}"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action
@@ -158,6 +163,7 @@
                       link_padding="0.0"
                       planning_group_names="{planning_groups}"
                       stop_safety_factor="1.500000"
+                      include_octomap="false"
                     />
                   </Decorator>
                 </Control>

--- a/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
@@ -215,17 +215,8 @@ joint_trajectory_admittance_controller:
 
 velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will claim.
-    joints:
-      - linear_rail_joint
-      - shoulder_pan_joint
-      - shoulder_lift_joint
-      - elbow_joint
-      - wrist_1_joint
-      - wrist_2_joint
-      - wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: base_link
+    # Joint group to control.
+    planning_group_name: manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: grasp_link
     # The frame where the force / torque sensor reading is given.

--- a/src/lab_sim/objectives/move_with_velocity_and_force.xml
+++ b/src/lab_sim/objectives/move_with_velocity_and_force.xml
@@ -16,8 +16,8 @@
         controller_names="/joint_trajectory_controller"
       />
       <Action
-        ID="ActivateControllers"
-        controller_names="/velocity_force_controller"
+        ID="SwitchController"
+        activate_controllers="velocity_force_controller"
       />
       <Action
         ID="CallTriggerService"

--- a/src/lab_sim/objectives/push_button_with_a_trajectory.xml
+++ b/src/lab_sim/objectives/push_button_with_a_trajectory.xml
@@ -59,8 +59,8 @@
       />
       <!--Activate the JTAC, tare the sensor and execute the trajectory with compliance-->
       <Action
-        ID="ActivateControllers"
-        controller_names="joint_trajectory_admittance_controller"
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_admittance_controller"
       />
       <Action
         ID="CallTriggerService"

--- a/src/lab_sim/objectives/request_teleoperation.xml
+++ b/src/lab_sim/objectives/request_teleoperation.xml
@@ -145,8 +145,8 @@
               <Decorator ID="Repeat" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
-                    ID="ActivateControllers"
-                    controller_names="{controllers}"
+                    ID="SwitchController"
+                    activate_controllers="{controllers}"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
@@ -10,8 +10,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Control ID="Sequence">
         <Action
-          ID="ActivateControllers"
-          controller_names="/joint_trajectory_controller"
+          ID="SwitchController"
+          activate_controllers="joint_trajectory_controller"
         />
         <Action
           ID="CreateStampedPose"

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_to_joint_state.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_to_joint_state.xml
@@ -5,7 +5,7 @@
     _description="Move to a specified joint state"
   >
     <Control ID="Sequence">
-      <Action ID="ActivateControllers" controller_names="{controller_names}" />
+      <Action ID="SwitchController" activate_controllers="{controller_names}" />
       <Action
         ID="PlanToJointGoal"
         joint_goal="{target_joint_state}"

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/control/picknik_kinova_gen3.ros2_control.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/control/picknik_kinova_gen3.ros2_control.yaml
@@ -120,15 +120,7 @@ servo_controller:
 
 velocity_force_controller:
   ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-      - joint_7
-    base_frame: base_link
+    planning_group_name: manipulator
     sensor_frame: grasp_link
     ee_frame: grasp_link
     jacobian_damping: 0.005

--- a/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
@@ -152,15 +152,7 @@ joint_trajectory_admittance_controller:
 
 velocity_force_controller:
   ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-      - joint_7
-    base_frame: base_link
+    planning_group_name: manipulator
     sensor_frame: fts_link
     ee_frame: grasp_link
     ft_sensor_name: fts

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
@@ -263,8 +263,8 @@
         goal_duration_tolerance="-1.000000"
       />
       <Action
-        ID="ActivateControllers"
-        controller_names="velocity_force_controller"
+        ID="SwitchController"
+        activate_controllers="velocity_force_controller"
       />
       <Action
         ID="CreateStampedTwist"
@@ -295,8 +295,8 @@
       </Control>
       <Decorator ID="Delay" delay_msec="1000">
         <Action
-          ID="ActivateControllers"
-          controller_names="joint_trajectory_controller"
+          ID="SwitchController"
+          activate_controllers="joint_trajectory_controller"
         />
       </Decorator>
     </Control>

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/demo_trajectory_stitching.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/demo_trajectory_stitching.xml
@@ -103,8 +103,8 @@
         admittance_parameters_msg="{admittance_parameters_msg}"
       />
       <Action
-        ID="ActivateControllers"
-        controller_names="/joint_trajectory_admittance_controller"
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_admittance_controller"
       />
       <Control ID="Parallel" failure_count="2" success_count="1">
         <Action

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
@@ -23,8 +23,8 @@
       />
       <Control ID="Sequence">
         <Action
-          ID="ActivateControllers"
-          controller_names="/joint_trajectory_controller"
+          ID="SwitchController"
+          activate_controllers="joint_trajectory_controller"
         />
         <Action
           ID="CreateStampedPose"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
@@ -10,8 +10,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Control ID="Sequence">
         <Action
-          ID="ActivateControllers"
-          controller_names="/joint_trajectory_admittance_controller"
+          ID="SwitchController"
+          activate_controllers="joint_trajectory_admittance_controller"
         />
         <Action
           ID="CreateStampedPose"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/velocity_force_controller_zero.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/velocity_force_controller_zero.xml
@@ -14,8 +14,8 @@
         linear_velocity_xyz="0.0;0.0;0.0"
       />
       <Action
-        ID="ActivateControllers"
-        controller_names="/velocity_force_controller"
+        ID="SwitchController"
+        activate_controllers="velocity_force_controller"
       />
       <Action
         ID="CreateStampedWrench"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/write_picknik.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/write_picknik.xml
@@ -24,8 +24,8 @@
         />
         <Control ID="Sequence" name="TopLevelSequence">
           <Action
-            ID="ActivateControllers"
-            controller_names="joint_trajectory_controller"
+            ID="SwitchController"
+            activate_controllers="joint_trajectory_controller"
           />
           <Action
             ID="LoadPoseStampedVectorFromYaml"

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_with_fuse.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_with_fuse.xml
@@ -12,8 +12,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <SubTree ID="Open Gripper" _collapsed="true" />
       <Action
-        ID="ActivateControllers"
-        controller_names="/velocity_force_controller"
+        ID="SwitchController"
+        activate_controllers="velocity_force_controller"
       />
       <Action
         ID="CreateStampedPose"

--- a/src/moveit_pro_ur_configs/mock_sim/objectives/rrt_connect_test.xml
+++ b/src/moveit_pro_ur_configs/mock_sim/objectives/rrt_connect_test.xml
@@ -9,8 +9,8 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
-        ID="ActivateControllers"
-        controller_names="joint_trajectory_controller"
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
       />
       <Decorator ID="Repeat" num_cycles="10">
         <Control ID="Sequence">

--- a/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
@@ -331,16 +331,8 @@ fourth_robotiq_gripper_controller:
 
 first_velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - first_shoulder_pan_joint
-      - first_shoulder_lift_joint
-      - first_elbow_joint
-      - first_wrist_1_joint
-      - first_wrist_2_joint
-      - first_wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: first_base_link
+    # Joint group to control.
+    planning_group_name: first_manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: first_grasp_link
     # The frame where the force / torque sensor reading is given.
@@ -397,16 +389,8 @@ first_velocity_force_controller:
 
 second_velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - second_shoulder_pan_joint
-      - second_shoulder_lift_joint
-      - second_elbow_joint
-      - second_wrist_1_joint
-      - second_wrist_2_joint
-      - second_wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: second_base_link
+    # Joint group to control.
+    planning_group_name: second_manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: second_grasp_link
     # The frame where the force / torque sensor reading is given.
@@ -463,16 +447,8 @@ second_velocity_force_controller:
 
 third_velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - third_shoulder_pan_joint
-      - third_shoulder_lift_joint
-      - third_elbow_joint
-      - third_wrist_1_joint
-      - third_wrist_2_joint
-      - third_wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: third_base_link
+    # Joint group to control.
+    planning_group_name: third_manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: third_grasp_link
     # The frame where the force / torque sensor reading is given.
@@ -528,16 +504,8 @@ third_velocity_force_controller:
 
 fourth_velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - fourth_shoulder_pan_joint
-      - fourth_shoulder_lift_joint
-      - fourth_elbow_joint
-      - fourth_wrist_1_joint
-      - fourth_wrist_2_joint
-      - fourth_wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: fourth_base_link
+    # Joint group to control.
+    planning_group_name: fourth_manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: fourth_grasp_link
     # The frame where the force / torque sensor reading is given.

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/request_teleoperation.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/request_teleoperation.xml
@@ -144,8 +144,8 @@
               <Decorator ID="Repeat" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
-                    ID="ActivateControllers"
-                    controller_names="{controllers}"
+                    ID="SwitchController"
+                    activate_controllers="{controllers}"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/config/control/picknik_ur.ros2_control.yaml
@@ -152,14 +152,7 @@ joint_trajectory_admittance_controller:
 
 velocity_force_controller:
   ros__parameters:
-    joints:
-      - shoulder_pan_joint
-      - shoulder_lift_joint
-      - elbow_joint
-      - wrist_1_joint
-      - wrist_2_joint
-      - wrist_3_joint
-    base_frame: base_link
+    planning_group_name: manipulator
     sensor_frame: tool0
     ee_frame: grasp_link
     ft_sensor_name: tcp_fts_sensor

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/config/control/picknik_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/config/control/picknik_ur.ros2_control.yaml
@@ -153,14 +153,7 @@ joint_trajectory_admittance_controller:
 
 velocity_force_controller:
   ros__parameters:
-    joints:
-      - shoulder_pan_joint
-      - shoulder_lift_joint
-      - elbow_joint
-      - wrist_1_joint
-      - wrist_2_joint
-      - wrist_3_joint
-    base_frame: base_link
+    planning_group_name: manipulator
     sensor_frame: tool0
     ee_frame: grasp_link
     ft_sensor_name: tcp_fts_sensor

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_to_reference.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/visual_servo_to_reference.xml
@@ -13,7 +13,7 @@
         output="{relative_pose}"
         file_path="visual_servo_reference.yaml"
       />
-      <Action ID="ActivateControllers" controller_names="servo_controller" />
+      <Action ID="SwitchController" activate_controllers="servo_controller" />
       <Control ID="Sequence">
         <SubTree
           ID="Sample April Tag"


### PR DESCRIPTION
Depends on https://github.com/PickNikRobotics/moveit_pro/pull/12589 and https://github.com/PickNikRobotics/moveit_pro/pull/12588

This PR does two things:
* Updates the VFC configs after https://github.com/PickNikRobotics/moveit_pro/pull/12589, which enables using the VFC on groups that don't start at the root. Added an example in `hangar_sim` for using Pose Jog with just the arm.
* Replaces all `ActivateControllers` with `SwitchController`, which has our own switch logic. This will allow deprecating `ActivateControllers` and the MoveIt pipeline behind it. In addition it handles a case that the MoveIt pipeline wasn't handling properly (closes https://github.com/PickNikRobotics/moveit_pro/issues/12456).