### PR TITLE
override link_padding to 0.0 in hangar sim teleop

### DIFF
--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -77,6 +77,7 @@
                       ID="Move to Pose"
                       _collapsed="false"
                       target_pose="{target_pose}"
+                      link_padding="0.0"
                       controller_names="/joint_trajectory_controller"
                     />
                     <Action


### PR DESCRIPTION
`hangar_sim` needs link padding set to zero because the arm base link is very close to the base top plate, so adding padding makes those two links collide.

Depends on https://github.com/PickNikRobotics/moveit_pro/pull/12864