### PR TITLE
Fix port value for mpc objective

### DIFF
--- a/src/lab_sim/objectives/mpc_pose_tracking.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking.xml
@@ -9,7 +9,7 @@
           _collapsed="true"
           acceleration_scale_factor="1.0"
           controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
           joint_group_name="manipulator"
           keep_orientation="false"
           keep_orientation_tolerance="0.05"


### PR DESCRIPTION
The port value had the `/` character in front of `joint_trajectory_controller` and was failing. 

## To test
1. Run the Objective and make sure it works.
2. As a sanity check, add back the slash and make sure it fails.