### PR TITLE
remove slashes from controller names

### DIFF
--- a/src/factory_sim/objectives/inspect_convex_bowl.xml
+++ b/src/factory_sim/objectives/inspect_convex_bowl.xml
@@ -59,7 +59,7 @@
           ID="InitializeMTCTask"
           task="{mtc_task}"
           trajectory_monitoring="false"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
         <Action

--- a/src/factory_sim/objectives/pick_up_tool_from_holder.xml
+++ b/src/factory_sim/objectives/pick_up_tool_from_holder.xml
@@ -15,7 +15,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="pick_up_tool"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{mtc_task}"
         trajectory_monitoring="false"
       />

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -15,7 +15,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="pick_up_tool"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{mtc_task}"
         trajectory_monitoring="false"
       />

--- a/src/factory_sim/objectives/retract.xml
+++ b/src/factory_sim/objectives/retract.xml
@@ -8,7 +8,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task_id="retract"
         task="{mtc_task}"
         trajectory_monitoring="false"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -208,7 +208,7 @@
                     />
                     <Action
                       ID="InitializeMTCTask"
-                      controller_names="/joint_trajectory_controller"
+                      controller_names="joint_trajectory_controller"
                       task="{task}"
                       task_id=""
                       trajectory_monitoring="false"

--- a/src/hangar_sim/objectives/move_to_pose_no_preview.xml
+++ b/src/hangar_sim/objectives/move_to_pose_no_preview.xml
@@ -9,7 +9,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="move_to_pose"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{move_to_pose_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -78,7 +78,7 @@
                       _collapsed="false"
                       target_pose="{target_pose}"
                       link_padding="0.0"
-                      controller_names="/joint_trajectory_controller"
+                      controller_names="joint_trajectory_controller"
                     />
                     <Action
                       ID="PublishEmpty"

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -115,7 +115,7 @@
                       target_joint_state="{target_joint_state}"
                       acceleration_scale_factor="1.0"
                       controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-                      controller_names="joint_trajectory_controller"
+                      controller_names="joint_trajectory_controller;platform_velocity_controller"
                       joint_group_name="manipulator"
                       keep_orientation="false"
                       keep_orientation_link_names="grasp_link"

--- a/src/hangar_sim/objectives/solution_move_forward_2m.xml
+++ b/src/hangar_sim/objectives/solution_move_forward_2m.xml
@@ -24,7 +24,7 @@
       <SubTree
         ID="Move to a StampedPose"
         _collapsed="true"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         target_pose="{stamped_pose}"
       />
     </Control>

--- a/src/lab_sim/objectives/add_poses_to_mtc_task.xml
+++ b/src/lab_sim/objectives/add_poses_to_mtc_task.xml
@@ -9,7 +9,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         trajectory_monitoring="false"
       />

--- a/src/lab_sim/objectives/grasp_planning.xml
+++ b/src/lab_sim/objectives/grasp_planning.xml
@@ -59,7 +59,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="pick_object"
-          controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+          controller_names="joint_trajectory_controller;robotiq_gripper_controller"
           task="{pick_object_task}"
           trajectory_monitoring="false"
         />

--- a/src/lab_sim/objectives/ml_grasp_object_from_text_prompt.xml
+++ b/src/lab_sim/objectives/ml_grasp_object_from_text_prompt.xml
@@ -71,7 +71,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="grasp"
-          controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+          controller_names="joint_trajectory_controller;robotiq_gripper_controller"
           task="{mtc_task}"
           trajectory_monitoring="false"
         />

--- a/src/lab_sim/objectives/move_along_square.xml
+++ b/src/lab_sim/objectives/move_along_square.xml
@@ -4,7 +4,7 @@
     <Control ID="Sequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{mtc_task}"
         task_id="move_along_axis"
       />

--- a/src/lab_sim/objectives/mpc_pose_tracking.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking.xml
@@ -9,7 +9,7 @@
           _collapsed="true"
           acceleration_scale_factor="1.0"
           controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
           joint_group_name="manipulator"
           keep_orientation="false"
           keep_orientation_tolerance="0.05"

--- a/src/lab_sim/objectives/pick_from_pose.xml
+++ b/src/lab_sim/objectives/pick_from_pose.xml
@@ -9,7 +9,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="pick_object"
         trajectory_monitoring="false"

--- a/src/lab_sim/objectives/pick_from_pose_with_approval.xml
+++ b/src/lab_sim/objectives/pick_from_pose_with_approval.xml
@@ -9,7 +9,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="pick_object"
         trajectory_monitoring="false"

--- a/src/lab_sim/objectives/place_at_pose.xml
+++ b/src/lab_sim/objectives/place_at_pose.xml
@@ -9,7 +9,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
         trajectory_monitoring="false"

--- a/src/lab_sim/objectives/place_at_pose_with_approval.xml
+++ b/src/lab_sim/objectives/place_at_pose_with_approval.xml
@@ -9,7 +9,7 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
         trajectory_monitoring="false"

--- a/src/lab_sim/objectives/plan_move_to_pose.xml
+++ b/src/lab_sim/objectives/plan_move_to_pose.xml
@@ -9,7 +9,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="move_to_pose"
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{move_to_pose_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
@@ -191,7 +191,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id=""
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         trajectory_monitoring="false"
       />
@@ -228,7 +228,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id=""
-        controller_names="/joint_trajectory_controller;/robotiq_gripper_controller"
+        controller_names="joint_trajectory_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         trajectory_monitoring="false"
       />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
@@ -17,7 +17,7 @@
         _collapsed="true"
         acceleration_scale_factor="1.0"
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
         keep_orientation_tolerance="0.05"

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_pose_ik_example.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_pose_ik_example.xml
@@ -93,7 +93,7 @@
         _collapsed="false"
         acceleration_scale_factor="1.0"
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         joint_group_name="manipulator"
         keep_orientation="false"
         keep_orientation_tolerance="0.05"

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/inspect_surface.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/inspect_surface.xml
@@ -9,7 +9,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="inspect_surface"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{move_to_pose_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
@@ -12,7 +12,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="push_button"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
           task="{push_button_task}"
         />
         <Action ID="SetupMTCCurrentState" task="{push_button_task}" />

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
@@ -95,7 +95,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="push_button_ml"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
           task="{push_along_axis_task}"
         />
         <Action ID="SetupMTCCurrentState" task="{push_along_axis_task}" />

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
@@ -5,7 +5,7 @@
       <Action
         ID="InitializeMTCTask"
         task_id="close_cabinet_door_retreat"
-        controller_names="/joint_trajectory_controller"
+        controller_names="joint_trajectory_controller"
         task="{retreat_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{retreat_task}" />


### PR DESCRIPTION
Updates configs to remove slashes from all controller names, e.g. `/joint_trajectory_controller` -> `joint_trajectory_controller`.
This makes it consistent everywhere and avoids potential issues with controller activation.

Slashed controller names are still accepted (after https://github.com/PickNikRobotics/moveit_pro/pull/12996) for backwards compatibility.

Closes https://github.com/PickNikRobotics/moveit_pro/issues/12962
Closes https://github.com/PickNikRobotics/moveit_pro/issues/12989