### PR TITLE
Add Mujoco migration Python files

### DIFF
--- a/src/mujoco_migration_scripts/README.mdx
+++ b/src/mujoco_migration_scripts/README.mdx
@@ -1,0 +1,3 @@
+# Mujoco Migration Scripts
+
+This directory contains the scripts used by the [Creating a MuJoCo Config from a URDF](https://docs.picknik.ai/how_to/configuration_tutorials/migrate_to_mujoco_config) guide.

--- a/src/mujoco_migration_scripts/add-gravcomp.py
+++ b/src/mujoco_migration_scripts/add-gravcomp.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+add-gravcomp.py
+
+Reads a MuJoCo MJCF XML file (preserving comments), sets gravcomp="1" on every <body> element,
+and writes the modified MJCF back to the same file without stripping comments.
+
+Usage:
+    python3 add-gravcomp.py path/to/scene.xml
+"""
+import argparse
+from xml.dom import minidom
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Set gravcomp="1" on all <body> elements in an MJCF file, preserving comments.'
+    )
+    parser.add_argument(
+        "mjcf_file", help="Path to the MJCF XML file to modify in-place"
+    )
+    args = parser.parse_args()
+
+    # Parse the MJCF with minidom (preserves comments)
+    doc = minidom.parse(args.mjcf_file)
+
+    # Iterate over all <body> elements and set gravcomp="1"
+    for node in doc.getElementsByTagName("body"):
+        node.setAttribute("gravcomp", "1")
+
+    # Write the XML back, preserving comments
+    with open(args.mjcf_file, "w", encoding="utf-8") as f:
+        doc.writexml(f, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mujoco_migration_scripts/add-position-actuators.py
+++ b/src/mujoco_migration_scripts/add-position-actuators.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+add-position-actuators.py
+
+Reads a MuJoCo MJCF XML file (preserving comments), adds a <position> actuator for every <joint>,
+and writes the modified MJCF back in-place.
+
+Each <position> uses:
+  joint="<joint_name>"
+  name="<joint_name>"
+  ctrlrange="-3.14 3.14"
+  kp="1000"
+  forcelimited="false"
+  dampratio="1"
+
+Usage:
+    python3 add-position-actuators.py path/to/scene.xml
+"""
+import argparse
+from xml.dom import minidom, Node
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add position actuators for every joint in an MJCF, preserving comments."
+    )
+    parser.add_argument(
+        "mjcf_file", help="Path to the MJCF XML file to modify in-place"
+    )
+    args = parser.parse_args()
+
+    # Parse the MJCF, preserving comments
+    doc = minidom.parse(args.mjcf_file)
+    root = doc.documentElement
+
+    # Collect joint names
+    joint_nodes = doc.getElementsByTagName("joint")
+    joint_names = [
+        n.getAttribute("name") for n in joint_nodes if n.hasAttribute("name")
+    ]
+
+    # Find or create <actuator> element
+    actuators = doc.getElementsByTagName("actuator")
+    if actuators:
+        actuator = actuators[0]
+    else:
+        actuator = doc.createElement("actuator")
+        # insert before first worldbody or at end
+        inserted = False
+        for child in root.childNodes:
+            if child.nodeType == Node.ELEMENT_NODE and child.tagName == "worldbody":
+                root.insertBefore(actuator, child)
+                inserted = True
+                break
+        if not inserted:
+            root.appendChild(actuator)
+        # add newline for readability
+        actuator.appendChild(doc.createTextNode("\n"))
+
+    # Append <position> for each joint
+    for name in joint_names:
+        # whitespace + indent
+        actuator.appendChild(doc.createTextNode("    "))
+        pos = doc.createElement("position")
+        pos.setAttribute("joint", name)
+        pos.setAttribute("name", name)
+        pos.setAttribute("ctrlrange", "-3.14 3.14")
+        pos.setAttribute("kp", "1000")
+        pos.setAttribute("forcelimited", "false")
+        pos.setAttribute("dampratio", "1")
+        actuator.appendChild(pos)
+        actuator.appendChild(doc.createTextNode("\n"))
+
+    # Write back to file
+    with open(args.mjcf_file, "w", encoding="utf-8") as f:
+        doc.writexml(f, addindent="", newl="")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mujoco_migration_scripts/assign-geom-names.py
+++ b/src/mujoco_migration_scripts/assign-geom-names.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+assign-geom-names.py
+
+Reads a MuJoCo MJCF XML file (preserving comments), assigns unique names to all <geom> elements,
+and writes the modified MJCF back to the same file without stripping comments.
+If multiple geoms under the same <body> share a base name, subsequent ones get a numeric suffix.
+
+Usage:
+    python3 assign-geom-names.py path/to/scene.xml
+"""
+import argparse
+import os
+from xml.dom import minidom, Node
+
+
+def find_parent_body(node):
+    """Climb the DOM tree to find the nearest enclosing <body> element."""
+    parent = node.parentNode
+    while parent and not (
+        parent.nodeType == Node.ELEMENT_NODE and parent.tagName == "body"
+    ):
+        parent = parent.parentNode
+    return parent
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Assign unique names to all <geom> in an MJCF, preserving comments."
+    )
+    parser.add_argument("mjcf_file", help="Path to MJCF XML file to modify in place")
+    args = parser.parse_args()
+
+    # Parse with minidom to preserve comments
+    doc = minidom.parse(args.mjcf_file)
+
+    # Find all geom elements
+    geoms = doc.getElementsByTagName("geom")
+
+    # Track counts of base names per body
+    counts = {}
+    for geom in geoms:
+        # Determine base name
+        if geom.hasAttribute("mesh"):
+            mesh_ref = geom.getAttribute("mesh")
+            base = os.path.splitext(os.path.basename(mesh_ref))[0]
+        else:
+            body = find_parent_body(geom)
+            if body and body.hasAttribute("name"):
+                base = body.getAttribute("name")
+            else:
+                base = (
+                    geom.getAttribute("type") if geom.hasAttribute("type") else "geom"
+                )
+
+        # Identify parent body for grouping key
+        parent_body = find_parent_body(geom)
+        key = (id(parent_body), base)
+
+        # Increment count and build unique name
+        counts[key] = counts.get(key, 0) + 1
+        if counts[key] > 1:
+            name = f"{base}{counts[key]}"
+        else:
+            name = base
+
+        # Assign name attribute
+        geom.setAttribute("name", name)
+
+    # Write back, preserving comments
+    with open(args.mjcf_file, "w", encoding="utf-8") as f:
+        doc.writexml(f)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds the python files used in the mujoco migration guide so that they can be linted and embeded into the guide. 