### PR TITLE
new hangar_sim training examples

### DIFF
--- a/src/hangar_sim/objectives/compute_ik_plan_and_move.xml
+++ b/src/hangar_sim/objectives/compute_ik_plan_and_move.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Compute IK, Plan and Move">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Compute IK, Plan and Move"
+    _description="An example showing how to compute Inverse Kinematics (IK) on a pose, then plan a path to get to the solution found."
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{target_pose}"
+        position_xyz="0;0;0.3"
+      />
+      <Action
+        ID="AddPoseStampedToVector"
+        input="{target_pose}"
+        vector="{target_poses}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="ComputeInverseKinematics"
+        ik_timeout_s="0.05"
+        link_padding="0.01"
+        planning_group_name="manipulator"
+        planning_scene_msg="{planning_scene}"
+        target_poses="{target_poses}"
+        tip_links="grasp_link"
+        solution="{joint_space_solution}"
+      />
+      <Action
+        ID="PlanToJointGoal"
+        acceleration_scale_factor="1.000000"
+        joint_goal="{joint_space_solution}"
+        joint_trajectory_msg="{joint_trajectory_msg}"
+        keep_orientation="false"
+        keep_orientation_link_names="grasp_link"
+        keep_orientation_tolerance="0.1"
+        link_padding="0.000000"
+        max_iterations="5000"
+        planning_group_name="manipulator"
+        seed="0"
+        trajectory_sampling_rate="100"
+        velocity_scale_factor="1.000000"
+      />
+      <Action
+        ID="SwitchController"
+        activate_asap="true"
+        automatic_deactivation="true"
+        controller_list_action_name="/controller_manager/list_controllers"
+        controller_switch_action_name="/controller_manager/switch_controller"
+        strictness="1"
+        timeout="0.000000"
+        activate_controllers="joint_trajectory_controller"
+      />
+      <Action
+        ID="ExecuteFollowJointTrajectory"
+        execute_follow_joint_trajectory_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+        goal_duration_tolerance="-1.000000"
+        goal_position_tolerance="0.000000"
+        goal_time_tolerance="0.000000"
+        joint_trajectory_msg="{joint_trajectory_msg}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Compute IK, Plan and Move">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Training Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/hangar_sim/objectives/point-to-point_trajectory.xml
+++ b/src/hangar_sim/objectives/point-to-point_trajectory.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Point-to-Point Trajectory">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Point-to-Point Trajectory"
+    _description="Example showing how to create and execute a point-to-point trajectory without planning motion around obstacles."
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action
+        ID="RetrieveWaypoint"
+        joint_group_name="manipulator"
+        waypoint_joint_state="{target_joint_state}"
+        waypoint_name="Arm Forward"
+      />
+      <SubTree
+        ID="Interpolate to Joint State"
+        _collapsed="false"
+        controller_names="joint_trajectory_controller"
+        target_joint_state="{target_joint_state}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Point-to-Point Trajectory">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Training Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/hangar_sim/waypoints/ur_waypoints.yaml
+++ b/src/hangar_sim/waypoints/ur_waypoints.yaml
@@ -7,7 +7,6 @@
     - hand
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -25,10 +24,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - 3.3844296327677555e-05
       - -2.409204126381687
@@ -39,10 +34,6 @@
       - -0.023276224427107906
       - -0.0058495831086503745
       - 0.004015076834925194
-      - -22.06584329361449
-      - -10.501371456301147
-      - 1.7668871273048772
-      - -0.8618225719047045
     velocity: []
   multi_dof_joint_state:
     header:
@@ -78,10 +69,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - -0.003738784044683501
       - -1.1833848468688086
@@ -92,10 +79,6 @@
       - -0.07207130127690735
       - -0.02369797544394028
       - -0.02531176395460309
-      - -0.09266642709106662
-      - -0.23557464236464182
-      - -0.18822018729128204
-      - -0.18656676335864855
     velocity: []
   multi_dof_joint_state:
     header:
@@ -116,7 +99,6 @@
     - hand
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -134,10 +116,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - -2.223614395803042e-06
       - -1.570948106783178
@@ -148,10 +126,6 @@
       - -6.499372338819932
       - 7.159543268978053
       - 1.7219908136112807
-      - -184.27503164809855
-      - 73.59944964015912
-      - 49.03228603651597
-      - -165.64553914942525
     velocity: []
   multi_dof_joint_state:
     header:
@@ -298,7 +272,6 @@
     - gripper
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -316,10 +289,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - -0.0008653582257948239
       - -1.4999470460772262
@@ -330,10 +299,6 @@
       - -9.783676065147956
       - 0.40660310842674036
       - 2.4791171509157226
-      - -142.7198324618306
-      - 118.18098276217249
-      - 84.62734650605745
-      - -103.47962770449797
     velocity: []
   multi_dof_joint_state:
     header:
@@ -354,7 +319,6 @@
     - hand
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -372,10 +336,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - 0.0001252230582440989
       - -1.5711894640623076
@@ -386,10 +346,6 @@
       - -4.113316847963269
       - 12.918999730656832
       - -0.037283236347385236
-      - -213.69277739236233
-      - 193.46627388607538
-      - 190.77164583281487
-      - -210.67226952086472
     velocity: []
   multi_dof_joint_state:
     header:
@@ -410,7 +366,6 @@
     - hand
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -428,10 +383,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - 1.0946682149617285e-05
       - -0.3689827456561105
@@ -442,10 +393,6 @@
       - -0.04757441449879662
       - -0.017574458418236898
       - 0.026111551466290402
-      - 12.651554154311288
-      - 18.60798312674178
-      - 1.2418086465660534
-      - -0.1871134768866237
     velocity: []
   multi_dof_joint_state:
     header:
@@ -466,7 +413,6 @@
     - hand
     - linear_actuator
     - manipulator
-    - wheel_actuator
   joint_state:
     effort: []
     header:
@@ -484,10 +430,6 @@
       - linear_x_joint
       - linear_y_joint
       - rotational_yaw_joint
-      - front_left_wheel
-      - front_right_wheel
-      - rear_left_wheel
-      - rear_right_wheel
     position:
       - -0.031728481550079304
       - -1.5562971214767365
@@ -498,10 +440,6 @@
       - -3.7530328568442513
       - 9.927768114612965
       - 0.21201817498956405
-      - -82.99100539844943
-      - 231.86494206573718
-      - 214.85620939660976
-      - -90.2456426427412
     velocity: []
   multi_dof_joint_state:
     header:


### PR DESCRIPTION
- Removes wheel joints from saved waypoints, since those are not needed and can trigger errors in some planning Behaviors that don't know what to do with the wheel actuators
- Adds a couple of training examples used in https://github.com/PickNikRobotics/moveit_pro/pull/13103