### PR TITLE
Update Dockerfile to include ros-core tools and SDK tutorial requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG MOVEIT_STUDIO_BASE_IMAGE=picknikciuser/moveit-studio:${STUDIO_DOCKER_TAG:-ma
 ARG USERNAME=studio-user
 ARG USER_UID=1000
 ARG USER_GID=1000
+ARG ROS_DISTRO=humble
 
 ##################################################
 # Starting from the specified MoveIt Pro release #
@@ -72,7 +73,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     rosdep install -q -y \
       --from-paths src \
-      --ignore-src
+      --ignore-src && \
+   apt-get install -y --no-install-recommends \
+      ros-${ROS_DISTRO}-ros-core ros-${ROS_DISTRO}-examples-rclcpp-minimal-service
 
 # Set up colcon defaults for the new user
 USER ${USERNAME}
@@ -177,7 +180,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     rosdep install -q -y \
       --from-paths src \
-      --ignore-src
+      --ignore-src && \
+   apt-get install -y --no-install-recommends \
+      ros-${ROS_DISTRO}-ros-core ros-${ROS_DISTRO}-examples-rclcpp-minimal-service
 
 # Set up colcon defaults for the new user
 USER ${USERNAME}


### PR DESCRIPTION
Adds these pacakges
- https://index.ros.org/p/ros_core/#humble-deps - has lots of common CLI debugging tools people expect to be pacakged
- https://index.ros.org/p/examples_rclcpp_minimal_service/#humble-deps - used by SDK tutorial https://docs.picknik.ai/setup_tutorials/developer_platform_usage/