### PR TITLE
Remove leading slash from controller name in MPC Pose Tracking

### DIFF
--- a/src/lab_sim/objectives/mpc_pose_tracking.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking.xml
@@ -9,7 +9,7 @@
           _collapsed="true"
           acceleration_scale_factor="1.0"
           controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
-          controller_names="/joint_trajectory_controller"
+          controller_names="joint_trajectory_controller"
           joint_group_name="manipulator"
           keep_orientation="false"
           keep_orientation_tolerance="0.05"


### PR DESCRIPTION
To resolve

<img width="437" height="122" alt="Screenshot from 2025-07-11 11-16-51" src="https://github.com/user-attachments/assets/22ad0efb-49d9-4140-9005-26e983f38795" />
