### PR TITLE
Only have calibration objectives, and favorite them.

### DIFF
--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/config/config.yaml
@@ -32,7 +32,7 @@ hardware:
 # Configuration for loading behaviors and objectives.
 objectives:
   objective_library_paths:
-    custom_objectives:
+    sim_objectives:
       package_name: "space_satellite_sim_camera_cal"
       relative_path: "objectives"
   # Specify location of the waypoints file.

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_scene_camera.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_scene_camera.xml
@@ -4,7 +4,7 @@
   <BehaviorTree
     ID="Calibrate Scene Camera"
     _description="Calibrate the scene camera from multiple waypoints using the DetectAprilTags behavior."
-    _favorite="false"
+    _favorite="true"
   >
     <SubTree
       ID="Calibrate Camera - Detect Tags"

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_servicer_camera.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_servicer_camera.xml
@@ -4,7 +4,7 @@
   <BehaviorTree
     ID="Calibrate Servicer Camera"
     _description="Calibrate the servicer camera from multiple waypoints using the DetectAprilTags behavior."
-    _favorite="false"
+    _favorite="true"
   >
     <SubTree
       ID="Calibrate Camera - Detect Tags"

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_servicer_camera_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_servicer_camera_-_tag_tfs.xml
@@ -7,7 +7,7 @@
   <BehaviorTree
     ID="Calibrate Servicer Camera - Tag TFs"
     _description="Calibrate the servicer camera from multiple waypoints using externally published detected AprilTag TF frames."
-    _favorite="false"
+    _favorite="true"
   >
     <SubTree
       ID="Calibrate Camera - Tag TFs"


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/moveit_pro/issues/13351.

space_satellite_sim objectives won't work, so overwrite space_satellite_sim Objectives with space_satellite_sim_camera_cal Objectives in config so only the Calibration Objectives are available.