### PR TITLE
Fix caching of dependency steps in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 build
 install
+log


### PR DESCRIPTION
`log` wasn't ignored in the build context and was causing cache busts.