### PR TITLE
13833 Change weights package for SAM2 and L2G back to lab_sim

### DIFF
--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -130,7 +130,7 @@
                   image="{image}"
                   pixel_coords="{pixel_coords}"
                   masks2d="{masks2d}"
-                  model_package="moveit_pro_clipseg"
+                  model_package="lab_sim"
                   decoder_model_path="models/decoder.onnx"
                   encoder_model_path="models/sam2_hiera_large_encoder.onnx"
                 />

--- a/src/hangar_sim/objectives/segment_image_from_point.xml
+++ b/src/hangar_sim/objectives/segment_image_from_point.xml
@@ -14,7 +14,7 @@
         encoder_model_path="models/sam2_hiera_large_encoder.onnx"
         image_topic_name="/wrist_camera/color"
         masks_visualization_topic="/masks_visualization"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         pixel_coords="{pixel_coords}"
         masks2d="{masks2d}"
       />

--- a/src/hangar_sim/objectives/segment_point_cloud_from_clicked_point.xml
+++ b/src/hangar_sim/objectives/segment_point_cloud_from_clicked_point.xml
@@ -18,7 +18,7 @@
         encoder_model_path="models/sam2_hiera_large_encoder.onnx"
         image_topic_name="/wrist_camera/color"
         masks_visualization_topic="/masks_visualization"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         points_topic_name="/wrist_camera/points"
       />
     </Control>

--- a/src/lab_sim/objectives/get_candidate_grasps_subtree.xml
+++ b/src/lab_sim/objectives/get_candidate_grasps_subtree.xml
@@ -12,18 +12,21 @@
         topic_name="{camera_image_topic}"
         timeout_sec="5.000000"
         message_out="{image}"
+        publisher_timeout_sec="5.000000"
       />
       <Action
         ID="GetPointCloud"
         topic_name="{camera_points_topic}"
         timeout_sec="5.000000"
         message_out="{point_cloud}"
+        publisher_timeout_sec="5.000000"
       />
       <Action
         ID="GetCameraInfo"
         topic_name="{camera_info_topic}"
         message_out="{camera_info}"
         timeout_sec="5.000000"
+        publisher_timeout_sec="5.000000"
       />
       <Action
         ID="GetMasks2DFromTextQuery"
@@ -65,7 +68,7 @@
             pixel_coords="{center2d}"
             decoder_model_path="models/decoder.onnx"
             encoder_model_path="models/sam2_hiera_large_encoder.onnx"
-            model_package="moveit_pro_clipseg"
+            model_package="lab_sim"
           />
         </Control>
       </Decorator>
@@ -115,7 +118,7 @@
         grasps="{grasps}"
         number_of_grasps_to_return="10"
         point_cloud="{point_cloud_fragment}"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         model_path="models/l2g.onnx"
       />
     </Control>

--- a/src/lab_sim/objectives/ml_auto_grasp_object_from_clicked_point.xml
+++ b/src/lab_sim/objectives/ml_auto_grasp_object_from_clicked_point.xml
@@ -34,7 +34,7 @@
         image_topic_name="/wrist_camera/color"
         masks_visualization_topic="/masks_visualization"
         masks2d="{masks2d}"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         pixel_coords="{pixel_coords}"
         decoder_model_path="models/decoder.onnx"
         name="Ask the user to pick an object"
@@ -79,7 +79,7 @@
         grasps="{grasps}"
         number_of_grasps_to_return="10"
         point_cloud="{point_cloud_fragment}"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         model_path="models/l2g.onnx"
       />
       <SubTree

--- a/src/lab_sim/objectives/ml_segment_point_cloud_from_clicked_point.xml
+++ b/src/lab_sim/objectives/ml_segment_point_cloud_from_clicked_point.xml
@@ -18,7 +18,7 @@
         encoder_model_path="models/sam2_hiera_large_encoder.onnx"
         image_topic_name="/wrist_camera/color"
         masks_visualization_topic="/masks_visualization"
-        model_package="moveit_pro_clipseg"
+        model_package="lab_sim"
         points_topic_name="/wrist_camera/points"
       />
     </Control>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_point_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_point_subtree.xml
@@ -9,7 +9,7 @@
     encoder_model_path="models/sam2_hiera_large_encoder.onnx"
     image_topic_name="/wrist_camera/color"
     masks_visualization_topic="/masks_visualization"
-    model_package="moveit_pro_clipseg"
+    model_package="lab_sim"
     masks2d="{masks2d}"
     pixel_coords="{pixel_coords}"
   >


### PR DESCRIPTION
https://github.com/PickNikRobotics/moveit_pro_example_ws/pull/387 accidentally pointed the model package for SAM2 and L2G to `moveit_pro_clipseg`, which does not contain weights for those models. Changing them back to `lab_sim`