### PR TITLE
update JTAC's zero_fts service name

### DIFF
--- a/src/lab_sim/objectives/push_button_with_a_trajectory.xml
+++ b/src/lab_sim/objectives/push_button_with_a_trajectory.xml
@@ -64,7 +64,7 @@
       />
       <Action
         ID="CallTriggerService"
-        service_name="/joint_trajectory_admittance_controller/zero_fts"
+        service_name="/joint_trajectory_admittance_controller/zero_fts/tool0"
       />
       <Action
         ID="SetAdmittanceParameters"


### PR DESCRIPTION
Update configs after https://github.com/PickNikRobotics/moveit_pro/pull/13576
The JTAC now supports multiple tips/sensors, so the tare service name now includes the sensor name