### PR TITLE
Fix example_behavior dependencies

### DIFF
--- a/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
@@ -2,11 +2,11 @@
 
 #include <behaviortree_cpp/action_node.h>
 #include <behaviortree_cpp/bt_factory.h>
-#include <moveit/robot_model_loader/robot_model_loader.h>
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 #include <Eigen/Core>
 #include <cartesian_planning/trajectory_utils.hpp>
+#include <moveit/robot_model_loader/robot_model_loader.hpp>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>

--- a/src/example_behaviors/src/example_sam2_segmentation.cpp
+++ b/src/example_behaviors/src/example_sam2_segmentation.cpp
@@ -1,3 +1,4 @@
+#include <fmt/format.h>
 #include <future>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Fixes

```
[Processing: example_behaviors]                               
--- stderr: example_behaviors                                 
In file included from /home/nbb/user_ws/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp:1:
/home/nbb/user_ws/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp:5:10: fatal error: moveit/robot_model_loader/robot_model_loader.h: No such file or directory
    5 | #include <moveit/robot_model_loader/robot_model_loader.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/example_behaviors.dir/build.make:90: CMakeFiles/example_behaviors.dir/src/example_convert_mtc_solution_to_joint_trajectory.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /home/nbb/user_ws/src/example_behaviors/src/register_behaviors.cpp:8:
/home/nbb/user_ws/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp:5:10: fatal error: moveit/robot_model_loader/robot_model_loader.h: No such file or directory
    5 | #include <moveit/robot_model_loader/robot_model_loader.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/example_behaviors.dir/build.make:244: CMakeFiles/example_behaviors.dir/src/register_behaviors.cpp.o] Error 1
/home/nbb/user_ws/src/example_behaviors/src/example_sam2_segmentation.cpp: In member function 'virtual tl::expected<bool, std::__cxx11::basic_string<char> > example_behaviors::ExampleSAM2Segmentation::doWork()':
/home/nbb/user_ws/src/example_behaviors/src/example_sam2_segmentation.cpp:95:26: error: 'fmt' has not been declared
   95 |     auto error_message = fmt::format("Failed to get required values from input data ports:\n{}", ports.error());
      |                          ^~~
/home/nbb/user_ws/src/example_behaviors/src/example_sam2_segmentation.cpp:103:9: error: 'fmt' has not been declared
  103 |         fmt::format("Invalid image message format. Expected `(rgb8, rgba8)` got :\n{}", image_msg.encoding);
      |         ^~~
/home/nbb/user_ws/src/example_behaviors/src/example_sam2_segmentation.cpp:130:32: error: 'fmt' has not been declared
  130 |     return tl::make_unexpected(fmt::format("Invalid argument: {}", e.what()));
      |                                ^~~
gmake[2]: *** [CMakeFiles/example_behaviors.dir/build.make:216: CMakeFiles/example_behaviors.dir/src/example_sam2_segmentation.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:172: CMakeFiles/example_behaviors.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< example_behaviors [45.3s, exited with code 2]

Summary: 63 packages finished [45.9s]
  1 package failed: example_behaviors
  2 packages had stderr output: example_behaviors ros_tcp_endpoint

```