### PR TITLE
Add new objective to show adding collision object to planning scene

### DIFF
--- a/src/lab_sim/objectives/addbottlestoplanningscene.xml
+++ b/src/lab_sim/objectives/addbottlestoplanningscene.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="AddBottlesToPlanningScene">
+  <BehaviorTree
+    ID="AddBottlesToPlanningScene"
+    _description="Detects flasks using ML and adds them as collision objects to the planning scene"
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree ID="Clear Previous Obstacles" _collapsed="true" />
+      <SubTree
+        ID="Move to Waypoint"
+        _collapsed="true"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_controller"
+        joint_group_name="manipulator"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.01"
+        seed="0"
+        velocity_scale_factor="1.0"
+        waypoint_name="Look at Flasks"
+      />
+      <SubTree ID="Take Wrist Camera Snapshot" _collapsed="true" />
+      <SubTree
+        ID="Segment Image from Text Prompt Subtree"
+        _collapsed="true"
+        clip_model_path="models/clip.onnx"
+        clipseg_model_path="models/clipseg.onnx"
+        masks_visualization_topic="/masks_visualization"
+        masks2d="{masks2d}"
+        model_package="moveit_pro_clipseg"
+        prompts="conical flask"
+        threshold="0.15"
+        image_topic_name="/wrist_camera/color"
+        negative_prompts="box"
+        erosion_size="10"
+      />
+      <Action
+        ID="GetPointCloud"
+        message_out="{point_cloud}"
+        publisher_timeout_sec="5.000000"
+        timeout_sec="5.000000"
+        topic_name="/wrist_camera/points"
+      />
+      <Action
+        ID="GetCameraInfo"
+        message_out="{camera_info}"
+        publisher_timeout_sec="5.000000"
+        timeout_sec="5.000000"
+        topic_name="/wrist_camera/camera_info"
+      />
+      <Action
+        ID="FindMaskedObjects"
+        base_frame="grasp_link"
+        camera_info="{camera_info}"
+        detected_shapes="{detected_shapes}"
+        face_separation_threshold="0.010000"
+        masks2d="{masks2d}"
+        minimum_face_area="0.000625"
+        plane_inlier_threshold="0.010000"
+        point_cloud="{point_cloud}"
+      />
+      <Decorator
+        ID="ForEach"
+        index="{index}"
+        out="{out}"
+        vector_in="{detected_shapes}"
+      >
+        <Control ID="Sequence">
+          <Control ID="Sequence">
+            <Action
+              ID="UnpackGraspableObjectMessage"
+              grasp_info="{grasp_info}"
+              graspable_object="{out}"
+              object="{object}"
+              object_color="{object_color}"
+            />
+            <Action
+              ID="UnpackCollisionObjectMessage"
+              collision_object="{object}"
+              header="{header}"
+              id="{id}"
+              mesh_poses="{mesh_poses}"
+              meshes="{meshes}"
+              operation="{operation}"
+              plane_poses="{plane_poses}"
+              planes="{planes}"
+              pose="{pose}"
+              primitive_poses="{primitive_poses}"
+              primitives="{primitives}"
+              subframe_names="{subframe_names}"
+              subframe_poses="{subframe_poses}"
+              type="{type}"
+            />
+            <Action
+              ID="UnpackPoseMessage"
+              orientation="{orientation}"
+              pose="{pose}"
+              position="{position}"
+            />
+            <Action
+              ID="UnpackPointMessage"
+              point="{position}"
+              x="{x}"
+              y="{y}"
+              z="{z}"
+            />
+          </Control>
+          <Control ID="Sequence">
+            <Action ID="ResetVector" vector="{vector}" />
+            <Action
+              ID="InsertInVector"
+              index="0"
+              output_vector="{vector}"
+              element="{z}"
+              input_vector="{vector}"
+            />
+            <Action
+              ID="InsertInVector"
+              index="0"
+              output_vector="{vector}"
+              element="{y}"
+              input_vector="{vector}"
+            />
+            <Action
+              ID="InsertInVector"
+              index="0"
+              output_vector="{vector}"
+              element="{x}"
+              input_vector="{vector}"
+            />
+          </Control>
+          <Action ID="Script" code="object_id:='bottle'..index" />
+          <SubTree
+            ID="AddCollisionBoxInFrontOfEndEffector"
+            _collapsed="true"
+            dimensions="0.15;0.15;0.15"
+            offset="{vector}"
+            object_id="{object_id}"
+          />
+        </Control>
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="AddBottlesToPlanningScene">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Perception - Planning Scene" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
+++ b/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root
+  BTCPP_format="4"
+  main_tree_to_execute="AddCollisionBoxInFrontOfEndEffector"
+>
+  <!--//////////-->
+  <BehaviorTree
+    ID="AddCollisionBoxInFrontOfEndEffector"
+    _description="Adds a collision box in front of the end effector with the specified ID, dimensions and offset."
+    _favorite="false"
+    name=""
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="grasp_link"
+        stamped_pose="{stamped_pose}"
+        position_xyz="{offset}"
+      />
+      <Action
+        ID="CreateSolidPrimitiveBox"
+        solid_primitive="{solid_primitive}"
+        dimensions="{dimensions}"
+      />
+      <Action
+        ID="CreateCollisionObjectFromSolidPrimitive"
+        collision_object="{collision_object}"
+        object_id="{object_id}"
+        pose="{stamped_pose}"
+        solid_primitive="{solid_primitive}"
+      />
+      <SubTree
+        ID="AddCollisionObjectToPlanningScene"
+        _collapsed="false"
+        collision_object="{collision_object}"
+        pose="{stamped_pose}"
+        object_id="{object_id}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="AddCollisionBoxInFrontOfEndEffector">
+      <MetadataFields>
+        <Metadata runnable="false" />
+        <Metadata subcategory="Perception - Planning Scene" />
+      </MetadataFields>
+      <inout_port
+        name="dimensions"
+        default="0.3;0.3;0.3"
+        type="std::vector&lt;double, std::allocator&lt;double&gt; &gt;"
+      />
+      <inout_port name="object_id" default="" type="std::string" />
+      <inout_port
+        name="offset"
+        default="0;0;0.1"
+        type="std::vector&lt;double, std::allocator&lt;double&gt; &gt;"
+      />
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/addcollisionobjecttoplanningscene.xml
+++ b/src/lab_sim/objectives/addcollisionobjecttoplanningscene.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="AddCollisionObjectToPlanningScene">
+  <!--//////////-->
+  <BehaviorTree
+    ID="AddCollisionObjectToPlanningScene"
+    _description="Adds a collision box to the planning scene  with the specified ID and pose."
+  >
+    <Control ID="Sequence">
+      <Action
+        ID="CreateGraspableObject"
+        cuboid_object="{cuboid_object}"
+        dx="0.100000"
+        dy="0.100000"
+        dz="0.100000"
+        generate_front_face="false"
+        generate_side_faces="false"
+        generate_top_face="false"
+        object_id="{object_id}"
+        pose="{pose}"
+      />
+      <Action
+        ID="UnpackGraspableObjectMessage"
+        grasp_info="{grasp_info}"
+        graspable_object="{cuboid_object}"
+        object="{object}"
+        object_color="{object_color}"
+      />
+      <Action
+        ID="CreateGraspableObjectMessage"
+        grasp_info="{grasp_info}"
+        graspable_object="{graspable_object}"
+        object="{collision_object}"
+        object_color="{object_color}"
+      />
+      <Action
+        ID="ModifyObjectInPlanningScene"
+        apply_planning_scene_service="/apply_planning_scene"
+        object="{graspable_object}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="IsCollisionObjectInPlanningScene"
+        planning_scene="{planning_scene}"
+        collision_object_name="{object_id}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="AddCollisionObjectToPlanningScene">
+      <MetadataFields>
+        <Metadata runnable="false" />
+        <Metadata subcategory="Perception - Planning Scene" />
+      </MetadataFields>
+      <inout_port name="collision_object" default="{collision_object}" />
+      <inout_port name="object_id" default="" type="std::string">
+        ID of collision object in the planning scene
+      </inout_port>
+      <inout_port
+        name="pose"
+        default="{stamped_pose}"
+        type="geometry_msgs::msg::PoseStamped_&lt;std::allocator&lt;void&gt; &gt;"
+      />
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/waypoints/ur_waypoints.yaml
+++ b/src/lab_sim/waypoints/ur_waypoints.yaml
@@ -686,6 +686,221 @@
     twist: []
     wrench: []
   name: Look at Base
+- description: Location left of the burner to look for bottles
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.052587508554489834
+    - 0.2968578480078406
+    - -0.006148632895028194
+    - -0.8175631700397911
+    - 1.2592096237510881
+    - -2.2864772465639494
+    - -1.548620949533172
+    - 0.0017334387814990154
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Look at Bottles Left
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.005250736667361686
+    - 0.28905780343437465
+    - -2.080646628339534
+    - -2.141055377241851
+    - -1.2137155511655011
+    - 2.1016864355675033
+    - -1.197419807165355
+    - -2.330740475762169
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Look at Flasks
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.010668053371874283
+    - 0.7128770076950819
+    - -0.08122196808779752
+    - -1.11190218141
+    - 0.7735713019368727
+    - -1.2414136646059095
+    - -2.0026807593048916
+    - -0.08031321356876141
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Look at Objects - Left
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.0106680533718743
+    - 0.02603207104532889
+    - -0.08122196691189307
+    - -1.1119021813364924
+    - 0.7885756618064743
+    - -1.2414136646088876
+    - -1.1126763995038707
+    - -0.08031321356882577
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Look at Objects - Right
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.010668053371874292
+    - 0.34684536153674317
+    - -0.08122195487921627
+    - -1.1119021804297864
+    - 0.7735713027325338
+    - -1.241413664401271
+    - -1.557512703220074
+    - -0.08031321357409668
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Look at Objects - Top
 - description: ''
   favorite: false
   joint_group_names:
@@ -858,6 +1073,49 @@
     twist: []
     wrench: []
   name: Place Cube
+- description: Location for the robot to go to before placing bottle.
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.005274374788506071
+    - -0.65899502183384
+    - -0.011044571105883248
+    - -0.9740961688696632
+    - 1.2354891461984063
+    - -2.0150613197113008
+    - -1.5477140380091456
+    - -0.0030875579024600766
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Predrop Bottles Right
 - description: ''
   favorite: false
   joint_group_names:
@@ -1030,218 +1288,3 @@
     twist: []
     wrench: []
   name: Wrist 2 Min
-- description: ''
-  favorite: false
-  joint_group_names:
-  - gripper
-  - linear_actuator
-  - manipulator
-  joint_state:
-    effort: []
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    name:
-    - robotiq_85_left_knuckle_joint
-    - linear_rail_joint
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-    position:
-    - 0.010668053371874283
-    - 0.7128770076950819
-    - -0.08122196808779752
-    - -1.11190218141
-    - 0.7735713019368727
-    - -1.2414136646059095
-    - -2.0026807593048916
-    - -0.08031321356876141
-    velocity: []
-  multi_dof_joint_state:
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    joint_names: []
-    transforms: []
-    twist: []
-    wrench: []
-  name: Look at Objects - Left
-- description: ''
-  favorite: false
-  joint_group_names:
-  - gripper
-  - linear_actuator
-  - manipulator
-  joint_state:
-    effort: []
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    name:
-    - robotiq_85_left_knuckle_joint
-    - linear_rail_joint
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-    position:
-    - 0.0106680533718743
-    - 0.02603207104532889
-    - -0.08122196691189307
-    - -1.1119021813364924
-    - 0.7885756618064743
-    - -1.2414136646088876
-    - -1.1126763995038707
-    - -0.08031321356882577
-    velocity: []
-  multi_dof_joint_state:
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    joint_names: []
-    transforms: []
-    twist: []
-    wrench: []
-  name: Look at Objects - Right
-- description: ''
-  favorite: false
-  joint_group_names:
-  - gripper
-  - linear_actuator
-  - manipulator
-  joint_state:
-    effort: []
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    name:
-    - robotiq_85_left_knuckle_joint
-    - linear_rail_joint
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-    position:
-    - 0.010668053371874292
-    - 0.34684536153674317
-    - -0.08122195487921627
-    - -1.1119021804297864
-    - 0.7735713027325338
-    - -1.241413664401271
-    - -1.557512703220074
-    - -0.08031321357409668
-    velocity: []
-  multi_dof_joint_state:
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    joint_names: []
-    transforms: []
-    twist: []
-    wrench: []
-  name: Look at Objects - Top
-- description: Location left of the burner to look for bottles
-  favorite: false
-  joint_group_names:
-  - gripper
-  - linear_actuator
-  - manipulator
-  joint_state:
-    effort: []
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    name:
-    - robotiq_85_left_knuckle_joint
-    - linear_rail_joint
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-    position:
-    - 0.052587508554489834
-    - 0.2968578480078406
-    - -0.006148632895028194
-    - -0.8175631700397911
-    - 1.2592096237510881
-    - -2.2864772465639494
-    - -1.548620949533172
-    - 0.0017334387814990154
-    velocity: []
-  multi_dof_joint_state:
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    joint_names: []
-    transforms: []
-    twist: []
-    wrench: []
-  name: Look at Bottles Left
-- description: Location for the robot to go to before placing bottle.
-  favorite: false
-  joint_group_names:
-  - gripper
-  - linear_actuator
-  - manipulator
-  joint_state:
-    effort: []
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    name:
-    - robotiq_85_left_knuckle_joint
-    - linear_rail_joint
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-    position:
-    - 0.005274374788506071
-    - -0.65899502183384
-    - -0.011044571105883248
-    - -0.9740961688696632
-    - 1.2354891461984063
-    - -2.0150613197113008
-    - -1.5477140380091456
-    - -0.0030875579024600766
-    velocity: []
-  multi_dof_joint_state:
-    header:
-      frame_id: ''
-      stamp:
-        nanosec: 0
-        sec: 0
-    joint_names: []
-    transforms: []
-    twist: []
-    wrench: []
-  name: Predrop Bottles Right


### PR DESCRIPTION
Added 3 new objectives which show the ability to add collision objects to the planning scene.

- AddBottlesToPlanningScene will find the flasks using clipseg and add collision boxes around them.
- AddCollisionObjectInFrontOfEndEffector will place a collision cube in front of the grasp_link
- AddCollisionObjectToPlanningScene will add a collision object at the specified position and orientation.
