### PR TITLE
Fix ghost of old bug in model serialization

### DIFF
--- a/src/lab_sim/objectives/load_mesh_as_red_pointcloud.xml
+++ b/src/lab_sim/objectives/load_mesh_as_red_pointcloud.xml
@@ -29,7 +29,6 @@
   <TreeNodesModel>
     <SubTree ID="Load Mesh as Red Point Cloud">
       <output_port name="point_cloud" default="{red_cloud}" />
-      <input_port name="_collapsed" default="false" />
       <input_port name="initial_pose" default="{stamped_pose}" />
       <MetadataFields>
         <Metadata subcategory="Perception - 3D Point Cloud" />


### PR DESCRIPTION

<img width="150" height="170" alt="ghost bug" src="https://github.com/user-attachments/assets/89758ee6-53a7-4aa2-bed3-1863d1696b95" />


This special attribute must have been erroneously serialized into the subtree model ~10 months ago, it seems.

Fixes PickNikRobotics/moveit_pro#14386.