### PR TITLE
Reverted change for gripper objectives in satellite_sim.

### DIFF
--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/close_gripper.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/close_gripper.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Gripper Open">
-  <!--//////////-->
+<root BTCPP_format="4" main_tree_to_execute="Close Gripper">
   <BehaviorTree
-    ID="Gripper Open"
-    _description="Open the gripper"
+    ID="Close Gripper"
+    _description="Close the gripper"
     _favorite="true"
   >
     <Control ID="Sequence" name="root">
       <Action
         ID="MoveGripperAction"
         gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
-        position="0.05"
+        position="0.77"
         timeout="10.000000"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Gripper Open">
+    <SubTree ID="Close Gripper">
       <MetadataFields>
         <Metadata subcategory="Grasping" />
         <Metadata runnable="true" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
@@ -10,7 +10,7 @@
     _favorite="true"
   >
     <Control ID="Sequence" name="TopLevelSequence">
-      <SubTree ID="Gripper Open" _collapsed="true" />
+      <SubTree ID="Open Gripper" _collapsed="true" />
       <SubTree
         ID="Move to Waypoint"
         _collapsed="true"
@@ -171,7 +171,7 @@
               />
             </Control>
           </Decorator>
-          <SubTree ID="Gripper Close" _collapsed="true" />
+          <SubTree ID="Close Gripper" _collapsed="true" />
         </Control>
       </Control>
     </Control>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/open_gripper.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/open_gripper.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<root BTCPP_format="4" main_tree_to_execute="Gripper Close">
+<root BTCPP_format="4" main_tree_to_execute="Open Gripper">
+  <!--//////////-->
   <BehaviorTree
-    ID="Gripper Close"
-    _description="Close the gripper"
+    ID="Open Gripper"
+    _description="Open the gripper"
     _favorite="true"
   >
     <Control ID="Sequence" name="root">
       <Action
         ID="MoveGripperAction"
         gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
-        position="0.77"
+        position="0.05"
         timeout="10.000000"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
-    <SubTree ID="Gripper Close">
+    <SubTree ID="Open Gripper">
       <MetadataFields>
         <Metadata subcategory="Grasping" />
         <Metadata runnable="true" />


### PR DESCRIPTION
## Issue

https://github.com/PickNikRobotics/moveit_pro/issues/14362

## Description

I reverted the names of "Open Gripper" and Close "Gripper" objectives, including their use in the objective "Grapple Moving Satellite via Fiducial Tracking"

## Tests

If you work in dev mode, remember to launch 

`ros2 launch space_satellite_sim agent_bridge.launch.xml`

instead of

`agent_bridge.app`

Check that the gripper open and close in teleoperation mode and run the objective "Grapple Moving Satellite via Fiducial Tracking".