### PR TITLE
Visualize relative transforms for isolated movements 

### DIFF
--- a/src/convert_odom_to_pose_stamped/CMakeLists.txt
+++ b/src/convert_odom_to_pose_stamped/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.22)
+project(convert_odom_to_pose_stamped CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_pro_behavior_interface pluginlib)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+add_library(
+  convert_odom_to_pose_stamped
+  SHARED
+  src/convert_odom_to_pose_stamped.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  convert_odom_to_pose_stamped
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(convert_odom_to_pose_stamped
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+# Install Libraries
+install(
+  TARGETS convert_odom_to_pose_stamped
+  EXPORT convert_odom_to_pose_stampedTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+if(BUILD_TESTING)
+  moveit_pro_behavior_test(convert_odom_to_pose_stamped)
+endif()
+
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_studio_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface convert_odom_to_pose_stamped_plugin_description.xml)
+
+ament_export_targets(convert_odom_to_pose_stampedTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/convert_odom_to_pose_stamped/behavior_plugin.yaml
+++ b/src/convert_odom_to_pose_stamped/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    convert_odom_to_pose_stamped:
+      - "convert_odom_to_pose_stamped::ConvertOdomToPoseStampedBehaviorsLoader"

--- a/src/convert_odom_to_pose_stamped/convert_odom_to_pose_stamped_plugin_description.xml
+++ b/src/convert_odom_to_pose_stamped/convert_odom_to_pose_stamped_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="convert_odom_to_pose_stamped">
+  <class
+    type="convert_odom_to_pose_stamped::ConvertOdomToPoseStampedBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/convert_odom_to_pose_stamped/include/convert_odom_to_pose_stamped/convert_odom_to_pose_stamped.hpp
+++ b/src/convert_odom_to_pose_stamped/include/convert_odom_to_pose_stamped/convert_odom_to_pose_stamped.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+
+namespace convert_odom_to_pose_stamped
+{
+/**
+ * @brief TODO(...)
+ */
+class ConvertOdomToPoseStamped : public BT::SyncActionNode
+{
+public:
+  /**
+   * @brief Constructor for the convert_odom_to_pose_stamped behavior.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when
+   * this Behavior is created within a new behavior tree.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the
+   * Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this
+   * Behavior is created within a new behavior tree.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after
+   * the initialize() function is called, so these classes should not be used within the constructor.
+   */
+  ConvertOdomToPoseStamped(const std::string& name, const BT::NodeConfiguration& config);
+
+  /**
+   * @brief Implementation of the required providedPorts() function for the convert_odom_to_pose_stamped Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named
+   * providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function
+   * must return an empty BT::PortsList. This function returns a list of ports with their names and port info, which is
+   * used internally by the behavior tree.
+   * @return convert_odom_to_pose_stamped does not expose any ports, so this function returns an empty list.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of BT::SyncActionNode::tick() for ConvertOdomToPoseStamped.
+   * @details This function is where the Behavior performs its work when the behavior tree is being run. Since
+   * ConvertOdomToPoseStamped is derived from BT::SyncActionNode, it is very important that its tick() function always
+   * finishes very quickly. If tick() blocks before returning, it will block execution of the entire behavior tree,
+   * which may have undesirable consequences for other Behaviors that require a fast update rate to work correctly.
+   */
+  BT::NodeStatus tick() override;
+};
+}  // namespace convert_odom_to_pose_stamped

--- a/src/convert_odom_to_pose_stamped/package.xml
+++ b/src/convert_odom_to_pose_stamped/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>convert_odom_to_pose_stamped</name>
+  <version>0.0.0</version>
+  <description>
+    This removes the twist part of the odom message so you can visualize/operate
+    on the pose.
+  </description>
+
+  <maintainer email="support@picknik.ai">MoveIt Pro User</maintainer>
+  <author email="support@picknik.ai">MoveIt Pro User</author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>moveit_pro_behavior_interface</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/convert_odom_to_pose_stamped/src/convert_odom_to_pose_stamped.cpp
+++ b/src/convert_odom_to_pose_stamped/src/convert_odom_to_pose_stamped.cpp
@@ -1,0 +1,59 @@
+#include <convert_odom_to_pose_stamped/convert_odom_to_pose_stamped.hpp>
+
+#include "spdlog/spdlog.h"
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+namespace
+{
+constexpr auto kPortIDOdometry = "odometry";
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+}  // namespace
+
+namespace convert_odom_to_pose_stamped
+{
+ConvertOdomToPoseStamped::ConvertOdomToPoseStamped(const std::string& name, const BT::NodeConfiguration& config)
+  : BT::SyncActionNode(name, config)
+{
+}
+
+BT::PortsList ConvertOdomToPoseStamped::providedPorts()
+{
+  return BT::PortsList(
+      { BT::InputPort<nav_msgs::msg::Odometry>(kPortIDOdometry, "{odometry}",
+                                               "The gnav_msgs::msg::Odometry message to "
+                                               "convert."),
+        BT::OutputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                        "The converted geometry_msgs::msg::PoseStamped message.") });
+}
+
+BT::KeyValueVector ConvertOdomToPoseStamped::metadata()
+{
+  return { { "description", "Converts a nav_msgs::msg::Odometry message into a "
+                            "geometry_msgs::msg::PoseStamped message." },
+           { "subcategory", "Conversions" } };
+}
+
+BT::NodeStatus ConvertOdomToPoseStamped::tick()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<nav_msgs::msg::Odometry>(kPortIDOdometry));
+
+  if (!ports.has_value())
+  {
+    spdlog::warn("Failed to get required value from input data port: {}", ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& odom_msg = std::get<0>(ports.value());
+
+  geometry_msgs::msg::PoseStamped pose_out;
+  pose_out.header = odom_msg.header;
+  pose_out.pose = odom_msg.pose.pose;
+
+  setOutput(kPortIDPoseStamped, pose_out);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace convert_odom_to_pose_stamped

--- a/src/convert_odom_to_pose_stamped/src/register_behaviors.cpp
+++ b/src/convert_odom_to_pose_stamped/src/register_behaviors.cpp
@@ -1,0 +1,24 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <convert_odom_to_pose_stamped/convert_odom_to_pose_stamped.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace convert_odom_to_pose_stamped
+{
+class ConvertOdomToPoseStampedBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(
+      BT::BehaviorTreeFactory& factory,
+      [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<ConvertOdomToPoseStamped>(factory, "ConvertOdomToPoseStamped");
+  }
+};
+}  // namespace convert_odom_to_pose_stamped
+
+PLUGINLIB_EXPORT_CLASS(convert_odom_to_pose_stamped::ConvertOdomToPoseStampedBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/convert_odom_to_pose_stamped/test/CMakeLists.txt
+++ b/src/convert_odom_to_pose_stamped/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+
+ament_add_ros_isolated_gtest(test_behavior_plugins test_behavior_plugins.cpp)
+ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/convert_odom_to_pose_stamped/test/test_behavior_plugins.cpp
+++ b/src/convert_odom_to_pose_stamped/test/test_behavior_plugins.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(BehaviorTests, test_load_behavior_plugins)
+{
+  pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      "moveit_pro_behavior_interface", "moveit_pro::behaviors::SharedResourcesNodeLoaderBase");
+
+  auto node = std::make_shared<rclcpp::Node>("BehaviorTests");
+  auto shared_resources = std::make_shared<moveit_pro::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance =
+        class_loader.createUniqueInstance("convert_odom_to_pose_stamped::ConvertOdomToPoseStampedBehaviorsLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+
+  // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "ConvertOdomToPoseStamped", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/convert_pose_stamped_to_transform_stamped/CMakeLists.txt
+++ b/src/convert_pose_stamped_to_transform_stamped/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.22)
+project(convert_pose_stamped_to_transform_stamped CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_pro_behavior_interface pluginlib)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+add_library(
+  convert_pose_stamped_to_transform_stamped
+  SHARED
+  src/convert_pose_stamped_to_transform_stamped.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  convert_pose_stamped_to_transform_stamped
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(convert_pose_stamped_to_transform_stamped
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+# Install Libraries
+install(
+  TARGETS convert_pose_stamped_to_transform_stamped
+  EXPORT convert_pose_stamped_to_transform_stampedTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+if(BUILD_TESTING)
+  moveit_pro_behavior_test(convert_pose_stamped_to_transform_stamped)
+endif()
+
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_studio_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface convert_pose_stamped_to_transform_stamped_plugin_description.xml)
+
+ament_export_targets(convert_pose_stamped_to_transform_stampedTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/convert_pose_stamped_to_transform_stamped/behavior_plugin.yaml
+++ b/src/convert_pose_stamped_to_transform_stamped/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    convert_pose_stamped_to_transform_stamped:
+      - "convert_pose_stamped_to_transform_stamped::ConvertPoseStampedToTransformStampedBehaviorsLoader"

--- a/src/convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped_plugin_description.xml
+++ b/src/convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="convert_pose_stamped_to_transform_stamped">
+  <class
+    type="convert_pose_stamped_to_transform_stamped::ConvertPoseStampedToTransformStampedBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/convert_pose_stamped_to_transform_stamped/include/convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped.hpp
+++ b/src/convert_pose_stamped_to_transform_stamped/include/convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+
+// This header includes the SharedResourcesNode type
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace convert_pose_stamped_to_transform_stamped
+{
+/**
+ * @brief Converts a geometry_msgs::msg::PoseStamped message into a geometry_msgs::msg::TransformStamped message.
+ */
+class ConvertPoseStampedToTransformStamped : public moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>
+{
+public:
+  /**
+   * @brief Constructor for the convert_pose_stamped_to_transform_stamped behavior.
+   * @param name The name of a particular instance of this Behavior. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
+   * @param config This contains runtime configuration info for this Behavior, such as the mapping between the Behavior's data ports on the behavior tree's blackboard. This will be set by the behavior tree factory when this Behavior is created within a new behavior tree.
+   * @param shared_resources A shared_ptr to a BehaviorContext that is shared among all SharedResourcesNode Behaviors in the behavior tree. This BehaviorContext is owned by the Studio Agent's ObjectiveServerNode.
+   * @details An important limitation is that the members of the base Behavior class are not instantiated until after the initialize() function is called, so these classes should not be used within the constructor.
+   */
+  ConvertPoseStampedToTransformStamped(const std::string& name, const BT::NodeConfiguration& config, const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  /**
+   * @brief Implementation of the required providedPorts() function for the convert_pose_stamped_to_transform_stamped Behavior.
+   * @details The BehaviorTree.CPP library requires that Behaviors must implement a static function named providedPorts() which defines their input and output ports. If the Behavior does not use any ports, this function must return an empty BT::PortsList.
+   * This function returns a list of ports with their names and port info, which is used internally by the behavior tree.
+   * @return A BT::PortsList containing the input ports for PoseStamped and child_frame_id, and output port for TransformStamped.
+   */
+  static BT::PortsList providedPorts();
+
+  /**
+   * @brief Implementation of the metadata() function for displaying metadata, such as Behavior description and
+   * subcategory, in the MoveIt Studio Developer Tool.
+   * @return A BT::KeyValueVector containing the Behavior metadata.
+   */
+  static BT::KeyValueVector metadata();
+
+  /**
+   * @brief Implementation of BT::SyncActionNode::tick() for ConvertPoseStampedToTransformStamped.
+   * @details This function is where the Behavior performs its work when the behavior tree is being run. Since ConvertPoseStampedToTransformStamped is derived from BT::SyncActionNode, it is very important that its tick() function always finishes very quickly. If tick() blocks before returning, it will block execution of the entire behavior tree, which may have undesirable consequences for other Behaviors that require a fast update rate to work correctly.
+   */
+  BT::NodeStatus tick() override;
+};
+}  // namespace convert_pose_stamped_to_transform_stamped

--- a/src/convert_pose_stamped_to_transform_stamped/package.xml
+++ b/src/convert_pose_stamped_to_transform_stamped/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>convert_pose_stamped_to_transform_stamped</name>
+  <version>0.0.0</version>
+  <description>Convert pose stamped to transform stamped.</description>
+
+  <maintainer email="support@picknik.ai">
+    MoveIt Pro User
+  </maintainer>
+  <author email="support@picknik.ai">
+    MoveIt Pro User
+  </author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>moveit_pro_behavior_interface</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/convert_pose_stamped_to_transform_stamped/src/convert_pose_stamped_to_transform_stamped.cpp
+++ b/src/convert_pose_stamped_to_transform_stamped/src/convert_pose_stamped_to_transform_stamped.cpp
@@ -1,0 +1,82 @@
+// Copyright 2025 PickNik Inc.
+// All rights reserved.
+//
+// Unauthorized copying of this code base via any medium is strictly prohibited.
+// Proprietary and confidential.
+
+#include <convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped.hpp>
+
+#include <behaviortree_cpp/basic_types.h>
+#include <behaviortree_cpp/tree_node.h>
+
+#include "spdlog/spdlog.h"
+#include "moveit_pro_behavior_interface/get_required_ports.hpp"
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+namespace
+{
+constexpr auto kPortIDPoseStamped = "pose_stamped";
+constexpr auto kPortIDTransformStamped = "transform_stamped";
+constexpr auto kPortIDChildFrameId = "child_frame_id";
+}  // namespace
+
+namespace convert_pose_stamped_to_transform_stamped
+{
+
+ConvertPoseStampedToTransformStamped::ConvertPoseStampedToTransformStamped(
+    const std::string& name, const BT::NodeConfiguration& config,
+    const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList ConvertPoseStampedToTransformStamped::providedPorts()
+{
+  return BT::PortsList(
+      { BT::InputPort<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped, "{pose_stamped}",
+                                                       "The geometry_msgs::msg::PoseStamped message to convert."),
+        BT::InputPort<std::string>(kPortIDChildFrameId, "child_frame",
+                                   "The child frame ID to set in the TransformStamped message."),
+        BT::OutputPort<geometry_msgs::msg::TransformStamped>(kPortIDTransformStamped, "{transform_stamped}",
+                                                             "The converted geometry_msgs::msg::TransformStamped message.") });
+}
+
+BT::KeyValueVector ConvertPoseStampedToTransformStamped::metadata()
+{
+  return { { "description", "Converts a geometry_msgs::msg::PoseStamped message into a "
+                            "geometry_msgs::msg::TransformStamped message." },
+           { "subcategory", "Conversions" } };
+}
+
+BT::NodeStatus ConvertPoseStampedToTransformStamped::tick()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(
+      getInput<geometry_msgs::msg::PoseStamped>(kPortIDPoseStamped),
+      getInput<std::string>(kPortIDChildFrameId));
+
+  if (!ports.has_value())
+  {
+    spdlog::warn("Failed to get required value from input data port: {}", ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& [pose_stamped, child_frame_id] = ports.value();
+
+  geometry_msgs::msg::TransformStamped transform_out;
+  transform_out.header = pose_stamped.header;
+  transform_out.child_frame_id = child_frame_id;
+  
+  // Convert the pose to transform
+  transform_out.transform.translation.x = pose_stamped.pose.position.x;
+  transform_out.transform.translation.y = pose_stamped.pose.position.y;
+  transform_out.transform.translation.z = pose_stamped.pose.position.z;
+  transform_out.transform.rotation = pose_stamped.pose.orientation;
+
+  setOutput(kPortIDTransformStamped, transform_out);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+}  // namespace convert_pose_stamped_to_transform_stamped

--- a/src/convert_pose_stamped_to_transform_stamped/src/register_behaviors.cpp
+++ b/src/convert_pose_stamped_to_transform_stamped/src/register_behaviors.cpp
@@ -1,0 +1,24 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <convert_pose_stamped_to_transform_stamped/convert_pose_stamped_to_transform_stamped.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace convert_pose_stamped_to_transform_stamped
+{
+class ConvertPoseStampedToTransformStampedBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(BT::BehaviorTreeFactory& factory,
+    [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<ConvertPoseStampedToTransformStamped>(factory, "ConvertPoseStampedToTransformStamped", shared_resources);
+    
+  }
+};
+}  // namespace convert_pose_stamped_to_transform_stamped
+
+PLUGINLIB_EXPORT_CLASS(convert_pose_stamped_to_transform_stamped::ConvertPoseStampedToTransformStampedBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/convert_pose_stamped_to_transform_stamped/test/CMakeLists.txt
+++ b/src/convert_pose_stamped_to_transform_stamped/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+
+ament_add_ros_isolated_gtest(test_behavior_plugins test_behavior_plugins.cpp)
+ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/convert_pose_stamped_to_transform_stamped/test/test_behavior_plugins.cpp
+++ b/src/convert_pose_stamped_to_transform_stamped/test/test_behavior_plugins.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(BehaviorTests, test_load_behavior_plugins)
+{
+  pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      "moveit_pro_behavior_interface", "moveit_pro::behaviors::SharedResourcesNodeLoaderBase");
+
+  auto node = std::make_shared<rclcpp::Node>("BehaviorTests");
+  auto shared_resources = std::make_shared<moveit_pro::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance = class_loader.createUniqueInstance("convert_pose_stamped_to_transform_stamped::ConvertPoseStampedToTransformStampedBehaviorsLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+
+  // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW(
+    (void)factory.instantiateTreeNode("test_behavior_name", "ConvertPoseStampedToTransformStamped", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/get_odom_instance/CMakeLists.txt
+++ b/src/get_odom_instance/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.22)
+project(get_odom_instance CXX)
+
+find_package(moveit_pro_package REQUIRED)
+moveit_pro_package()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS moveit_pro_behavior_interface pluginlib)
+foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${package} REQUIRED)
+endforeach()
+
+add_library(
+  get_odom_instance
+  SHARED
+  src/get_odom_instance.cpp
+  src/register_behaviors.cpp)
+target_include_directories(
+  get_odom_instance
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(get_odom_instance
+                          ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+# Install Libraries
+install(
+  TARGETS get_odom_instance
+  EXPORT get_odom_instanceTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES
+  DESTINATION include)
+
+if(BUILD_TESTING)
+  moveit_pro_behavior_test(get_odom_instance)
+endif()
+
+# Export the behavior plugins defined in this package so they are available to
+# plugin loaders that load the behavior base class library from the
+# moveit_studio_behavior package.
+pluginlib_export_plugin_description_file(
+  moveit_pro_behavior_interface get_odom_instance_plugin_description.xml)
+
+ament_export_targets(get_odom_instanceTargets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/get_odom_instance/behavior_plugin.yaml
+++ b/src/get_odom_instance/behavior_plugin.yaml
@@ -1,0 +1,4 @@
+objectives:
+  behavior_loader_plugins:
+    get_odom_instance:
+      - "get_odom_instance::GetOdomInstanceBehaviorsLoader"

--- a/src/get_odom_instance/get_odom_instance_plugin_description.xml
+++ b/src/get_odom_instance/get_odom_instance_plugin_description.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<library path="get_odom_instance">
+  <class
+    type="get_odom_instance::GetOdomInstanceBehaviorsLoader"
+    base_class_type="moveit_pro::behaviors::SharedResourcesNodeLoaderBase"
+  />
+</library>

--- a/src/get_odom_instance/include/get_odom_instance/get_odom_instance.hpp
+++ b/src/get_odom_instance/include/get_odom_instance/get_odom_instance.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <optional>
+#include <shared_mutex>
+
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <behaviortree_cpp/action_node.h>
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+
+namespace get_odom_instance
+{
+/**
+ * @brief Subscribes to a single odometry message and publishes it to the blackboard.
+ *
+ * The behavior exits successfully after the first message is received.
+ */
+class GetOdomInstance : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  GetOdomInstance(const std::string& name, const BT::NodeConfiguration& config,
+                  const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+  static BT::KeyValueVector metadata();
+
+private:
+  /** @brief Called once when the behavior starts. Sets up the subscription. */
+  BT::NodeStatus onStart() override;
+
+  /**
+   * @brief Called while the behavior is running.
+   * @return RUNNING until an odometry message is received, then SUCCESS.
+   */
+  BT::NodeStatus onRunning() override;
+
+  /** @brief Called when the behavior is halted. Cleans up the subscription. */
+  void onHalted() override;
+
+  /** @brief Subscriber for the odom topic. */
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_subscriber_;
+
+  /** @brief Mutex for thread-safe access to odometry data. */
+  std::shared_mutex odom_mutex_;
+
+  /** @brief Latest received odometry message, if any. */
+  std::optional<nav_msgs::msg::Odometry> current_odometry_;
+
+  std::string odom_topic_name_;
+};
+
+}  // namespace get_odom_instance

--- a/src/get_odom_instance/package.xml
+++ b/src/get_odom_instance/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package format="3">
+  <name>get_odom_instance</name>
+  <version>0.0.0</version>
+  <description>
+    Gets the most recent odom message, saves to blackboard, then exits.
+  </description>
+
+  <maintainer email="support@picknik.ai">MoveIt Pro User</maintainer>
+  <author email="support@picknik.ai">MoveIt Pro User</author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_pro_package</build_depend>
+
+  <depend>moveit_pro_behavior_interface</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+  <buildtool_depend>python3-colcon-common-extensions</buildtool_depend>
+</package>

--- a/src/get_odom_instance/src/get_odom_instance.cpp
+++ b/src/get_odom_instance/src/get_odom_instance.cpp
@@ -1,0 +1,98 @@
+#include <get_odom_instance/get_odom_instance.hpp>
+
+#include <nav_msgs/msg/odometry.hpp>
+
+#include "fmt/format.h"
+
+#include "moveit_pro_behavior_interface/get_required_ports.hpp"
+#include "moveit_pro_behavior_interface/metadata_fields.hpp"
+
+namespace get_odom_instance
+{
+
+constexpr auto kPortIdOdomTopicName = "odom_topic_name";
+constexpr auto kPortIdOdomValue = "subscribed_odom_instance";
+
+GetOdomInstance::GetOdomInstance(const std::string& name, const BT::NodeConfiguration& config,
+                                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+  odom_subscriber_ = shared_resources_->node->create_subscription<nav_msgs::msg::Odometry>(
+      "odom",  // temporary default; overridden in onStart if needed
+      rclcpp::SystemDefaultsQoS(), [this](const nav_msgs::msg::Odometry::SharedPtr msg) {
+        std::unique_lock<std::shared_mutex> lock(odom_mutex_);
+        current_odometry_ = *msg;
+      });
+}
+
+BT::PortsList GetOdomInstance::providedPorts()
+{
+  return { BT::InputPort<std::string>(kPortIdOdomTopicName, "odom",
+                                      "The name of the nav_msgs::msg::Odometry topic to subscribe to."),
+           BT::OutputPort<nav_msgs::msg::Odometry>(kPortIdOdomValue, "{subscribed_odom_instance}",
+                                                   "Subscribed odometry message.") };
+}
+
+BT::KeyValueVector GetOdomInstance::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "User Created Behaviors" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey,
+             "Subscribe to a single odometry message and store it on the blackboard." } };
+}
+
+BT::NodeStatus GetOdomInstance::onStart()
+{
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdOdomTopicName));
+
+  if (!ports)
+  {
+    shared_resources_->logger->publishFailureMessage(name(), ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+
+  const auto& [odom_topic_name] = ports.value();
+
+  // Recreate subscriber only if topic changed
+  if (!odom_subscriber_ || odom_topic_name != odom_topic_name_)
+  {
+    odom_topic_name_ = odom_topic_name;
+    odom_subscriber_ = shared_resources_->node->create_subscription<nav_msgs::msg::Odometry>(
+        odom_topic_name_, rclcpp::SystemDefaultsQoS(), [this](const nav_msgs::msg::Odometry::SharedPtr msg) {
+          std::unique_lock<std::shared_mutex> lock(odom_mutex_);
+          current_odometry_ = *msg;
+        });
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetOdomInstance::onRunning()
+{
+  std::optional<nav_msgs::msg::Odometry> odom_copy;
+
+  {
+    std::shared_lock<std::shared_mutex> lock(odom_mutex_);
+    if (!current_odometry_)
+    {
+      return BT::NodeStatus::RUNNING;
+    }
+    odom_copy = current_odometry_;
+  }
+
+  setOutput(kPortIdOdomValue, *odom_copy);
+
+  // Stop listening — snapshot behavior
+  odom_subscriber_.reset();
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+void GetOdomInstance::onHalted()
+{
+  odom_subscriber_.reset();
+
+  std::unique_lock<std::shared_mutex> lock(odom_mutex_);
+  current_odometry_.reset();
+}
+
+}  // namespace get_odom_instance

--- a/src/get_odom_instance/src/register_behaviors.cpp
+++ b/src/get_odom_instance/src/register_behaviors.cpp
@@ -1,0 +1,24 @@
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/behavior_context.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+
+#include <get_odom_instance/get_odom_instance.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+namespace get_odom_instance
+{
+class GetOdomInstanceBehaviorsLoader : public moveit_pro::behaviors::SharedResourcesNodeLoaderBase
+{
+public:
+  void registerBehaviors(
+      BT::BehaviorTreeFactory& factory,
+      [[maybe_unused]] const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
+  {
+    moveit_pro::behaviors::registerBehavior<GetOdomInstance>(factory, "GetOdomInstance", shared_resources);
+  }
+};
+}  // namespace get_odom_instance
+
+PLUGINLIB_EXPORT_CLASS(get_odom_instance::GetOdomInstanceBehaviorsLoader,
+                       moveit_pro::behaviors::SharedResourcesNodeLoaderBase);

--- a/src/get_odom_instance/test/CMakeLists.txt
+++ b/src/get_odom_instance/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+
+ament_add_ros_isolated_gtest(test_behavior_plugins test_behavior_plugins.cpp)
+ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/get_odom_instance/test/test_behavior_plugins.cpp
+++ b/src/get_odom_instance/test/test_behavior_plugins.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/node.hpp>
+
+/**
+ * @brief This test makes sure that the Behaviors provided in this package can be successfully registered and
+ * instantiated by the behavior tree factory.
+ */
+TEST(BehaviorTests, test_load_behavior_plugins)
+{
+  pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase> class_loader(
+      "moveit_pro_behavior_interface", "moveit_pro::behaviors::SharedResourcesNodeLoaderBase");
+
+  auto node = std::make_shared<rclcpp::Node>("BehaviorTests");
+  auto shared_resources = std::make_shared<moveit_pro::behaviors::BehaviorContext>(node);
+
+  BT::BehaviorTreeFactory factory;
+  {
+    auto plugin_instance = class_loader.createUniqueInstance("get_odom_instance::GetOdomInstanceBehaviorsLoader");
+    ASSERT_NO_THROW(plugin_instance->registerBehaviors(factory, shared_resources));
+  }
+
+  // Test that ClassLoader is able to find and instantiate each behavior using the package's plugin description info.
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "GetOdomInstance", BT::NodeConfiguration()));
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/lab_sim/objectives/convertposestampedtovectors.xml
+++ b/src/lab_sim/objectives/convertposestampedtovectors.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="ConvertPoseStampedToVectors">
+  <!--//////////-->
+  <BehaviorTree ID="ConvertPoseStampedToVectors">
+    <Control
+      ID="Sequence"
+      name="Extract PoseStamped point and quaternion into vectors"
+    >
+      <Action ID="UnpackPoseStampedMessage" pose_stamped="{pose_stamped}" />
+      <Action
+        ID="UnpackPoseMessage"
+        position="{point}"
+        orientation="{quaternion}"
+        pose="{pose}"
+      />
+      <Action ID="UnpackPointMessage" x="{x}" />
+      <Action ID="ResetVector" vector="{vec_position}" />
+      <Action
+        ID="InsertInVector"
+        index="0"
+        input_vector="{vec_position}"
+        output_vector="{vec_position}"
+        element="{x}"
+      />
+      <Action
+        ID="InsertInVector"
+        index="1"
+        input_vector="{vec_position}"
+        output_vector="{vec_position}"
+        element="{y}"
+      />
+      <Action
+        ID="InsertInVector"
+        index="2"
+        input_vector="{vec_position}"
+        output_vector="{vec_position}"
+        element="{z}"
+      />
+      <Action
+        ID="UnpackQuaternionMessage"
+        w="{qw}"
+        x="{qx}"
+        y="{qy}"
+        z="{qz}"
+      />
+      <Action ID="ResetVector" vector="{vec_quaternion}" />
+      <Action
+        ID="InsertInVector"
+        output_vector="{vec_quaternion}"
+        input_vector="{vec_quaternion}"
+        index="0"
+        element="{qx}"
+      />
+      <Action
+        ID="InsertInVector"
+        output_vector="{vec_quaternion}"
+        input_vector="{vec_quaternion}"
+        index="1"
+        element="{qy}"
+      />
+      <Action
+        ID="InsertInVector"
+        output_vector="{vec_quaternion}"
+        input_vector="{vec_quaternion}"
+        index="2"
+        element="{qz}"
+      />
+      <Action
+        ID="InsertInVector"
+        output_vector="{vec_quaternion}"
+        input_vector="{vec_quaternion}"
+        index="3"
+        element="{qw}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="ConvertPoseStampedToVectors">
+      <MetadataFields>
+        <Metadata runnable="false" />
+        <Metadata subcategory="Conversion" />
+      </MetadataFields>
+      <inout_port name="vec_quaternion" default="{vec_quaternion}">
+        Output vector of xyzw quaternion
+      </inout_port>
+      <inout_port name="vec_position" default="{vec_position}">
+        Output vector of xyz positions
+      </inout_port>
+      <inout_port
+        name="pose_stamped"
+        default="{pose_stamped}"
+        type="geometry_msgs::msg::PoseStamped"
+      >
+        Input PoseStamped
+      </inout_port>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/transform_quest_frame.xml
+++ b/src/lab_sim/objectives/transform_quest_frame.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Transform Quest Frame">
+  <BehaviorTree
+    ID="Transform Quest Frame"
+    _description="This objective outputs the transformation from the end effector to an odom instance (right_controller_odom)"
+  >
+    <Control ID="Sequence">
+      <!--Get initial controller pose in quest frame (C₀)-->
+      <Action
+        ID="GetOdomInstance"
+        odom_topic_name="right_controller_odom"
+        subscribed_odom_instance="{controller_odom_at_calibration}"
+      />
+      <Action
+        ID="ConvertOdomToPoseStamped"
+        odometry="{controller_odom_at_calibration}"
+        pose_stamped="{controller_pose_at_calibration}"
+      />
+      <!--Get initial EE pose in world frame (E₀)-->
+      <SubTree
+        ID="Get Transform Frame Pose"
+        requested_frame="grasp_link"
+        requested_pose="{ee_pose_at_calibration}"
+      />
+      <!--Visualize both initial poses-->
+      <Action
+        ID="VisualizePose"
+        pose="{ee_pose_at_calibration}"
+        marker_text="EE"
+        marker_name="init_ee_pose"
+        _skipIf="true"
+      />
+      <Action
+        ID="VisualizePose"
+        marker_name="init_controller_pose"
+        marker_text="IC"
+        pose="{controller_pose_at_calibration}"
+      />
+      <!--Calculate offset from Controller to EE (this gives us quest→world transform)-->
+      <!--At calibration: controller and EE are at same physical location-->
+      <!--So: T_quest_to_world ≈ E₀ - C₀ (treating positions as vectors)-->
+      <Action
+        ID="CalculatePoseOffset"
+        source_pose="{controller_pose_at_calibration}"
+        destination_pose="{ee_pose_at_calibration}"
+        source_to_destination_pose="{quest_to_world_offset}"
+      />
+      <!--Convert the offset pose to vectors (bypasses frame_id checking)-->
+      <SubTree
+        ID="ConvertPoseStampedToVectors"
+        pose_stamped="{quest_to_world_offset}"
+        vec_position="{offset_position}"
+        vec_quaternion="{offset_quaternion}"
+      />
+      <!--Apply the transform to controller pose to verify it aligns with EE-->
+      <Action
+        ID="TransformPose"
+        input_pose="{controller_pose_at_calibration}"
+        translation_xyz="{offset_position}"
+        quaternion_xyzw="{offset_quaternion}"
+        output_pose="{transformed_controller_pose}"
+      />
+      <!--Visualize transformed pose - should align with EE-->
+      <Action
+        ID="VisualizePose"
+        pose="{transformed_controller_pose}"
+        marker_text="ITP"
+        marker_name="initial_transformed_pose"
+        marker_size="0.100000"
+        _skipIf="true"
+      />
+      <!--Extract header from EE pose (has frame_id="world") and pose from offset-->
+      <Action
+        ID="UnpackPoseStampedMessage"
+        pose_stamped="{ee_pose_at_calibration}"
+        header="{world_header}"
+        pose="{ee_pose}"
+      />
+      <Action
+        ID="UnpackPoseStampedMessage"
+        pose_stamped="{quest_to_world_offset}"
+        header="{offset_header}"
+        pose="{offset_pose}"
+      />
+      <!--Create PoseStamped with world frame header and the offset pose-->
+      <Action
+        ID="CreatePoseStampedMessage"
+        pose="{offset_pose}"
+        header="{world_header}"
+        pose_stamped="{quest_to_world_pose}"
+      />
+      <Action
+        ID="PublishStaticFrame"
+        pose="{quest_to_world_pose}"
+        child_frame_id="quest"
+        _skipIf="true"
+      />
+      <Action
+        ID="ConvertPoseStampedToTransformStamped"
+        pose_stamped="{quest_to_world_pose}"
+        child_frame_id="quest"
+        transform_stamped="{quest_to_world_transform}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Transform Quest Frame">
+      <inout_port
+        name="initial_controller_pose"
+        default="{controller_pose_at_calibration}"
+        type="geometry_msgs::msg::PoseStamped"
+      />
+      <inout_port
+        name="initial_ee_pose"
+        default="{ee_pose_at_calibration}"
+        type="geometry_msgs::msg::PoseStamped"
+      />
+      <inout_port
+        name="quest_to_world_transform"
+        default="{quest_to_world_transform}"
+        type="geometry_msgs::msg::TransformStamped"
+      />
+      <inout_port
+        name="transformed_controller_pose"
+        default="{transformed_controller_pose}"
+        type="geometry_msgs::msg::PoseStamped"
+      />
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/visualize_quest_transform.xml
+++ b/src/lab_sim/objectives/visualize_quest_transform.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Visualize Quest Transform">
+  <!---->
+  <BehaviorTree ID="Visualize Quest Transform">
+    <Control ID="Sequence">
+      <!--Get initial transform from Quest controller to robot end effector-->
+      <SubTree ID="Transform Quest Frame" _autoremap="true" />
+      <!--Transform ITP (initial transformed pose) to world frame-->
+      <Action
+        ID="TransformPoseFrame"
+        input_pose="{transformed_controller_pose}"
+        output_pose="{transformed_controller_pose_world}"
+        target_frame_id="world"
+      />
+      <!--Unpack ITP to get position and header-->
+      <Action
+        ID="UnpackPoseStampedMessage"
+        pose_stamped="{transformed_controller_pose_world}"
+        pose="{itp_pose}"
+        header="{itp_header}"
+      />
+      <Action
+        ID="UnpackPoseMessage"
+        pose="{itp_pose}"
+        position="{itp_position}"
+        orientation="{itp_orientation}"
+      />
+      <!--Unpack ITP position to individual components for later addition-->
+      <Action
+        ID="UnpackPointMessage"
+        point="{itp_position}"
+        x="{itp_x}"
+        y="{itp_y}"
+        z="{itp_z}"
+      />
+      <!--Create identity quaternion (no rotation: x=0, y=0, z=0, w=1)-->
+      <Action
+        ID="CreateQuaternionMessage"
+        x="0.0"
+        y="0.0"
+        z="0.0"
+        w="1.0"
+        quaternion="{identity_quaternion}"
+      />
+      <!--Create new pose with ITP position but identity rotation-->
+      <Action
+        ID="CreatePoseMessage"
+        position="{itp_position}"
+        orientation="{identity_quaternion}"
+        pose="{itp_pose_no_rotation}"
+      />
+      <Action
+        ID="CreatePoseStampedMessage"
+        pose="{itp_pose_no_rotation}"
+        header="{itp_header}"
+        pose_stamped="{itp_no_rotation}"
+      />
+      <!--Visualize ITP before entering loop-->
+      <Action
+        ID="VisualizePose"
+        pose="{itp_no_rotation}"
+        marker_name="ITP"
+        marker_text="ITP"
+        marker_size="0.05"
+        _skipIf="true"
+      />
+      <!--Transform initial controller pose to world frame for delta calculation-->
+      <Action
+        ID="TransformPoseFrame"
+        input_pose="{controller_pose_at_calibration}"
+        output_pose="{controller_pose_at_calibration_world}"
+        target_frame_id="world"
+      />
+      <!--Continuously get controller pose and visualize transformed result-->
+      <Decorator ID="KeepRunningUntilFailure">
+        <Control ID="Sequence">
+          <!--Get single odom instance and convert to PoseStamped-->
+          <Action
+            ID="GetOdomInstance"
+            odom_topic_name="right_controller_odom"
+            subscribed_odom_instance="{odometry}"
+          />
+          <Action
+            ID="ConvertOdomToPoseStamped"
+            odometry="{odometry}"
+            pose_stamped="{current_controller_pose}"
+          />
+          <!--Transform current controller pose to world frame-->
+          <Action
+            ID="TransformPoseFrame"
+            input_pose="{current_controller_pose}"
+            output_pose="{current_controller_pose_world}"
+            target_frame_id="world"
+          />
+          <!--Calculate movement delta in world frame-->
+          <Action
+            ID="CalculatePoseOffset"
+            source_pose="{controller_pose_at_calibration_world}"
+            destination_pose="{current_controller_pose_world}"
+            source_to_destination_pose="{controller_movement_delta_world}"
+          />
+          <!--Unpack delta to get translation and rotation separately-->
+          <Action
+            ID="UnpackPoseStampedMessage"
+            pose_stamped="{controller_movement_delta_world}"
+            pose="{delta_pose}"
+            header="{delta_header}"
+          />
+          <Action
+            ID="UnpackPoseMessage"
+            pose="{delta_pose}"
+            position="{delta_position}"
+            orientation="{delta_orientation}"
+          />
+          <Action
+            ID="UnpackPointMessage"
+            point="{delta_position}"
+            x="{delta_x}"
+            y="{delta_y}"
+            z="{delta_z}"
+          />
+          <Action
+            ID="UnpackQuaternionMessage"
+            quaternion="{delta_orientation}"
+            x="{delta_qx}"
+            y="{delta_qy}"
+            z="{delta_qz}"
+            w="{delta_qw}"
+          />
+          <!--=== AXIS REMAPPING ===-->
+          <!--Translation remapping: Swap/negate axes as needed-->
+          <!--Current: controller forward->sideways, so swap x and y-->
+          <!--Adjust signs (-) as needed to fix direction-->
+          <Action
+            ID="Script"
+            code="remapped_x := delta_y; remapped_y := delta_x; remapped_z := delta_z"
+          />
+          <!--Rotation remapping: Swap quaternion components to fix pitch/roll swap-->
+          <!--qx=roll, qy=pitch, qz=yaw-->
+          <!--To flip pitch direction: negate both the pitch component AND qw-->
+          <Action
+            ID="Script"
+            code="remapped_qx := delta_qy; remapped_qy := delta_qx; remapped_qz := -delta_qz; remapped_qw := -delta_qw"
+          />
+          <!--=== END AXIS REMAPPING ===-->
+          <!--Add remapped delta translation to ITP position-->
+          <Action
+            ID="Script"
+            code="target_x := itp_x + remapped_x; target_y := itp_y + remapped_y; target_z := itp_z + remapped_z"
+          />
+          <!--Create target position from added values-->
+          <Action
+            ID="CreatePointMessage"
+            x="{target_x}"
+            y="{target_y}"
+            z="{target_z}"
+            point="{target_position}"
+          />
+          <!--Create remapped quaternion-->
+          <Action
+            ID="CreateQuaternionMessage"
+            x="{remapped_qx}"
+            y="{remapped_qy}"
+            z="{remapped_qz}"
+            w="{remapped_qw}"
+            quaternion="{target_orientation}"
+          />
+          <!--Build final pose: translated position + remapped rotation-->
+          <Action
+            ID="CreatePoseMessage"
+            position="{target_position}"
+            orientation="{target_orientation}"
+            pose="{target_pose}"
+          />
+          <Action
+            ID="CreatePoseStampedMessage"
+            pose="{target_pose}"
+            header="{itp_header}"
+            pose_stamped="{target_controller_pose}"
+          />
+          <!--Visualize the target controller pose-->
+          <Action
+            ID="VisualizePose"
+            pose="{target_controller_pose}"
+            marker_name="TC"
+            marker_text="TC"
+            marker_size="0.05"
+          />
+        </Control>
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Visualize Quest Transform" />
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
This PR makes 2 new exciting objectives:

Visualize Quest Transform: shows basically what the transformed controller pose will look like
Transform Quest Frame: which is a subtree you need inside visualize quest transform
There are some important new custom behaviors we use in here, like GetOdomInstance which just listens to the desired topic and exits successfully after receiving a single odom message on that topic (making it accessible on the blackboard) instead of GetOdom which runs forever, and convert odom to pose stamped is also important.