### PR TITLE
Add objective integration tests for all example_ws configs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,37 @@ on:
     - cron: "0 */6 * * 1-5"
 
 jobs:
+  # Lint and non-integration tests for all packages
   integration-test-in-studio-container:
     uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.0.7
     with:
       image_tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+      colcon_test_args: "--executor sequential"
+    secrets:
+      moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
+
+  # Per-config objective integration tests (run in parallel via matrix)
+  objective-integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        config_package:
+          - lab_sim
+          - kitchen_sim
+          - april_tag_sim
+          - grinding_sim
+          - dual_arm_sim
+          - factory_sim
+          - hangar_sim
+          - kinova_sim
+          - space_satellite_sim
+          - space_satellite_sim_camera_cal
+          - mock_sim
+          - multi_arm_sim
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.0.6
+    with:
+      image_tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+      config_package: ${{ matrix.config_package }}
       colcon_test_args: "--executor sequential"
     secrets:
       moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}

--- a/src/april_tag_sim/CMakeLists.txt
+++ b/src/april_tag_sim/CMakeLists.txt
@@ -28,8 +28,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=april_tag_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/april_tag_sim/package.xml
+++ b/src/april_tag_sim/package.xml
@@ -28,7 +28,9 @@
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/april_tag_sim/test/objectives_integration_test.py
+++ b/src/april_tag_sim/test/objectives_integration_test.py
@@ -1,0 +1,57 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring AprilTag camera perception (no simulated camera feed in CI)
+skip_objectives = {
+    "Pick April Tag Labeled Object",  # Requires AprilTag detection + camera
+    "Collect Angled AprilTag Detection Data",  # Requires camera feed
+    "Collect AprilTag Detection Data",  # Requires camera feed
+    "Collect Parallel AprilTag Detection Data",  # Requires camera feed
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("april_tag_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/dual_arm_sim/CMakeLists.txt
+++ b/src/dual_arm_sim/CMakeLists.txt
@@ -15,8 +15,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=dual_arm_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/dual_arm_sim/package.xml
+++ b/src/dual_arm_sim/package.xml
@@ -20,8 +20,10 @@
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
 
   <export>

--- a/src/dual_arm_sim/test/objectives_integration_test.py
+++ b/src/dual_arm_sim/test/objectives_integration_test.py
@@ -1,0 +1,54 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or ML/GPU inference
+skip_objectives = {
+    "Teleoperate",  # Requires user teleoperation input
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("dual_arm_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/factory_sim/CMakeLists.txt
+++ b/src/factory_sim/CMakeLists.txt
@@ -31,8 +31,13 @@ install(DIRECTORY "${PICKNIK_ACCESSORIES_PATH}"
         FILES_MATCHING PATTERN "*")
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=factory_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/factory_sim/package.xml
+++ b/src/factory_sim/package.xml
@@ -20,7 +20,9 @@
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/factory_sim/test/objectives_integration_test.py
+++ b/src/factory_sim/test/objectives_integration_test.py
@@ -1,0 +1,57 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or ML/GPU inference
+skip_objectives = {
+    "Automask from File",  # Requires ML segmentation model
+    "Automask from Camera",  # Requires ML segmentation model + camera
+    "Automask Camera Iterate Masks",  # Requires ML segmentation model + camera
+    "Pick and Place Brackets from Left Bin",  # Requires ML perception pipeline
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("factory_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/grinding_sim/CMakeLists.txt
+++ b/src/grinding_sim/CMakeLists.txt
@@ -25,8 +25,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=grinding_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/grinding_sim/package.xml
+++ b/src/grinding_sim/package.xml
@@ -20,7 +20,9 @@
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/grinding_sim/test/objectives_integration_test.py
+++ b/src/grinding_sim/test/objectives_integration_test.py
@@ -1,0 +1,54 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or perception hardware
+skip_objectives = {
+    "Grind Machined Part",  # Requires admittance control user interaction
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("grinding_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -32,8 +32,13 @@ install(IMPORTED_RUNTIME_ARTIFACTS moveit_studio_plugins::dummy_controller_handl
         lib)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=hangar_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -29,7 +29,9 @@
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -1,0 +1,59 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or ML/GPU inference
+skip_objectives = {
+    "Count Boxes",  # Requires ML segmentation
+    "ML Move Boxes to Loading Zone",  # Requires ML segmentation
+    "Segment Image from Point",  # Requires clicked point + ML segmentation
+    "Segment Image from Text Prompt",  # Requires ML segmentation
+    "Segment Point Cloud from Clicked Point",  # Requires clicked point + ML segmentation
+    "Verify Box Count",  # Requires ML segmentation (calls Count Boxes)
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("hangar_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/kitchen_sim/CMakeLists.txt
+++ b/src/kitchen_sim/CMakeLists.txt
@@ -15,8 +15,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=kitchen_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/kitchen_sim/package.xml
+++ b/src/kitchen_sim/package.xml
@@ -20,8 +20,10 @@
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
 
   <export>

--- a/src/kitchen_sim/test/objectives_integration_test.py
+++ b/src/kitchen_sim/test/objectives_integration_test.py
@@ -1,0 +1,58 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input (clicked point) or ML/GPU inference
+skip_objectives = {
+    "Segment Point Cloud from Point",  # Requires clicked point + ML segmentation
+    "Grasp Object from Point",  # Requires clicked point + ML segmentation
+    "Generate Graspable Object",  # Requires ML segmentation
+    "Segment Image from Point",  # Requires clicked point + ML segmentation
+    "Segment Image from Prompt",  # Requires ML segmentation
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("kitchen_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/lab_sim/package.xml
+++ b/src/lab_sim/package.xml
@@ -30,7 +30,9 @@
   <exec_depend>velocity_force_controller</exec_depend>
   <exec_depend>lab_sim_behaviors</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/moveit_pro_kinova_configs/kinova_sim/CMakeLists.txt
+++ b/src/moveit_pro_kinova_configs/kinova_sim/CMakeLists.txt
@@ -16,8 +16,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=kinova_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/moveit_pro_kinova_configs/kinova_sim/package.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/package.xml
@@ -22,6 +22,9 @@
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/moveit_pro_kinova_configs/kinova_sim/test/objectives_integration_test.py
+++ b/src/moveit_pro_kinova_configs/kinova_sim/test/objectives_integration_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or ML/GPU inference
+skip_objectives = {
+    "April Tag Object Registration",  # Requires AprilTag detection + camera
+    "Demo Trajectory Stitching",  # Requires user interaction for trajectory recording
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("kinova_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/CMakeLists.txt
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/CMakeLists.txt
@@ -26,8 +26,13 @@ install(DIRECTORY "${PICKNIK_ACCESSORIES_SHARE_DIR}"
         FILES_MATCHING PATTERN "*")
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=space_satellite_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/package.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/package.xml
@@ -27,6 +27,9 @@
   <exec_depend>robotiq_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/test/objectives_integration_test.py
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/test/objectives_integration_test.py
@@ -1,0 +1,56 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input or ML/GPU inference
+skip_objectives = {
+    "Grapple Moving Satellite via Fiducial Tracking",  # Requires AprilTag detection + camera
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params(
+        "space_satellite_sim", cancel_objectives, skip_objectives
+    ),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/CMakeLists.txt
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/CMakeLists.txt
@@ -42,8 +42,13 @@ install(DIRECTORY "${PICKNIK_ACCESSORIES_SHARE_DIR}"
         FILES_MATCHING PATTERN "*")
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=space_satellite_sim_camera_cal MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/package.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/package.xml
@@ -17,6 +17,9 @@
   <depend>space_satellite_sim</depend>
   <depend>apriltag_ros</depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/test/objectives_integration_test.py
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/test/objectives_integration_test.py
@@ -1,0 +1,55 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# No objectives require user input or ML/GPU — all non-runnable ones are already
+# tagged runnable="false" in their XML and will be auto-skipped by the fixture.
+skip_objectives = set()
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params(
+        "space_satellite_sim_camera_cal", cancel_objectives, skip_objectives
+    ),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/moveit_pro_ur_configs/mock_sim/CMakeLists.txt
+++ b/src/moveit_pro_ur_configs/mock_sim/CMakeLists.txt
@@ -16,8 +16,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=mock_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/moveit_pro_ur_configs/mock_sim/package.xml
+++ b/src/moveit_pro_ur_configs/mock_sim/package.xml
@@ -15,6 +15,9 @@
 
   <depend>picknik_ur_base_config</depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/moveit_pro_ur_configs/mock_sim/test/objectives_integration_test.py
+++ b/src/moveit_pro_ur_configs/mock_sim/test/objectives_integration_test.py
@@ -1,0 +1,52 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# No objectives require user input or ML/GPU in mock_sim.
+skip_objectives = set()
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("mock_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)

--- a/src/moveit_pro_ur_configs/multi_arm_sim/CMakeLists.txt
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/CMakeLists.txt
@@ -15,8 +15,13 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=multi_arm_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
 endif()
 
 ament_package()

--- a/src/moveit_pro_ur_configs/multi_arm_sim/package.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/package.xml
@@ -23,7 +23,9 @@
   <exec_depend>robotiq_controllers</exec_depend>
   <exec_depend>ur_description</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>

--- a/src/moveit_pro_ur_configs/multi_arm_sim/test/objectives_integration_test.py
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/test/objectives_integration_test.py
@@ -1,0 +1,54 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    run_objective,
+)
+
+cancel_objectives = set()
+
+# Objectives requiring user input
+skip_objectives = {
+    "Teleoperate",  # Requires user teleoperation input
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("multi_arm_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    run_objective(objective_id, should_cancel, execute_objective_resource)


### PR DESCRIPTION
## Summary
- Add `objectives_integration_test.py` to 11 config packages (kitchen_sim, april_tag_sim, grinding_sim, dual_arm_sim, factory_sim, hangar_sim, kinova_sim, space_satellite_sim, space_satellite_sim_camera_cal, mock_sim, multi_arm_sim)
- Each test auto-discovers objectives via `SystemConfigParser` and runs them with per-config skip lists for user-input/ML/GPU objectives
- New objectives are automatically tested — if one requires skipping, CI fails and the PR author adds it to the skip list (fail-safe design)
- Add CI matrix job to run each config's tests in parallel via the existing `workspace_integration_test` reusable workflow
- Add missing `ament_cmake_pytest` + `moveit_pro_test_utils` test deps across all configs (including existing lab_sim)

## Known TODOs
- [ ] Skip lists are best-guess based on objective names/XML analysis — need to validate with actual CI runs
- [ ] The existing `integration-test-in-studio-container` job still runs all tests including these, causing double-runs. Consider adding `--packages-skip` for config packages to that job
- [ ] 600s timeout may need tuning for configs with many objectives (e.g. lab_sim has 80)
- [ ] Cancel objectives sets are empty for new configs — looping objectives may need to be identified and added

## Test plan
- [x] All 12 test files parse correctly with valid Python syntax
- [x] Skip list objective IDs verified against actual `main_tree_to_execute` XML attributes — all match
- [x] CMakeLists.txt and package.xml changes follow existing lab_sim pattern
- [ ] Run integration tests for mock_sim (simplest, no skips) to validate end-to-end
- [ ] Run integration tests for a config with skips (e.g. kitchen_sim) to validate skip behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)