### PR TITLE
Add replanning objective and dual-lidar nav2 integration for ur5e_ridgeback

### DIFF
--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -3,6 +3,16 @@
   <xacro:macro name="picknik_ur_mujoco_ros2_control" params="mujoco_model mujoco_viewer:=false">
 
     <ros2_control name="ur_mujoco_control" type="system">
+      <!-- Per-LiDAR topic routing. Sensor names match the MJCF site-name prefix
+           (the portion before the '-' in replicated rangefinder site names).
+           Each LiDAR publishes to its own topic so Nav2's obstacle layer can
+           treat them as independent observation sources. -->
+      <sensor name="lidar_front">
+        <param name="topic">/scan_front</param>
+      </sensor>
+      <sensor name="lidar_rear">
+        <param name="topic">/scan_rear</param>
+      </sensor>
       <hardware>
           <plugin>picknik_mujoco_ros/MujocoSystem</plugin>
           <param name="mujoco_model">${mujoco_model}</param>

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -284,16 +284,40 @@ def generate_launch_description():
 
     hangar_sim_pkg = FindPackageShare("hangar_sim")
 
-    # Angular bounds filter: clips chassis self-hitting beams (±93° to ±135°),
-    # publishes clean scan to /scan_filtered for Nav2 costmap.
-    laser_filter_node = Node(
+    # Angular bounds filter: clips chassis self-hitting beams (±93° to ±135°).
+    # One filter instance per lidar; each publishes its filtered scan to
+    # /scan_{front,rear}_filtered for Nav2 to consume as an independent
+    # obstacle observation source.
+    laser_filter_params = PathJoinSubstitution(
+        [hangar_sim_pkg, "params", "laser_filter_params.yaml"]
+    )
+
+    laser_filter_front_node = Node(
         package="laser_filters",
         executable="scan_to_scan_filter_chain",
-        name="laser_angular_filter",
+        name="laser_angular_filter_front",
+        remappings=[
+            ("scan", "/scan_front"),
+            ("scan_filtered", "/scan_front_filtered"),
+        ],
         parameters=[
-            PathJoinSubstitution(
-                [hangar_sim_pkg, "params", "laser_filter_params.yaml"]
-            ),
+            laser_filter_params,
+            {"use_sim_time": use_sim_time},
+            {"qos_overrides./scan.subscription.reliability": "best_effort"},
+        ],
+        output="log",
+    )
+
+    laser_filter_rear_node = Node(
+        package="laser_filters",
+        executable="scan_to_scan_filter_chain",
+        name="laser_angular_filter_rear",
+        remappings=[
+            ("scan", "/scan_rear"),
+            ("scan_filtered", "/scan_rear_filtered"),
+        ],
+        parameters=[
+            laser_filter_params,
             {"use_sim_time": use_sim_time},
             {"qos_overrides./scan.subscription.reliability": "best_effort"},
         ],
@@ -342,7 +366,8 @@ def generate_launch_description():
     ld.add_action(static_tf_world_to_map)
     ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
-    ld.add_action(laser_filter_node)
+    ld.add_action(laser_filter_front_node)
+    ld.add_action(laser_filter_rear_node)
     ld.add_action(fuse_state_estimator)
 
     return ld

--- a/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root
+  BTCPP_format="4"
+  main_tree_to_execute="Navigate to Clicked Point with Replanning"
+>
+  <!--//////////-->
+  <BehaviorTree
+    ID="Navigate to Clicked Point with Replanning"
+    _description="Navigate to a point clicked by the user in the UI. This Objective will repeatedly replan the path as new obstacles appear on the local costmap."
+    _favorite="true"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action
+        ID="CreateStampedPose"
+        reference_frame="base_link"
+        stamped_pose="{start}"
+      />
+      <Action
+        ID="SwitchController"
+        activate_controllers="platform_velocity_controller_nav2"
+        deactivate_controllers="velocity_force_controller;joint_trajectory_controller;platform_velocity_controller"
+      />
+      <Action
+        ID="GetPoseFromUser"
+        is_normal="true"
+        pose_prompt="Click point on UI"
+        user_pose="{goal}"
+        view_name="Visualization"
+      />
+      <Action
+        ID="NavigateToPoseAction"
+        action_name="/navigate_to_pose"
+        behavior_tree_path="/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"
+        pose_stamped="{goal}"
+      />
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Navigate to Clicked Point with Replanning">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Navigation" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/hangar_sim/params/laser_filter_params.yaml
+++ b/src/hangar_sim/params/laser_filter_params.yaml
@@ -1,8 +1,8 @@
 # Angular bounds filter for the dual SICK TIM571 lidars.
 #
-# Both lidars publish to /scan with angle_min=0 and angle_max=4.7124 (270 deg sweep).
-# The lidar _ROS frame X axis points at beam-0, so scan angle alpha maps to robot frame
-# angle (alpha + frame_yaw):
+# Each lidar publishes to its own topic (/scan_front, /scan_rear) with angle_min=0
+# and angle_max=4.7124 (270 deg sweep). The lidar _ROS frame X axis points at beam-0,
+# so scan angle alpha maps to robot frame angle (alpha + frame_yaw):
 #   front lidar frame yaw = -135 deg: robot angle = scan_angle - 135 deg
 #   rear  lidar frame yaw =  +45 deg: robot angle = scan_angle + 45 deg
 #
@@ -10,7 +10,20 @@
 # than 90 deg backward. This maps to scan angles 0-45 deg and 225-270 deg for both lidars.
 # Keeping scan angles 45-225 deg (0.7854 to 3.9270 rad) eliminates all self-hits and
 # gives each lidar a clean 180 deg arc; combined they cover 360 deg.
-laser_angular_filter:
+#
+# Two filter chain instances run, one per lidar, each remapped to its own
+# /scan_{front,rear} input and /scan_{front,rear}_filtered output. Nav2 consumes
+# both filtered topics as independent obstacle observation sources.
+laser_angular_filter_front:
+  ros__parameters:
+    filter1:
+      name: angular_bounds
+      type: laser_filters/LaserScanAngularBoundsFilter
+      params:
+        lower_angle: 0.7854
+        upper_angle: 3.9270
+
+laser_angular_filter_rear:
   ros__parameters:
     filter1:
       name: angular_bounds

--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -241,8 +241,8 @@ local_costmap:
       robot_base_frame: ridgeback_base_link
       use_sim_time: True
       rolling_window: true
-      width: 10
-      height: 10
+      width: 5
+      height: 5
       resolution: 0.05
       footprint: "[[0.45, 0.375], [0.45, -0.375], [-0.45, -0.375], [-0.45, 0.375]]"
       footprint_padding: 0.025
@@ -254,16 +254,29 @@ local_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
+        observation_sources: scan_front scan_rear
+        scan_front:
+          topic: /scan_front_filtered
           max_obstacle_height: 2.0
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 10.0
+          raytrace_max_range: 4.5
           raytrace_min_range: 0.0
-          obstacle_max_range: 8.0
+          obstacle_max_range: 3.5
+          inf_is_valid: false
+          qos_overriding_options:
+            policy_kinds: [reliability]
+            reliability: best_effort
+        scan_rear:
+          topic: /scan_rear_filtered
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 4.5
+          raytrace_min_range: 0.0
+          obstacle_max_range: 3.5
           inf_is_valid: false
           qos_overriding_options:
             policy_kinds: [reliability]
@@ -290,16 +303,30 @@ global_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
+        observation_sources: scan_front scan_rear
+        scan_front:
+          topic: /scan_front_filtered
           max_obstacle_height: 2.0
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 3.0
+          raytrace_max_range: 10.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
+          obstacle_max_range: 8.0
+          obstacle_min_range: 0.0
+          inf_is_valid: false
+          qos_overriding_options:
+            policy_kinds: [reliability]
+            reliability: best_effort
+        scan_rear:
+          topic: /scan_rear_filtered
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 10.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 8.0
           obstacle_min_range: 0.0
           inf_is_valid: false
           qos_overriding_options:


### PR DESCRIPTION
## Summary

- Adds `navigate_to_clicked_point_with_replanning.xml` objective for `ur5e_ridgeback` in `hangar_sim`.
- Objective activates `platform_velocity_controller_nav2` at entry and switches back to `joint_trajectory_controller` at exit, so whole-body planning is the default state after navigation completes (matches the pattern in the sibling `navigate_to_clicked_point.xml`).
- Enables both front and rear SICK TIM571 lidars on `ur5e_ridgeback`, routing each to a per-sensor Nav2 topic (`/scan_front`, `/scan_rear`) via the `<sensor>`-block feature added in PickNikRobotics/moveit_pro#18160.
- Two parallel `scan_to_scan_filter_chain` instances apply `LaserScanAngularBoundsFilter` (0.7854–3.9270 rad) to each scan independently, clipping chassis self-hits. Combined arcs give 360° coverage with no self-return overlap.
- Nav2 obstacle layer (local + global costmaps) uses `scan_front scan_rear` as observation sources.
- Resized the local costmap rolling window from 10 × 10 m to **5 × 5 m** (2.5 m axial, ~3.54 m diagonal).
- Tuned obstacle / raytrace ranges for the TIM571:
  - Local: `obstacle_max_range: 3.5`, `raytrace_max_range: 4.5` — matches the 5 × 5 m rolling window diagonal with a 1 m clearing margin.
  - Global: `obstacle_max_range: 8.0`, `raytrace_max_range: 10.0` — keeps the global planner's horizon comfortably beyond the local window while staying within the sensor's high-confidence range.

## Dependencies

Requires PickNikRobotics/moveit_pro#18160 (per-sensor MuJoCo LiDAR topic configuration). Must merge first.

## Test plan

- [x] Both `/scan_front` and `/scan_rear` publish from MuJoCo.
- [x] `/scan_front_filtered` and `/scan_rear_filtered` combine to cover 360° with no chassis artifacts.
- [x] Nav2 marks obstacles from both lidars around the full robot footprint in both costmaps.
- [x] Global planner uses the global costmap — verified by temporarily disabling the local obstacle_layer and observing that the plan still routes around lidar-detected obstacles that aren't in the static map.
- [x] Rear-lidar-only run verifies the rear pipeline (MJCF → `/scan_rear` → filter → Nav2) works independently.