### PR TITLE
remove changes to platform_vel_controller maintain whole body planning

### DIFF
--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -92,12 +92,12 @@ ros2_control:
     - "force_torque_sensor_broadcaster"
     - "imu_sensor_broadcaster"
     - "joint_state_broadcaster"
-    - "joint_trajectory_controller"
+    - "platform_velocity_controller"
     - "vacuum_gripper"
   # Load but do not start these controllers so they can be activated later if needed.
   controllers_inactive_at_startup:
     - "platform_velocity_controller_nav2"
-    - "platform_velocity_controller"
+    - "joint_trajectory_controller"
     - "velocity_force_controller"
     - "arm_only_velocity_force_controller"
     - "joint_velocity_controller"

--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -37,7 +37,8 @@ platform_velocity_controller:
     interface_name: velocity
     command_joint_names: ["front_left_wheel", "rear_left_wheel", "rear_right_wheel", "front_right_wheel"]
     reference_joint_names: ["linear_x_joint", "linear_y_joint", "rotational_yaw_joint"]
-    body_frame_control: true
+    body_frame_control: false
+    body_frame_yaw_joint: "rotational_yaw_joint"
     front_left_wheel_command_joint_name: "front_left_wheel"
     front_right_wheel_command_joint_name: "front_right_wheel"
     rear_right_wheel_command_joint_name: "rear_right_wheel"
@@ -238,7 +239,7 @@ joint_trajectory_controller:
         ff_velocity_scale: 1.0
     constraints:
       stopped_velocity_tolerance: 0.0
-      goal_time: 5.0
+      goal_time: 0.0
       shoulder_pan_joint:
         goal: 0.05
       shoulder_lift_joint:


### PR DESCRIPTION
I broke whole body during my mecanum tuning testing and left some remanents in the wrong controller pipeline. I reverted those and ensured the robot moves laterally properly again. 

Video of the objective running now:


https://github.com/user-attachments/assets/1f1bd041-b11b-4098-a7cd-dbd6846a0f53

