### PR TITLE
Required Changes for MuJoCo 3.6.0 Upgrade

### DIFF
--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -417,19 +417,13 @@
     <!-- qpos layout: -->
     <!-- robot [joint_1..joint_6] (6) -->
     <!-- shelf freejoint [x y z qw qx qy qz] (7) -->
-    <!-- bracket-0 freejoint (7), bracket-1 freejoint (7), bracket-2 freejoint (7) -->
-    <!-- suction_tool (gripper_base) freejoint (7) -->
-    <!-- inspection_tool freejoint (7) -->
+    <!-- Bracket and tool body positions are set via body pos attributes -->
+    <!-- and replicate offsets, not via keyframe qpos. -->
     <key
       name="default"
       qpos="
         0 0 0 0 0 0
-        0.25 -0.4 0.2301 1 0 0 0
-        -0.42 0.5 0.35 1 0 0 0
-        -0.42 0.56 0.40 1 0 0 0
-        -0.42 0.62 0.45 1 0 0 0
-        0.25 0.08 0.3 0 1 0 0
-        0.25 -0.08 0.3 0 1 0 0"
+        0.25 -0.4 0.2301 1 0 0 0"
       ctrl="0 0 0 0 0 0"
     />
   </keyframe>

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -228,14 +228,552 @@
               pos="0 0 0"
               diaginertia="0.0001 0.0001 0.0001"
             />
-            <replicate count="91" sep="-" offset="0 0 0" euler="0 0 0.05236">
-              <site
-                name="lidar_front"
-                size="0.01"
-                pos="0 0 0"
-                quat="0.2706 0.6533 0.2706 -0.6533"
-              />
-            </replicate>
+            <site
+              name="lidar_front-0"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2706 0.6533 0.2706 -0.6533"
+            />
+            <site
+              name="lidar_front-1"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2876087 0.6459926 0.2876087 -0.6459926"
+            />
+            <site
+              name="lidar_front-2"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3044203 0.6382425 0.3044203 -0.6382425"
+            />
+            <site
+              name="lidar_front-3"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3210233 0.630055 0.3210233 -0.630055"
+            />
+            <site
+              name="lidar_front-4"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3374062 0.6214357 0.3374062 -0.6214357"
+            />
+            <site
+              name="lidar_front-5"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3535579 0.6123904 0.3535579 -0.6123904"
+            />
+            <site
+              name="lidar_front-6"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3694673 0.6029255 0.3694673 -0.6029255"
+            />
+            <site
+              name="lidar_front-7"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3851235 0.5930473 0.3851235 -0.5930473"
+            />
+            <site
+              name="lidar_front-8"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4005157 0.5827627 0.4005157 -0.5827627"
+            />
+            <site
+              name="lidar_front-9"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4156335 0.5720787 0.4156335 -0.5720787"
+            />
+            <site
+              name="lidar_front-10"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4304664 0.5610026 0.4304664 -0.5610026"
+            />
+            <site
+              name="lidar_front-11"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4450042 0.5495421 0.4450042 -0.5495421"
+            />
+            <site
+              name="lidar_front-12"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4592371 0.5377049 0.4592371 -0.5377049"
+            />
+            <site
+              name="lidar_front-13"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4731552 0.5254992 0.4731552 -0.5254992"
+            />
+            <site
+              name="lidar_front-14"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4867491 0.5129333 0.4867491 -0.5129333"
+            />
+            <site
+              name="lidar_front-15"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5000093 0.5000159 0.5000093 -0.5000159"
+            />
+            <site
+              name="lidar_front-16"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5129269 0.4867558 0.5129269 -0.4867558"
+            />
+            <site
+              name="lidar_front-17"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.525493 0.4731621 0.525493 -0.4731621"
+            />
+            <site
+              name="lidar_front-18"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5376989 0.4592441 0.5376989 -0.4592441"
+            />
+            <site
+              name="lidar_front-19"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5495362 0.4450114 0.5495362 -0.4450114"
+            />
+            <site
+              name="lidar_front-20"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.560997 0.4304737 0.560997 -0.4304737"
+            />
+            <site
+              name="lidar_front-21"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5720733 0.415641 0.5720733 -0.415641"
+            />
+            <site
+              name="lidar_front-22"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5827575 0.4005234 0.5827575 -0.4005234"
+            />
+            <site
+              name="lidar_front-23"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5930423 0.3851313 0.5930423 -0.3851313"
+            />
+            <site
+              name="lidar_front-24"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6029206 0.3694752 0.6029206 -0.3694752"
+            />
+            <site
+              name="lidar_front-25"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6123858 0.353566 0.6123858 -0.353566"
+            />
+            <site
+              name="lidar_front-26"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6214312 0.3374144 0.6214312 -0.3374144"
+            />
+            <site
+              name="lidar_front-27"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6300508 0.3210315 0.6300508 -0.3210315"
+            />
+            <site
+              name="lidar_front-28"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6382385 0.3044287 0.6382385 -0.3044287"
+            />
+            <site
+              name="lidar_front-29"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6459889 0.2876172 0.6459889 -0.2876172"
+            />
+            <site
+              name="lidar_front-30"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6532965 0.2706086 0.6532965 -0.2706086"
+            />
+            <site
+              name="lidar_front-31"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6601563 0.2534145 0.6601563 -0.2534145"
+            />
+            <site
+              name="lidar_front-32"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6665637 0.2360467 0.6665637 -0.2360467"
+            />
+            <site
+              name="lidar_front-33"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6725143 0.2185172 0.6725143 -0.2185172"
+            />
+            <site
+              name="lidar_front-34"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.678004 0.2008379 0.678004 -0.2008379"
+            />
+            <site
+              name="lidar_front-35"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.683029 0.183021 0.683029 -0.183021"
+            />
+            <site
+              name="lidar_front-36"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6875859 0.1650786 0.6875859 -0.1650786"
+            />
+            <site
+              name="lidar_front-37"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6916715 0.1470231 0.6916715 -0.1470231"
+            />
+            <site
+              name="lidar_front-38"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6952831 0.1288668 0.6952831 -0.1288668"
+            />
+            <site
+              name="lidar_front-39"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6984182 0.1106222 0.6984182 -0.1106222"
+            />
+            <site
+              name="lidar_front-40"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7010746 0.0923018 0.7010746 -0.0923018"
+            />
+            <site
+              name="lidar_front-41"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7032506 0.0739181 0.7032506 -0.0739181"
+            />
+            <site
+              name="lidar_front-42"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7049445 0.0554838 0.7049445 -0.0554838"
+            />
+            <site
+              name="lidar_front-43"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7061554 0.0370115 0.7061554 -0.0370115"
+            />
+            <site
+              name="lidar_front-44"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7068822 0.0185137 0.7068822 -0.0185137"
+            />
+            <site
+              name="lidar_front-45"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7071246 0.0000033 0.7071246 -0.0000033"
+            />
+            <site
+              name="lidar_front-46"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7068824 -0.0185071 0.7068824 0.0185071"
+            />
+            <site
+              name="lidar_front-47"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7061557 -0.0370048 0.7061557 0.0370048"
+            />
+            <site
+              name="lidar_front-48"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7049451 -0.0554772 0.7049451 0.0554772"
+            />
+            <site
+              name="lidar_front-49"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7032513 -0.0739115 0.7032513 0.0739115"
+            />
+            <site
+              name="lidar_front-50"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.7010755 -0.0922952 0.7010755 0.0922952"
+            />
+            <site
+              name="lidar_front-51"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6984192 -0.1106156 0.6984192 0.1106156"
+            />
+            <site
+              name="lidar_front-52"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6952843 -0.1288602 0.6952843 0.1288602"
+            />
+            <site
+              name="lidar_front-53"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6916729 -0.1470166 0.6916729 0.1470166"
+            />
+            <site
+              name="lidar_front-54"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6875874 -0.1650721 0.6875874 0.1650721"
+            />
+            <site
+              name="lidar_front-55"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6830307 -0.1830145 0.6830307 0.1830145"
+            />
+            <site
+              name="lidar_front-56"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6780059 -0.2008315 0.6780059 0.2008315"
+            />
+            <site
+              name="lidar_front-57"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6725164 -0.2185109 0.6725164 0.2185109"
+            />
+            <site
+              name="lidar_front-58"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6665659 -0.2360404 0.6665659 0.2360404"
+            />
+            <site
+              name="lidar_front-59"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6601587 -0.2534083 0.6601587 0.2534083"
+            />
+            <site
+              name="lidar_front-60"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.653299 -0.2706024 0.653299 0.2706024"
+            />
+            <site
+              name="lidar_front-61"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6459916 -0.2876111 0.6459916 0.2876111"
+            />
+            <site
+              name="lidar_front-62"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6382414 -0.3044227 0.6382414 0.3044227"
+            />
+            <site
+              name="lidar_front-63"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6300538 -0.3210256 0.6300538 0.3210256"
+            />
+            <site
+              name="lidar_front-64"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6214344 -0.3374085 0.6214344 0.3374085"
+            />
+            <site
+              name="lidar_front-65"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6123891 -0.3535602 0.6123891 0.3535602"
+            />
+            <site
+              name="lidar_front-66"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6029241 -0.3694695 0.6029241 0.3694695"
+            />
+            <site
+              name="lidar_front-67"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5930459 -0.3851257 0.5930459 0.3851257"
+            />
+            <site
+              name="lidar_front-68"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5827613 -0.4005179 0.5827613 0.4005179"
+            />
+            <site
+              name="lidar_front-69"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5720772 -0.4156356 0.5720772 0.4156356"
+            />
+            <site
+              name="lidar_front-70"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5610011 -0.4304684 0.5610011 0.4304684"
+            />
+            <site
+              name="lidar_front-71"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5495404 -0.4450062 0.5495404 0.4450062"
+            />
+            <site
+              name="lidar_front-72"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5377032 -0.4592391 0.5377032 0.4592391"
+            />
+            <site
+              name="lidar_front-73"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5254974 -0.4731572 0.5254974 0.4731572"
+            />
+            <site
+              name="lidar_front-74"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5129315 -0.486751 0.5129315 0.486751"
+            />
+            <site
+              name="lidar_front-75"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5000141 -0.5000112 0.5000141 0.5000112"
+            />
+            <site
+              name="lidar_front-76"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4867539 -0.5129287 0.4867539 0.5129287"
+            />
+            <site
+              name="lidar_front-77"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4731602 -0.5254947 0.4731602 0.5254947"
+            />
+            <site
+              name="lidar_front-78"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4592422 -0.5377006 0.4592422 0.5377006"
+            />
+            <site
+              name="lidar_front-79"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4450094 -0.5495379 0.4450094 0.5495379"
+            />
+            <site
+              name="lidar_front-80"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4304716 -0.5609986 0.4304716 0.5609986"
+            />
+            <site
+              name="lidar_front-81"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4156389 -0.5720748 0.4156389 0.5720748"
+            />
+            <site
+              name="lidar_front-82"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4005212 -0.5827589 0.4005212 0.5827589"
+            />
+            <site
+              name="lidar_front-83"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3851291 -0.5930437 0.3851291 0.5930437"
+            />
+            <site
+              name="lidar_front-84"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.369473 -0.602922 0.369473 0.602922"
+            />
+            <site
+              name="lidar_front-85"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3535637 -0.6123871 0.3535637 0.6123871"
+            />
+            <site
+              name="lidar_front-86"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3374121 -0.6214325 0.3374121 0.6214325"
+            />
+            <site
+              name="lidar_front-87"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3210292 -0.630052 0.3210292 0.630052"
+            />
+            <site
+              name="lidar_front-88"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3044263 -0.6382397 0.3044263 0.6382397"
+            />
+            <site
+              name="lidar_front-89"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2876148 -0.6459899 0.2876148 0.6459899"
+            />
+            <site
+              name="lidar_front-90"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2706062 -0.6532974 0.2706062 0.6532974"
+            />
             <!-- TIM571 body: dark cylinder, visual-only -->
             <geom
               name="lidar_front_body"
@@ -259,14 +797,552 @@
               pos="0 0 0"
               diaginertia="0.0001 0.0001 0.0001"
             />
-            <replicate count="91" sep="-" offset="0 0 0" euler="0 0 0.05236">
-              <site
-                name="lidar_rear"
-                size="0.01"
-                pos="0 0 0"
-                quat="0.6533 -0.2706 0.6533 0.2706"
-              />
-            </replicate>
+            <site
+              name="lidar_rear-0"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6533 -0.2706 0.6533 0.2706"
+            />
+            <site
+              name="lidar_rear-1"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6459926 -0.2876087 0.6459926 0.2876087"
+            />
+            <site
+              name="lidar_rear-2"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6382425 -0.3044203 0.6382425 0.3044203"
+            />
+            <site
+              name="lidar_rear-3"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.630055 -0.3210233 0.630055 0.3210233"
+            />
+            <site
+              name="lidar_rear-4"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6214357 -0.3374062 0.6214357 0.3374062"
+            />
+            <site
+              name="lidar_rear-5"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6123904 -0.3535579 0.6123904 0.3535579"
+            />
+            <site
+              name="lidar_rear-6"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.6029255 -0.3694673 0.6029255 0.3694673"
+            />
+            <site
+              name="lidar_rear-7"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5930473 -0.3851235 0.5930473 0.3851235"
+            />
+            <site
+              name="lidar_rear-8"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5827627 -0.4005157 0.5827627 0.4005157"
+            />
+            <site
+              name="lidar_rear-9"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5720787 -0.4156335 0.5720787 0.4156335"
+            />
+            <site
+              name="lidar_rear-10"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5610026 -0.4304664 0.5610026 0.4304664"
+            />
+            <site
+              name="lidar_rear-11"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5495421 -0.4450042 0.5495421 0.4450042"
+            />
+            <site
+              name="lidar_rear-12"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5377049 -0.4592371 0.5377049 0.4592371"
+            />
+            <site
+              name="lidar_rear-13"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5254992 -0.4731552 0.5254992 0.4731552"
+            />
+            <site
+              name="lidar_rear-14"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5129333 -0.4867491 0.5129333 0.4867491"
+            />
+            <site
+              name="lidar_rear-15"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.5000159 -0.5000093 0.5000159 0.5000093"
+            />
+            <site
+              name="lidar_rear-16"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4867558 -0.5129269 0.4867558 0.5129269"
+            />
+            <site
+              name="lidar_rear-17"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4731621 -0.525493 0.4731621 0.525493"
+            />
+            <site
+              name="lidar_rear-18"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4592441 -0.5376989 0.4592441 0.5376989"
+            />
+            <site
+              name="lidar_rear-19"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4450114 -0.5495362 0.4450114 0.5495362"
+            />
+            <site
+              name="lidar_rear-20"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4304737 -0.560997 0.4304737 0.560997"
+            />
+            <site
+              name="lidar_rear-21"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.415641 -0.5720733 0.415641 0.5720733"
+            />
+            <site
+              name="lidar_rear-22"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.4005234 -0.5827575 0.4005234 0.5827575"
+            />
+            <site
+              name="lidar_rear-23"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3851313 -0.5930423 0.3851313 0.5930423"
+            />
+            <site
+              name="lidar_rear-24"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3694752 -0.6029206 0.3694752 0.6029206"
+            />
+            <site
+              name="lidar_rear-25"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.353566 -0.6123858 0.353566 0.6123858"
+            />
+            <site
+              name="lidar_rear-26"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3374144 -0.6214312 0.3374144 0.6214312"
+            />
+            <site
+              name="lidar_rear-27"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3210315 -0.6300508 0.3210315 0.6300508"
+            />
+            <site
+              name="lidar_rear-28"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.3044287 -0.6382385 0.3044287 0.6382385"
+            />
+            <site
+              name="lidar_rear-29"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2876172 -0.6459889 0.2876172 0.6459889"
+            />
+            <site
+              name="lidar_rear-30"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2706086 -0.6532965 0.2706086 0.6532965"
+            />
+            <site
+              name="lidar_rear-31"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2534145 -0.6601563 0.2534145 0.6601563"
+            />
+            <site
+              name="lidar_rear-32"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2360467 -0.6665637 0.2360467 0.6665637"
+            />
+            <site
+              name="lidar_rear-33"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2185172 -0.6725143 0.2185172 0.6725143"
+            />
+            <site
+              name="lidar_rear-34"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.2008379 -0.678004 0.2008379 0.678004"
+            />
+            <site
+              name="lidar_rear-35"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.183021 -0.683029 0.183021 0.683029"
+            />
+            <site
+              name="lidar_rear-36"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.1650786 -0.6875859 0.1650786 0.6875859"
+            />
+            <site
+              name="lidar_rear-37"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.1470231 -0.6916715 0.1470231 0.6916715"
+            />
+            <site
+              name="lidar_rear-38"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.1288668 -0.6952831 0.1288668 0.6952831"
+            />
+            <site
+              name="lidar_rear-39"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.1106222 -0.6984182 0.1106222 0.6984182"
+            />
+            <site
+              name="lidar_rear-40"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0923018 -0.7010746 0.0923018 0.7010746"
+            />
+            <site
+              name="lidar_rear-41"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0739181 -0.7032506 0.0739181 0.7032506"
+            />
+            <site
+              name="lidar_rear-42"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0554838 -0.7049445 0.0554838 0.7049445"
+            />
+            <site
+              name="lidar_rear-43"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0370115 -0.7061554 0.0370115 0.7061554"
+            />
+            <site
+              name="lidar_rear-44"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0185137 -0.7068822 0.0185137 0.7068822"
+            />
+            <site
+              name="lidar_rear-45"
+              size="0.01"
+              pos="0 0 0"
+              quat="0.0000033 -0.7071246 0.0000033 0.7071246"
+            />
+            <site
+              name="lidar_rear-46"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.0185071 -0.7068824 -0.0185071 0.7068824"
+            />
+            <site
+              name="lidar_rear-47"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.0370048 -0.7061557 -0.0370048 0.7061557"
+            />
+            <site
+              name="lidar_rear-48"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.0554772 -0.7049451 -0.0554772 0.7049451"
+            />
+            <site
+              name="lidar_rear-49"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.0739115 -0.7032513 -0.0739115 0.7032513"
+            />
+            <site
+              name="lidar_rear-50"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.0922952 -0.7010755 -0.0922952 0.7010755"
+            />
+            <site
+              name="lidar_rear-51"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.1106156 -0.6984192 -0.1106156 0.6984192"
+            />
+            <site
+              name="lidar_rear-52"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.1288602 -0.6952843 -0.1288602 0.6952843"
+            />
+            <site
+              name="lidar_rear-53"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.1470166 -0.6916729 -0.1470166 0.6916729"
+            />
+            <site
+              name="lidar_rear-54"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.1650721 -0.6875874 -0.1650721 0.6875874"
+            />
+            <site
+              name="lidar_rear-55"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.1830145 -0.6830307 -0.1830145 0.6830307"
+            />
+            <site
+              name="lidar_rear-56"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2008315 -0.6780059 -0.2008315 0.6780059"
+            />
+            <site
+              name="lidar_rear-57"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2185109 -0.6725164 -0.2185109 0.6725164"
+            />
+            <site
+              name="lidar_rear-58"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2360404 -0.6665659 -0.2360404 0.6665659"
+            />
+            <site
+              name="lidar_rear-59"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2534083 -0.6601587 -0.2534083 0.6601587"
+            />
+            <site
+              name="lidar_rear-60"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2706024 -0.653299 -0.2706024 0.653299"
+            />
+            <site
+              name="lidar_rear-61"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.2876111 -0.6459916 -0.2876111 0.6459916"
+            />
+            <site
+              name="lidar_rear-62"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3044227 -0.6382414 -0.3044227 0.6382414"
+            />
+            <site
+              name="lidar_rear-63"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3210256 -0.6300538 -0.3210256 0.6300538"
+            />
+            <site
+              name="lidar_rear-64"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3374085 -0.6214344 -0.3374085 0.6214344"
+            />
+            <site
+              name="lidar_rear-65"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3535602 -0.6123891 -0.3535602 0.6123891"
+            />
+            <site
+              name="lidar_rear-66"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3694695 -0.6029241 -0.3694695 0.6029241"
+            />
+            <site
+              name="lidar_rear-67"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.3851257 -0.5930459 -0.3851257 0.5930459"
+            />
+            <site
+              name="lidar_rear-68"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4005179 -0.5827613 -0.4005179 0.5827613"
+            />
+            <site
+              name="lidar_rear-69"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4156356 -0.5720772 -0.4156356 0.5720772"
+            />
+            <site
+              name="lidar_rear-70"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4304684 -0.5610011 -0.4304684 0.5610011"
+            />
+            <site
+              name="lidar_rear-71"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4450062 -0.5495404 -0.4450062 0.5495404"
+            />
+            <site
+              name="lidar_rear-72"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4592391 -0.5377032 -0.4592391 0.5377032"
+            />
+            <site
+              name="lidar_rear-73"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.4731572 -0.5254974 -0.4731572 0.5254974"
+            />
+            <site
+              name="lidar_rear-74"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.486751 -0.5129315 -0.486751 0.5129315"
+            />
+            <site
+              name="lidar_rear-75"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5000112 -0.5000141 -0.5000112 0.5000141"
+            />
+            <site
+              name="lidar_rear-76"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5129287 -0.4867539 -0.5129287 0.4867539"
+            />
+            <site
+              name="lidar_rear-77"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5254947 -0.4731602 -0.5254947 0.4731602"
+            />
+            <site
+              name="lidar_rear-78"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5377006 -0.4592422 -0.5377006 0.4592422"
+            />
+            <site
+              name="lidar_rear-79"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5495379 -0.4450094 -0.5495379 0.4450094"
+            />
+            <site
+              name="lidar_rear-80"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5609986 -0.4304716 -0.5609986 0.4304716"
+            />
+            <site
+              name="lidar_rear-81"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5720748 -0.4156389 -0.5720748 0.4156389"
+            />
+            <site
+              name="lidar_rear-82"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5827589 -0.4005212 -0.5827589 0.4005212"
+            />
+            <site
+              name="lidar_rear-83"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.5930437 -0.3851291 -0.5930437 0.3851291"
+            />
+            <site
+              name="lidar_rear-84"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.602922 -0.369473 -0.602922 0.369473"
+            />
+            <site
+              name="lidar_rear-85"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.6123871 -0.3535637 -0.6123871 0.3535637"
+            />
+            <site
+              name="lidar_rear-86"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.6214325 -0.3374121 -0.6214325 0.3374121"
+            />
+            <site
+              name="lidar_rear-87"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.630052 -0.3210292 -0.630052 0.3210292"
+            />
+            <site
+              name="lidar_rear-88"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.6382397 -0.3044263 -0.6382397 0.3044263"
+            />
+            <site
+              name="lidar_rear-89"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.6459899 -0.2876148 -0.6459899 0.2876148"
+            />
+            <site
+              name="lidar_rear-90"
+              size="0.01"
+              pos="0 0 0"
+              quat="-0.6532974 -0.2706062 -0.6532974 0.2706062"
+            />
             <!-- TIM571 body: dark cylinder, visual-only -->
             <geom
               name="lidar_rear_body"
@@ -665,8 +1741,704 @@
          angle_min=0 so the _ROS frame X axis points at beam-0 (per plugin convention).
          The sweep is 0 to 4.7124 rad (270 deg) in the sensor frame, which maps to
          beam-0 at -135 deg and beam-90 at +135 deg in the robot frame. -->
-    <rangefinder site="lidar_front" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder
+      site="lidar_front-0"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-1"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-2"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-3"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-4"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-5"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-6"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-7"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-8"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-9"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-10"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-11"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-12"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-13"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-14"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-15"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-16"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-17"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-18"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-19"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-20"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-21"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-22"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-23"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-24"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-25"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-26"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-27"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-28"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-29"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-30"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-31"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-32"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-33"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-34"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-35"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-36"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-37"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-38"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-39"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-40"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-41"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-42"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-43"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-44"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-45"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-46"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-47"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-48"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-49"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-50"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-51"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-52"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-53"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-54"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-55"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-56"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-57"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-58"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-59"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-60"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-61"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-62"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-63"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-64"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-65"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-66"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-67"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-68"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-69"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-70"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-71"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-72"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-73"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-74"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-75"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-76"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-77"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-78"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-79"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-80"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-81"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-82"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-83"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-84"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-85"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-86"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-87"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-88"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-89"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_front-90"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
     <!-- Rear TIM571: same convention — angle_min=0, frame X points at beam-0 (+45 deg robot frame). -->
-    <rangefinder site="lidar_rear" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-0" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-1" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-2" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-3" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-4" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-5" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-6" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-7" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-8" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder site="lidar_rear-9" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
+    <rangefinder
+      site="lidar_rear-10"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-11"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-12"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-13"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-14"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-15"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-16"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-17"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-18"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-19"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-20"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-21"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-22"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-23"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-24"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-25"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-26"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-27"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-28"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-29"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-30"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-31"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-32"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-33"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-34"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-35"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-36"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-37"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-38"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-39"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-40"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-41"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-42"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-43"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-44"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-45"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-46"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-47"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-48"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-49"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-50"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-51"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-52"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-53"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-54"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-55"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-56"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-57"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-58"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-59"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-60"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-61"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-62"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-63"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-64"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-65"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-66"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-67"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-68"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-69"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-70"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-71"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-72"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-73"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-74"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-75"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-76"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-77"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-78"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-79"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-80"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-81"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-82"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-83"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-84"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-85"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-86"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-87"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-88"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-89"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
+    <rangefinder
+      site="lidar_rear-90"
+      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
+    />
   </sensor>
 </mujoco>


### PR DESCRIPTION
Upgrading from MuJoCo 3.2.7 to 3.6.0 exposes some bugs in our configs because validation checks weren't previously being run on `qpos` values or the `<replicate>` tag. Claude tells me it's not possible to use the `<replicate>` tag in the way it was being used in `hangar_sim` and still pass those checks which is why the values have to be broken out individually. These changes should be backward-compatible.

Companion to PickNikRobotics/moveit_pro#18077.