### PR TITLE
Fix: Clarify pose prompt in Navigate to Clicked Point objective

### DIFF
--- a/src/hangar_sim/objectives/navigate_to_clicked_point.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point.xml
@@ -20,7 +20,7 @@
       <Action
         ID="GetPoseFromUser"
         is_normal="true"
-        pose_prompt="Click point on UI"
+        pose_prompt="Choose a goal waypoint by clicking in the 3D Visualization pane"
         user_pose="{goal}"
         view_name="Visualization"
       />


### PR DESCRIPTION
Updates the `pose_prompt` on the `GetPoseFromUser` action in the Navigate to Clicked Point objective from `"Click point on UI"` to `"Choose a goal waypoint by clicking in the 3D Visualization pane"` so the instruction is clearer to users.