### PR TITLE
Fix: Set MuJoCo arena memory to 64M in lab_sim scene

### DIFF
--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -9,7 +9,10 @@
   <option integrator="implicitfast" impratio="10" noslip_iterations="3" />
 
   <!-- nuser_cam=1 enables per-camera user params: 0=RGB+Depth, 1=RGB-only, 2=3D-lidar -->
-  <size nuser_cam="1" />
+  <!-- memory: arena size for contacts/constraints. MuJoCo 3.3+ stopped growing the arena
+       dynamically; the default heuristic here yields ~15MB and overflows during grasping
+       (emitting mjWARN_CNSTRFULL and dropping constraints), which destabilises picks. -->
+  <size nuser_cam="1" memory="64M" />
 
   <asset>
     <!-- Laptop keyboard texture (dark checker pattern) -->


### PR DESCRIPTION
## Summary

- Sets `memory="64M"` on the `<size>` element of `src/lab_sim/description/scene.xml` so MuJoCo 3.6.0 can keep all contact/constraint rows during grasping instead of silently dropping them.
- Fixes the flaky-CI regression on `main` tracked in [PickNikRobotics/moveit_pro#18534](https://github.com/PickNikRobotics/moveit_pro/issues/18534):

  | Objective | Pre-fix status |
  | --- | --- |
  | Pick April Tag Labeled Object | always fails |
  | Push Button With a Trajectory | sometimes fails |
  | ML Segment Point Cloud | sometimes fails |
  | MPC Pose Tracking Static Point Cloud Avoidance with Sphere Down Sample | sometimes fails |
  | MPC Pose Tracking With Static Sphere Point Cloud Avoidance | sometimes fails |
  | Playback Square Trajectory | sometimes fails |

## Why

MuJoCo 3.2.7 → 3.6.0 (bundled in MoveIt Pro `main` since [PickNikRobotics/moveit_pro@6eedef8](https://github.com/PickNikRobotics/moveit_pro/commit/6eedef88a5)) changed how the constraint-solver arena is sized. In 3.2.7 the arena grew on demand. From 3.3+ it is statically sized at model compile time from the `<size memory="..."/>` attribute; when `memory` is absent MuJoCo falls back to a conservative heuristic (roughly 15 MB for this scene).

`lab_sim/description/scene.xml` never set `memory`. With 11 free-joint bodies (6 tubes, 5 bottles), the UR5e + Robotiq 2f85 with `condim=4` friction contacts, and the gripper closing on an object, the heuristic arena overflows — MuJoCo emits `mjWARN_CNSTRFULL` ("Insufficient arena memory for the number of constraints generated") and drops constraint rows. Dropped friction/contact constraints produce exactly the reported failures: objects sliding through the gripper, incorrect push forces, and unstable trajectory playback.

The `v9.2` branch is unaffected because it still ships MuJoCo 3.2.7, which grew the arena on demand.

## Test plan

- [x] Built `overlay_ws` (moveit_pro) and `user_ws` (this repo) inside the dev container.
- [x] Launched `agent_robot.app` with `MOVEIT_CONFIG_PACKAGE=lab_sim` and confirmed `You can start planning now!`.
- [x] Ran the previously-failing Objectives via `ros2 action send_goal /do_objective`:
  - `Pick April Tag Labeled Object` → **SUCCEEDED**
  - `Push Button With a Trajectory` → **SUCCEEDED**
  - `Playback Square Trajectory` → **SUCCEEDED**
  - `MPC Pose Tracking With Static Sphere Point Cloud Avoidance` → **SUCCEEDED**
- [x] Confirmed zero `mjWARN_CNSTRFULL` lines in the backend log and no `MUJOCO_LOG.TXT` was written during the run.
- [ ] Watch the `integration-test-in-studio-container` CI job on this PR to confirm the full `lab_sim` Objective suite passes.

A matching release-notes entry will land in `moveit_pro` alongside this PR so downstream users know when they might need the same change in their own `scene.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)