### PR TITLE
Fix: Set MuJoCo timestep to 0.005 so lab_sim keeps up with wall time

### DIFF
--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -6,7 +6,18 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" impratio="10" noslip_iterations="3" />
+  <!-- timestep=0.005 matches dual_arm_sim. MuJoCo 3.6.0 contact/constraint
+       solving is slower than 3.2.7, so the previous default 0.002 s (500 Hz)
+       caused mj_step to exceed its wall-time budget on CI hardware, emitting
+       "Mujoco model timestep not running in realtime" and producing path
+       tolerance violations in Pick April Tag Labeled Object and Push Button
+       With a Trajectory. -->
+  <option
+    integrator="implicitfast"
+    impratio="10"
+    noslip_iterations="3"
+    timestep="0.005"
+  />
 
   <!-- nuser_cam=1 enables per-camera user params: 0=RGB+Depth, 1=RGB-only, 2=3D-lidar -->
   <!-- memory: arena size for contacts/constraints. MuJoCo 3.3+ stopped growing the arena


### PR DESCRIPTION
## Summary

Follow-up to [#597](https://github.com/PickNikRobotics/moveit_pro_example_ws/pull/597). That PR set `memory="64M"` to stop the MuJoCo arena from overflowing, which cleared four of the six flaky objectives in [PickNikRobotics/moveit_pro#18534](https://github.com/PickNikRobotics/moveit_pro/issues/18534). The remaining two — **Pick April Tag Labeled Object** and **Push Button With a Trajectory** — still failed in [CI run 24904523506](https://github.com/PickNikRobotics/moveit_pro_example_ws/actions/runs/24904523506/job/72930384327?pr=597), but with a *different* symptom than the arena warning:

```
[MujocoSystem]: Mujoco model timestep not running in realtime. Increase the model timestep.
...
Path tolerance violated, trajectory will be aborted. Current joint deviations:
  [0.056, 0.003, 0.133, 0.201, 0.071, 0.001, 0.005]  tolerance: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
```

This PR addresses that second root cause by setting an explicit `timestep="0.005"` on `lab_sim`'s `<option>` element.

## Why

MuJoCo 3.6.0 contact/constraint solving is slower than 3.2.7, and `lab_sim`'s scene inherited MuJoCo's default timestep of `0.002 s` (500 Hz). `picknik_mujoco_ros`'s simulation loop calls `mj_step` once per iteration and then sleeps for `timestep - step_wall_duration`; when that is negative, it emits the "not running in realtime" warning and the sim falls behind wall time. Controllers read joint positions in wall time but the robot lags by the sim/wall deficit, pushing deviation past the 0.2 rad path tolerance — hence the abort.

Raising `timestep` to `0.005 s` (200 Hz) gives each `mj_step` a larger wall-time budget without a proportional increase in per-step cost, and keeps the sim ahead of real time on the CI runner. Other `*_sim` scenes already use similar values: `dual_arm_sim` runs at `0.005`, `factory_sim` at `0.01`. Simulation remains stable for the scene's grasping, compliance, and MPC objectives.

## Test plan

- [x] Rebuilt `lab_sim` and relaunched `agent_robot.app` with `MOVEIT_CONFIG_PACKAGE=lab_sim` inside the dev container.
- [x] Ran the following sequence (with `Open Gripper` between grasp objectives to reset the gripper state, mirroring a fresh CI test):
  - `Pick April Tag Labeled Object` → **SUCCEEDED**
  - `Push Button With a Trajectory` → **SUCCEEDED**
  - `Playback Square Trajectory` → **SUCCEEDED**
  - `ML Segment Point Cloud` → **SUCCEEDED**
- [x] Confirmed the backend log has **zero** `Mujoco model timestep not running in realtime` and **zero** `mjWARN_CNSTRFULL` lines.
- [ ] Wait for the `integration-test-in-studio-container` CI job on this PR to confirm the full `lab_sim` suite passes.

An accompanying release-note update in `moveit_pro` will extend the existing MuJoCo 3.6.0 breaking-change section with a third bullet about `timestep` tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)