### PR TITLE
Fix: Activate per-test MuJoCo reset fixture in lab_sim integration test

### DIFF
--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -34,6 +34,7 @@ from moveit_pro_test_utils.objective_test_fixture import (
     ExecuteObjectiveResource,
     execute_objective_resource as execute_objective_resource,
     get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
     run_objective,
 )
 


### PR DESCRIPTION
## Summary

- Re-exports the new `reset_simulation_before_test` fixture from `moveit_pro_test_utils` so pytest activates the autouse MuJoCo reset for every parametrized objective in `lab_sim/test/objectives_integration_test.py`.

## Why

The lab_sim objective integration test runs ~117 parametrized objectives against a single shared backend / MuJoCo instance, with no reset between tests. Objectives that move objects leave residual world state for subsequent tests, which became visible as failures after the MuJoCo 3.2.7 → 3.6.0 upgrade (e.g., `Push Button With a Trajectory` failing with "Force/Torque threshold exceeded" mid-trajectory because a prior test had left an object in the path). The reset service already exists in `picknik_mujoco_ros`; the upstream PR adds a fixture that calls it; this PR opts the lab_sim test in.

## Dependency

This PR depends on PickNikRobotics/moveit_pro#18731 — `reset_simulation_before_test` only exists once that PR ships and a new `picknikciuser/moveit-studio:main-humble` image is published. CI here will fail until then.

## Test plan

- [ ] Pre-commit passes locally (verified)
- [ ] After the upstream PR merges and the container image rebuilds, the `Integration Test in Studio Container` job on this branch goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)