### PR TITLE
feat: hangar_sim, add beluga_amcl localization with hardcoded initial…

### DIFF
--- a/src/hangar_sim/launch/sim/localization_launch.py
+++ b/src/hangar_sim/launch/sim/localization_launch.py
@@ -26,23 +26,26 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Non-composable launch mode is not supported — hangar_sim always uses use_composition:=True.
+
 import os
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.actions import (
+    DeclareLaunchArgument,
+    OpaqueFunction,
+    SetEnvironmentVariable,
+)
+from launch.conditions import IfCondition, UnlessCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode, ParameterFile
 from nav2_common.launch import RewrittenYaml
 
 
-# This file is adapted from: https://github.com/ros-navigation/navigation2/blob/humble/nav2_bringup/launch/localization_launch.py
 def generate_launch_description():
-    # Get the launch directory
     bringup_dir = get_package_share_directory("nav2_bringup")
 
     namespace = LaunchConfiguration("namespace")
@@ -50,23 +53,12 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
     autostart = LaunchConfiguration("autostart")
     params_file = LaunchConfiguration("params_file")
-    use_composition = LaunchConfiguration("use_composition")
     container_name = LaunchConfiguration("container_name")
     container_name_full = (namespace, "/", container_name)
-    use_respawn = LaunchConfiguration("use_respawn")
-    log_level = LaunchConfiguration("log_level")
+    localization = LaunchConfiguration("localization")
 
-    lifecycle_nodes = ["map_server"]
-
-    # Map fully qualified names to relative ones so the node's namespace can be prepended.
-    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
-    # https://github.com/ros/geometry2/issues/32
-    # https://github.com/ros/robot_state_publisher/pull/30
-    # TODO(orduno) Substitute with `PushNodeRemapping`
-    #              https://github.com/ros2/launch_ros/issues/56
     remappings = [("/tf", "tf"), ("/tf_static", "tf_static")]
 
-    # Create our own temporary YAML files that include substitutions
     param_substitutions = {"use_sim_time": use_sim_time, "yaml_filename": map_yaml_file}
 
     configured_params = ParameterFile(
@@ -83,95 +75,106 @@ def generate_launch_description():
         "RCUTILS_LOGGING_BUFFERED_STREAM", "1"
     )
 
-    declare_namespace_cmd = DeclareLaunchArgument(
-        "namespace", default_value="", description="Top-level namespace"
-    )
+    def check_map_exists(context):
+        # map_server is loaded in both the localization and map-only paths below,
+        # so the map must exist regardless of the localization flag.
+        map_file = context.perform_substitution(map_yaml_file)
+        if not os.path.exists(map_file):
+            raise RuntimeError(
+                f"Map file not found: {map_file}\n"
+                "Run SLAM first (slam:=True) to build a map, or provide a map path via map:=<path>."
+            )
+        return []
 
-    declare_map_yaml_cmd = DeclareLaunchArgument(
-        "map", description="Full path to map yaml file to load"
-    )
+    map_check = OpaqueFunction(function=check_map_exists)
 
-    declare_use_sim_time_cmd = DeclareLaunchArgument(
-        "use_sim_time",
-        default_value="false",
-        description="Use simulation (Gazebo) clock if true",
-    )
-
-    declare_params_file_cmd = DeclareLaunchArgument(
-        "params_file",
-        default_value=os.path.join(bringup_dir, "params", "nav2_params.yaml"),
-        description="Full path to the ROS2 parameters file to use for all launched nodes",
-    )
-
-    declare_autostart_cmd = DeclareLaunchArgument(
-        "autostart",
-        default_value="true",
-        description="Automatically startup the nav2 stack",
-    )
-
-    declare_use_composition_cmd = DeclareLaunchArgument(
-        "use_composition",
-        default_value="False",
-        description="Use composed bringup if True",
-    )
-
-    declare_container_name_cmd = DeclareLaunchArgument(
-        "container_name",
-        default_value="nav2_container",
-        description="the name of container that nodes will load in if use composition",
-    )
-
-    declare_use_respawn_cmd = DeclareLaunchArgument(
-        "use_respawn",
-        default_value="False",
-        description="Whether to respawn if a node crashes. Applied when composition is disabled.",
-    )
-
-    declare_log_level_cmd = DeclareLaunchArgument(
-        "log_level", default_value="info", description="log level"
-    )
-
-    load_nodes = GroupAction(
-        condition=IfCondition(PythonExpression(["not ", use_composition])),
-        actions=[
-            Node(
+    # Load map_server and amcl into the shared nav2_container when localization is enabled.
+    load_localization_nodes = LoadComposableNodes(
+        condition=IfCondition(localization),
+        target_container=container_name_full,
+        composable_node_descriptions=[
+            # Merge the front and rear lidar scans into a single 360-degree scan
+            # for AMCL. With only the front lidar, the long featureless fuselage
+            # of the hangar airplane gives the particle filter no position lock
+            # and it can diverge; the rear lidar always sees structure the front
+            # cannot, removing that ambiguity.
+            ComposableNode(
+                package="dual_laser_merger",
+                plugin="merger_node::MergerNode",
+                name="dual_laser_merger",
+                parameters=[
+                    {
+                        "use_sim_time": use_sim_time,
+                        "laser_1_topic": "/scan_front_filtered",
+                        "laser_2_topic": "/scan_rear_filtered",
+                        "merged_scan_topic": "/scan_merged",
+                        "target_frame": "ridgeback_base_link",
+                        "laser_1_x_offset": 0.0,
+                        "laser_1_y_offset": 0.0,
+                        "laser_1_yaw_offset": 0.0,
+                        "laser_2_x_offset": 0.0,
+                        "laser_2_y_offset": 0.0,
+                        "laser_2_yaw_offset": 0.0,
+                        "tolerance": 0.05,
+                        # Buffer several scans per input so the approximate-time
+                        # sync still pairs front+rear when the sim falls behind
+                        # real time and lidar stamps go irregular (keeps
+                        # /scan_merged flowing instead of starving AMCL).
+                        "queue_size": 10,
+                        "angle_increment": 0.0087,
+                        "scan_time": 0.1,
+                        "range_min": 0.05,
+                        "range_max": 25.0,
+                        "min_height": -2.0,
+                        "max_height": 2.0,
+                        "angle_min": -3.141592654,
+                        "angle_max": 3.141592654,
+                        "inf_epsilon": 1.0,
+                        "use_inf": True,
+                        "allowed_radius": 0.45,
+                        # The hangar scans are sparse (open space + self-hit
+                        # filtering leave finite returns surrounded by inf). The
+                        # shadow/average filters treat those as noise and drop
+                        # ~95% of returns, leaving AMCL almost no data. Disable
+                        # them so the merged scan keeps the real returns.
+                        "enable_shadow_filter": False,
+                        "enable_average_filter": False,
+                    }
+                ],
+            ),
+            ComposableNode(
                 package="nav2_map_server",
-                executable="map_server",
+                plugin="nav2_map_server::MapServer",
                 name="map_server",
-                output="screen",
-                respawn=use_respawn,
-                respawn_delay=2.0,
                 parameters=[configured_params],
-                arguments=["--ros-args", "--log-level", log_level],
                 remappings=remappings,
             ),
-            # Node(
-            #     package='nav2_amcl',
-            #     executable='amcl',
-            #     name='amcl',
-            #     output='screen',
-            #     respawn=use_respawn,
-            #     respawn_delay=2.0,
-            #     parameters=[configured_params],
-            #     arguments=['--ros-args', '--log-level', log_level],
-            #     remappings=remappings),
-            Node(
+            ComposableNode(
+                package="beluga_amcl",
+                plugin="beluga_amcl::AmclNode",
+                name="amcl",
+                parameters=[configured_params],
+                remappings=remappings,
+            ),
+            ComposableNode(
                 package="nav2_lifecycle_manager",
-                executable="lifecycle_manager",
+                plugin="nav2_lifecycle_manager::LifecycleManager",
                 name="lifecycle_manager_localization",
-                output="screen",
-                arguments=["--ros-args", "--log-level", log_level],
                 parameters=[
-                    {"use_sim_time": use_sim_time},
-                    {"autostart": autostart},
-                    {"node_names": lifecycle_nodes},
+                    {
+                        "use_sim_time": use_sim_time,
+                        "autostart": autostart,
+                        "node_names": ["map_server", "amcl"],
+                    }
                 ],
             ),
         ],
     )
 
-    load_composable_nodes = LoadComposableNodes(
-        condition=IfCondition(use_composition),
+    # Load map_server only (no AMCL) when localization is disabled.
+    # A static map->odom TF is expected from the parent launch in this case.
+    load_map_server_only = LoadComposableNodes(
+        condition=UnlessCondition(localization),
         target_container=container_name_full,
         composable_node_descriptions=[
             ComposableNode(
@@ -189,32 +192,63 @@ def generate_launch_description():
                     {
                         "use_sim_time": use_sim_time,
                         "autostart": autostart,
-                        "node_names": lifecycle_nodes,
+                        "node_names": ["map_server"],
                     }
                 ],
             ),
         ],
     )
 
-    # Create the launch description and populate
     ld = LaunchDescription()
 
-    # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
 
-    # Declare the launch options
-    ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_map_yaml_cmd)
-    ld.add_action(declare_use_sim_time_cmd)
-    ld.add_action(declare_params_file_cmd)
-    ld.add_action(declare_autostart_cmd)
-    ld.add_action(declare_use_composition_cmd)
-    ld.add_action(declare_container_name_cmd)
-    ld.add_action(declare_use_respawn_cmd)
-    ld.add_action(declare_log_level_cmd)
+    ld.add_action(
+        DeclareLaunchArgument(
+            "namespace", default_value="", description="Top-level namespace"
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument("map", description="Full path to map yaml file to load")
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulation clock if true",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(bringup_dir, "params", "nav2_params.yaml"),
+            description="Full path to the ROS2 parameters file to use for all launched nodes",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "autostart",
+            default_value="true",
+            description="Automatically startup the nav2 stack",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "container_name",
+            default_value="nav2_container",
+            description="Name of the component container to load nodes into",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "localization",
+            default_value="True",
+            description="Run beluga_amcl for map-based localization. Set False to use a static map->odom TF instead.",
+        )
+    )
 
-    # Add the actions to launch all of the localiztion nodes
-    ld.add_action(load_nodes)
-    ld.add_action(load_composable_nodes)
+    ld.add_action(map_check)
+    ld.add_action(load_localization_nodes)
+    ld.add_action(load_map_server_only)
 
     return ld

--- a/src/hangar_sim/launch/sim/localization_launch.py
+++ b/src/hangar_sim/launch/sim/localization_launch.py
@@ -26,23 +26,28 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Non-composable launch mode is not supported — hangar_sim always uses use_composition:=True.
+
 import os
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+    SetEnvironmentVariable,
+    TimerAction,
+)
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import LoadComposableNodes
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode, ParameterFile
 from nav2_common.launch import RewrittenYaml
 
 
-# This file is adapted from: https://github.com/ros-navigation/navigation2/blob/humble/nav2_bringup/launch/localization_launch.py
 def generate_launch_description():
-    # Get the launch directory
     bringup_dir = get_package_share_directory("nav2_bringup")
 
     namespace = LaunchConfiguration("namespace")
@@ -50,23 +55,13 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
     autostart = LaunchConfiguration("autostart")
     params_file = LaunchConfiguration("params_file")
-    use_composition = LaunchConfiguration("use_composition")
     container_name = LaunchConfiguration("container_name")
     container_name_full = (namespace, "/", container_name)
-    use_respawn = LaunchConfiguration("use_respawn")
     log_level = LaunchConfiguration("log_level")
+    localization = LaunchConfiguration("localization")
 
-    lifecycle_nodes = ["map_server"]
-
-    # Map fully qualified names to relative ones so the node's namespace can be prepended.
-    # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
-    # https://github.com/ros/geometry2/issues/32
-    # https://github.com/ros/robot_state_publisher/pull/30
-    # TODO(orduno) Substitute with `PushNodeRemapping`
-    #              https://github.com/ros2/launch_ros/issues/56
     remappings = [("/tf", "tf"), ("/tf_static", "tf_static")]
 
-    # Create our own temporary YAML files that include substitutions
     param_substitutions = {"use_sim_time": use_sim_time, "yaml_filename": map_yaml_file}
 
     configured_params = ParameterFile(
@@ -83,95 +78,57 @@ def generate_launch_description():
         "RCUTILS_LOGGING_BUFFERED_STREAM", "1"
     )
 
-    declare_namespace_cmd = DeclareLaunchArgument(
-        "namespace", default_value="", description="Top-level namespace"
-    )
+    def check_map_exists(context):
+        if context.perform_substitution(localization) != "True":
+            return []
+        map_file = context.perform_substitution(map_yaml_file)
+        if not os.path.exists(map_file):
+            raise RuntimeError(
+                f"Map file not found: {map_file}\n"
+                "Run SLAM first (slam:=True) to build a map, or provide a map path via map:=<path>."
+            )
+        return []
 
-    declare_map_yaml_cmd = DeclareLaunchArgument(
-        "map", description="Full path to map yaml file to load"
-    )
+    map_check = OpaqueFunction(function=check_map_exists)
 
-    declare_use_sim_time_cmd = DeclareLaunchArgument(
-        "use_sim_time",
-        default_value="false",
-        description="Use simulation (Gazebo) clock if true",
-    )
-
-    declare_params_file_cmd = DeclareLaunchArgument(
-        "params_file",
-        default_value=os.path.join(bringup_dir, "params", "nav2_params.yaml"),
-        description="Full path to the ROS2 parameters file to use for all launched nodes",
-    )
-
-    declare_autostart_cmd = DeclareLaunchArgument(
-        "autostart",
-        default_value="true",
-        description="Automatically startup the nav2 stack",
-    )
-
-    declare_use_composition_cmd = DeclareLaunchArgument(
-        "use_composition",
-        default_value="False",
-        description="Use composed bringup if True",
-    )
-
-    declare_container_name_cmd = DeclareLaunchArgument(
-        "container_name",
-        default_value="nav2_container",
-        description="the name of container that nodes will load in if use composition",
-    )
-
-    declare_use_respawn_cmd = DeclareLaunchArgument(
-        "use_respawn",
-        default_value="False",
-        description="Whether to respawn if a node crashes. Applied when composition is disabled.",
-    )
-
-    declare_log_level_cmd = DeclareLaunchArgument(
-        "log_level", default_value="info", description="log level"
-    )
-
-    load_nodes = GroupAction(
-        condition=IfCondition(PythonExpression(["not ", use_composition])),
-        actions=[
-            Node(
+    # Load map_server and amcl into the shared nav2_container when localization is enabled.
+    load_localization_nodes = LoadComposableNodes(
+        condition=IfCondition(localization),
+        target_container=container_name_full,
+        composable_node_descriptions=[
+            ComposableNode(
                 package="nav2_map_server",
-                executable="map_server",
+                plugin="nav2_map_server::MapServer",
                 name="map_server",
-                output="screen",
-                respawn=use_respawn,
-                respawn_delay=2.0,
                 parameters=[configured_params],
-                arguments=["--ros-args", "--log-level", log_level],
                 remappings=remappings,
             ),
-            # Node(
-            #     package='nav2_amcl',
-            #     executable='amcl',
-            #     name='amcl',
-            #     output='screen',
-            #     respawn=use_respawn,
-            #     respawn_delay=2.0,
-            #     parameters=[configured_params],
-            #     arguments=['--ros-args', '--log-level', log_level],
-            #     remappings=remappings),
-            Node(
+            ComposableNode(
+                package="beluga_amcl",
+                plugin="beluga_amcl::AmclNode",
+                name="amcl",
+                parameters=[configured_params],
+                remappings=remappings,
+            ),
+            ComposableNode(
                 package="nav2_lifecycle_manager",
-                executable="lifecycle_manager",
+                plugin="nav2_lifecycle_manager::LifecycleManager",
                 name="lifecycle_manager_localization",
-                output="screen",
-                arguments=["--ros-args", "--log-level", log_level],
                 parameters=[
-                    {"use_sim_time": use_sim_time},
-                    {"autostart": autostart},
-                    {"node_names": lifecycle_nodes},
+                    {
+                        "use_sim_time": use_sim_time,
+                        "autostart": autostart,
+                        "node_names": ["map_server", "amcl"],
+                    }
                 ],
             ),
         ],
     )
 
-    load_composable_nodes = LoadComposableNodes(
-        condition=IfCondition(use_composition),
+    # Load map_server only (no AMCL) when localization is disabled.
+    # A static map->odom TF is expected from the parent launch in this case.
+    load_map_server_only = LoadComposableNodes(
+        condition=IfCondition(PythonExpression(["not ", localization])),
         target_container=container_name_full,
         composable_node_descriptions=[
             ComposableNode(
@@ -189,32 +146,103 @@ def generate_launch_description():
                     {
                         "use_sim_time": use_sim_time,
                         "autostart": autostart,
-                        "node_names": lifecycle_nodes,
+                        "node_names": ["map_server"],
                     }
                 ],
             ),
         ],
     )
 
-    # Create the launch description and populate
+    # Publish the robot's known sim spawn pose to /initialpose so beluga_amcl
+    # can initialize its particle filter without a manual 2D pose estimate.
+    # The 3-second delay gives map_server and amcl time to activate first.
+    # Covariance values match nav2_amcl defaults (±0.5 m, ±~15 deg).
+    initial_pose_pub = TimerAction(
+        condition=IfCondition(localization),
+        period=3.0,
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    "ros2",
+                    "topic",
+                    "pub",
+                    "--once",
+                    "/initialpose",
+                    "geometry_msgs/msg/PoseWithCovarianceStamped",
+                    (
+                        '{"header": {"frame_id": "map"}, '
+                        '"pose": {"pose": {'
+                        '"position": {"x": 0.0, "y": 0.0, "z": 0.0}, '
+                        '"orientation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0}}, '
+                        '"covariance": [0.25, 0, 0, 0, 0, 0, '
+                        "0, 0.25, 0, 0, 0, 0, "
+                        "0, 0, 0, 0, 0, 0, "
+                        "0, 0, 0, 0, 0, 0, "
+                        "0, 0, 0, 0, 0, 0, "
+                        "0, 0, 0, 0, 0, 0.0685]}}"
+                    ),
+                ],
+                output="log",
+            )
+        ],
+    )
+
     ld = LaunchDescription()
 
-    # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
 
-    # Declare the launch options
-    ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_map_yaml_cmd)
-    ld.add_action(declare_use_sim_time_cmd)
-    ld.add_action(declare_params_file_cmd)
-    ld.add_action(declare_autostart_cmd)
-    ld.add_action(declare_use_composition_cmd)
-    ld.add_action(declare_container_name_cmd)
-    ld.add_action(declare_use_respawn_cmd)
-    ld.add_action(declare_log_level_cmd)
+    ld.add_action(
+        DeclareLaunchArgument(
+            "namespace", default_value="", description="Top-level namespace"
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument("map", description="Full path to map yaml file to load")
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="false",
+            description="Use simulation clock if true",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(bringup_dir, "params", "nav2_params.yaml"),
+            description="Full path to the ROS2 parameters file to use for all launched nodes",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "autostart",
+            default_value="true",
+            description="Automatically startup the nav2 stack",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "container_name",
+            default_value="nav2_container",
+            description="Name of the component container to load nodes into",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "log_level", default_value="info", description="log level"
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "localization",
+            default_value="True",
+            description="Run beluga_amcl for map-based localization. Set False to use a static map->odom TF instead.",
+        )
+    )
 
-    # Add the actions to launch all of the localiztion nodes
-    ld.add_action(load_nodes)
-    ld.add_action(load_composable_nodes)
+    ld.add_action(map_check)
+    ld.add_action(load_localization_nodes)
+    ld.add_action(load_map_server_only)
+    ld.add_action(initial_pose_pub)
 
     return ld

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -66,6 +66,7 @@ def generate_launch_description():
     namespace = LaunchConfiguration("namespace")
     use_namespace = LaunchConfiguration("use_namespace")
     slam = LaunchConfiguration("slam")
+    localization = LaunchConfiguration("localization")
     map_yaml_file = LaunchConfiguration("map")
     use_sim_time = LaunchConfiguration("use_sim_time")
     params_file = LaunchConfiguration("params_file")
@@ -128,6 +129,12 @@ def generate_launch_description():
 
     declare_slam_cmd = DeclareLaunchArgument(
         "slam", default_value="False", description="Whether run a SLAM"
+    )
+
+    declare_localization_cmd = DeclareLaunchArgument(
+        "localization",
+        default_value="True",
+        description="Run beluga_amcl for map-based localization. Set False to use a static map->odom TF instead.",
     )
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
@@ -227,6 +234,7 @@ def generate_launch_description():
                     "use_composition": use_composition,
                     "use_respawn": use_respawn,
                     "container_name": "nav2_container",
+                    "localization": localization,
                 }.items(),
             ),
             IncludeLaunchDescription(
@@ -265,8 +273,11 @@ def generate_launch_description():
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "map"],
     )
 
-    # Static TF between map and odom frame
+    # Static map->odom TF fallback: only used when neither SLAM nor AMCL is publishing it.
     static_tf_map_to_odom = Node(
+        condition=IfCondition(
+            PythonExpression(["not ", slam, " and not ", localization])
+        ),
         package="tf2_ros",
         executable="static_transform_publisher",
         name="static_transform_publisher",
@@ -346,6 +357,7 @@ def generate_launch_description():
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)
+    ld.add_action(declare_localization_cmd)
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_params_file_cmd)

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -116,6 +116,7 @@ def generate_launch_description():
     namespace = LaunchConfiguration("namespace")
     use_namespace = LaunchConfiguration("use_namespace")
     slam = LaunchConfiguration("slam")
+    localization = LaunchConfiguration("localization")
     map_yaml_file = LaunchConfiguration("map")
     use_sim_time = LaunchConfiguration("use_sim_time")
     params_file = LaunchConfiguration("params_file")
@@ -178,6 +179,12 @@ def generate_launch_description():
 
     declare_slam_cmd = DeclareLaunchArgument(
         "slam", default_value="False", description="Whether run a SLAM"
+    )
+
+    declare_localization_cmd = DeclareLaunchArgument(
+        "localization",
+        default_value="True",
+        description="Run beluga_amcl for map-based localization. Set False to use a static map->odom TF instead.",
     )
 
     declare_map_yaml_cmd = DeclareLaunchArgument(
@@ -274,9 +281,8 @@ def generate_launch_description():
                     "use_sim_time": use_sim_time,
                     "autostart": autostart,
                     "params_file": params_file,
-                    "use_composition": use_composition,
-                    "use_respawn": use_respawn,
                     "container_name": "nav2_container",
+                    "localization": localization,
                 }.items(),
             ),
             IncludeLaunchDescription(
@@ -316,16 +322,26 @@ def generate_launch_description():
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "map"],
     )
 
-    # Static map→odom bootstrap: anchors 'odom' in the TF tree before MuJoCo finishes loading so
-    # bt_navigator can initialize without an "unconnected trees" TF error. Not used in slam mode
-    # because slam_toolbox owns and publishes map→odom dynamically.
+    # Static map->odom TF fallback: only used when neither SLAM nor AMCL is publishing it.
+    # Compare lowercased strings rather than `not <bareword>` so this still works
+    # when slam/localization are passed as ROS-style lowercase booleans.
     static_tf_map_to_odom = Node(
+        condition=IfCondition(
+            PythonExpression(
+                [
+                    "'",
+                    slam,
+                    "'.lower() == 'false' and '",
+                    localization,
+                    "'.lower() == 'false'",
+                ]
+            )
+        ),
         package="tf2_ros",
         executable="static_transform_publisher",
         name="static_tf_map_to_odom",
         output="log",
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "map", "odom"],
-        condition=IfCondition(PythonExpression(["not ", slam])),
     )
 
     # Static TF connecting MoveIt's planning root ('world') to the simulation root ('mj_world').
@@ -411,6 +427,7 @@ def generate_launch_description():
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)
+    ld.add_action(declare_localization_cmd)
     ld.add_action(declare_map_yaml_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_params_file_cmd)

--- a/src/hangar_sim/objectives/navigate_to_clicked_point.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point.xml
@@ -7,6 +7,7 @@
     _favorite="true"
   >
     <Control ID="Sequence" name="TopLevelSequence">
+      <Action ID="SetInitialPose" robot_frame_id="ridgeback_base_link" />
       <Action
         ID="CreatePoseStamped"
         reference_frame="base_link"

--- a/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
@@ -10,6 +10,7 @@
     _favorite="true"
   >
     <Control ID="Sequence" name="TopLevelSequence">
+      <Action ID="SetInitialPose" robot_frame_id="ridgeback_base_link" />
       <Action
         ID="CreatePoseStamped"
         reference_frame="base_link"

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
+  <exec_depend>beluga_amcl</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>picknik_accessories</exec_depend>

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -20,6 +20,8 @@
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
+  <exec_depend>beluga_amcl</exec_depend>
+  <exec_depend>dual_laser_merger</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>picknik_accessories</exec_depend>

--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -1,44 +1,43 @@
-# amcl is not used because odom is received directly from MuJoCo
-# amcl:
-#   ros__parameters:
-#     use_sim_time: True
-#     alpha1: 0.2
-#     alpha2: 0.2
-#     alpha3: 0.2
-#     alpha4: 0.2
-#     alpha5: 0.2
-#     base_frame_id: "base_footprint"
-#     beam_skip_distance: 0.5
-#     beam_skip_error_threshold: 0.9
-#     beam_skip_threshold: 0.3
-#     do_beamskip: false
-#     global_frame_id: "map"
-#     lambda_short: 0.1
-#     laser_likelihood_max_dist: 2.0
-#     laser_max_range: 100.0
-#     laser_min_range: -1.0
-#     laser_model_type: "likelihood_field"
-#     max_beams: 60
-#     max_particles: 2000
-#     min_particles: 500
-#     odom_frame_id: "odom"
-#     pf_err: 0.05
-#     pf_z: 0.99
-#     recovery_alpha_fast: 0.0
-#     recovery_alpha_slow: 0.0
-#     resample_interval: 1
-#     robot_model_type: "nav2_amcl::DifferentialMotionModel"
-#     save_pose_rate: 0.5
-#     sigma_hit: 0.2
-#     tf_broadcast: true
-#     transform_tolerance: 1.0
-#     update_min_a: 0.2
-#     update_min_d: 0.25
-#     z_hit: 0.5
-#     z_max: 0.05
-#     z_rand: 0.5
-#     z_short: 0.05
-#     scan_topic: scan
+amcl:
+  ros__parameters:
+    use_sim_time: True
+    alpha1: 0.2
+    alpha2: 0.2
+    alpha3: 0.2
+    alpha4: 0.2
+    alpha5: 0.2
+    base_frame_id: "ridgeback_base_link"
+    beam_skip_distance: 0.5
+    beam_skip_error_threshold: 0.9
+    beam_skip_threshold: 0.3
+    do_beamskip: false
+    global_frame_id: "map"
+    lambda_short: 0.1
+    laser_likelihood_max_dist: 2.0
+    laser_max_range: 100.0
+    laser_min_range: -1.0
+    laser_model_type: "likelihood_field"
+    max_beams: 60
+    max_particles: 2000
+    min_particles: 500
+    odom_frame_id: "odom"
+    pf_err: 0.05
+    pf_z: 0.99
+    recovery_alpha_fast: 0.0
+    recovery_alpha_slow: 0.0
+    resample_interval: 1
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
+    save_pose_rate: 0.5
+    sigma_hit: 0.2
+    tf_broadcast: true
+    transform_tolerance: 1.0
+    update_min_a: 0.2
+    update_min_d: 0.25
+    z_hit: 0.5
+    z_max: 0.05
+    z_rand: 0.5
+    z_short: 0.05
+    scan_topic: /scan_front_filtered
 
 bt_navigator:
   ros__parameters:

--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -1,44 +1,57 @@
-# amcl is not used because odom is received directly from MuJoCo
-# amcl:
-#   ros__parameters:
-#     use_sim_time: True
-#     alpha1: 0.2
-#     alpha2: 0.2
-#     alpha3: 0.2
-#     alpha4: 0.2
-#     alpha5: 0.2
-#     base_frame_id: "base_footprint"
-#     beam_skip_distance: 0.5
-#     beam_skip_error_threshold: 0.9
-#     beam_skip_threshold: 0.3
-#     do_beamskip: false
-#     global_frame_id: "map"
-#     lambda_short: 0.1
-#     laser_likelihood_max_dist: 2.0
-#     laser_max_range: 100.0
-#     laser_min_range: -1.0
-#     laser_model_type: "likelihood_field"
-#     max_beams: 60
-#     max_particles: 2000
-#     min_particles: 500
-#     odom_frame_id: "odom"
-#     pf_err: 0.05
-#     pf_z: 0.99
-#     recovery_alpha_fast: 0.0
-#     recovery_alpha_slow: 0.0
-#     resample_interval: 1
-#     robot_model_type: "nav2_amcl::DifferentialMotionModel"
-#     save_pose_rate: 0.5
-#     sigma_hit: 0.2
-#     tf_broadcast: true
-#     transform_tolerance: 1.0
-#     update_min_a: 0.2
-#     update_min_d: 0.25
-#     z_hit: 0.5
-#     z_max: 0.05
-#     z_rand: 0.5
-#     z_short: 0.05
-#     scan_topic: scan
+amcl:
+  ros__parameters:
+    use_sim_time: True
+    # Self-seed the particle filter at the robot's spawn pose (map origin) on
+    # activation, so localization starts without a manual 2D pose estimate.
+    # beluga_amcl is 2D: only x, y, yaw are declared (no z). The covariances set
+    # the initial spread (~0.5 m position, ~15 deg yaw) so the seed is not
+    # overconfident; beluga's default covariance is near-zero. The SetInitialPose
+    # Behavior re-seeds at the robot's current pose at each navigation Objective.
+    set_initial_pose: true
+    initial_pose:
+      x: 0.0
+      y: 0.0
+      yaw: 0.0
+      covariance_x: 0.25
+      covariance_y: 0.25
+      covariance_yaw: 0.0685
+    alpha1: 0.05
+    alpha2: 0.05
+    alpha3: 0.1
+    alpha4: 0.05
+    alpha5: 0.05
+    base_frame_id: "ridgeback_base_link"
+    beam_skip_distance: 0.5
+    beam_skip_error_threshold: 0.9
+    beam_skip_threshold: 0.3
+    do_beamskip: false
+    global_frame_id: "map"
+    lambda_short: 0.1
+    laser_likelihood_max_dist: 2.0
+    laser_max_range: 25.0
+    laser_min_range: 0.0
+    laser_model_type: "likelihood_field"
+    max_beams: 60
+    max_particles: 5000
+    min_particles: 1000
+    odom_frame_id: "odom"
+    pf_err: 0.05
+    pf_z: 0.99
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
+    resample_interval: 1
+    robot_model_type: "nav2_amcl::OmniMotionModel"
+    save_pose_rate: 0.5
+    sigma_hit: 0.2
+    tf_broadcast: true
+    transform_tolerance: 1.0
+    update_min_a: 0.2
+    update_min_d: 0.25
+    z_hit: 0.5
+    z_max: 0.05
+    z_rand: 0.5
+    z_short: 0.05
+    scan_topic: /scan_merged
 
 bt_navigator:
   ros__parameters:
@@ -155,6 +168,11 @@ controller_server:
       transform_tolerance: 0.1
       temperature: 0.3
       gamma: 0.015
+      # The Ridgeback is a mecanum (holonomic) base, but the controller runs in
+      # diff-drive mode on purpose: the robot reorients then drives forward,
+      # which keeps motion simple. DiffDrive constrains vy to 0, so vy_std/vy_max
+      # above are inactive; they are retained for an easy switch to motion_model
+      # "Omni" if holonomic strafing is wanted later.
       motion_model: "DiffDrive"
       visualize: false
       TrajectoryVisualizer:


### PR DESCRIPTION
needs: moveit_pro/#19710

Closes PickNikRobotics/moveit_pro#18065

Adds `beluga_amcl` map-based localization to hangar_sim, replacing the static identity `map → odom` TF with laser-scan localization.

## What
- Enables `beluga_amcl` as the localizer when `slam:=False` (default `localization:=True`). `dual_laser_merger` + `map_server` + `beluga_amcl` + `lifecycle_manager` load into the existing `nav2_container`.
- `dual_laser_merger` fuses the front and rear lidar scans into a single 360° `/scan_merged` for AMCL — with the front lidar alone, the airplane's long featureless fuselage gave the particle filter no position lock and it could diverge catastrophically.
- AMCL uses an omnidirectional motion model (the Ridgeback is mecanum) and self-seeds at the spawn pose via the native `set_initial_pose` param, so the filter starts without a manual 2D pose estimate.
- The `SetInitialPose` Behavior is added at the start of the clicked-point nav Objectives, re-seeding the filter at the robot's current pose each run.

## Why
The old setup had no real localization (a static identity TF stood in for `map → odom`). beluga estimates the pose from laser scans; merging both lidars is what keeps it stable near the fuselage (validated: max particle spread 149 m front-only → 0.69 m merged, zero divergence on the same route).

## Depends on
PickNikRobotics/moveit_pro#19710 — adds the `SetInitialPose` Behavior these Objectives use. **Merge #19710 first**; this PR's CI tests against #19710's image via the `needs:` token above.

## Release notes
Enhancement: Added `beluga_amcl` localization to `hangar_sim`, replacing the static `map → odom` identity TF with laser-scan-based localization. AMCL consumes a merged front+rear 360° scan so the particle filter stays stable near the hangar airplane.

## Claude agent checks
- [x] `code-reviewer`
- [x] `test-runner`
- [x] `platform-architect-bot`

_Reviewed via the rubrics in moveit_pro's `.claude/agents/`. Findings applied: `code-reviewer` (unused `log_level` removed; map-existence check made unconditional), `platform-architect-bot` (dead launch args removed; `not <bareword>` launch conditions replaced with `UnlessCondition`/string compares so lowercase `true`/`false` no longer crash), `roboticist-bot` (merge geometry/frames confirmed; `scan_time`/`laser_max_range` corrected; sync `queue_size` raised for headroom). Copilot findings applied (same gating fixes). `test-runner`: example_ws integration tests run against #19710's image via the `needs:` token._
