### PR TITLE
Docs: Add Tutorial 3 place waypoints

### DIFF
--- a/src/lab_sim/waypoints/ur_waypoints.yaml
+++ b/src/lab_sim/waypoints/ur_waypoints.yaml
@@ -1116,3 +1116,89 @@
     twist: []
     wrench: []
   name: Wrist 2 Min
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.4304390605935317
+    - -0.4378567680480089
+    - -0.32506040849446244
+    - -1.3786813884060156
+    - 1.5681700648384158
+    - -1.961524554294909
+    - -1.720721876348498
+    - 0.16537484166715177
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Above Tray Place Simple
+- description: ''
+  favorite: false
+  joint_group_names:
+  - gripper
+  - linear_actuator
+  - manipulator
+  joint_state:
+    effort: []
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - robotiq_85_left_knuckle_joint
+    - linear_rail_joint
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.4293739997326402
+    - -0.4053106793283895
+    - -0.3946348859742542
+    - -0.9263280141317556
+    - 1.4578660059546231
+    - -1.8691029152454264
+    - -1.675182968077337
+    - 0.16331769984549638
+    velocity: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        nanosec: 0
+        sec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+  name: Tray Place Simple


### PR DESCRIPTION
## Summary

Companion to the Tutorial 3 (Perception & ML) docs refresh in `moveit_pro` ([PR #18782](https://github.com/PickNikRobotics/moveit_pro/pull/18782)). Adds the two joint waypoints the AprilTag picker's two-stage place uses via `Move to Waypoint` with `keep_orientation_link_names=grasp_link`:

- `Above Tray Place Simple` — robot hovering above the placement tray, gripper pointing down
- `Tray Place Simple` — robot at the tray surface, gripper pointing down, ready to release

The tutorial walks readers through building the Objectives that consume these waypoints, so the Objectives themselves don't need to ship in `lab_sim`. The waypoints have to be saved here because their joint values can't easily be described in prose.

## Test plan

- [ ] Reload `lab_sim` and confirm the two new waypoints appear in the **Waypoints** panel
- [ ] Tutorial 3 walkthrough in companion PR [#18782](https://github.com/PickNikRobotics/moveit_pro/pull/18782) succeeds end-to-end against this waypoint set

🤖 Generated with [Claude Code](https://claude.com/claude-code)