### PR TITLE
Fix: VisualizePose port typo in MPC pose tracking Objectives

### DIFF
--- a/src/lab_sim/objectives/mpc_pose_tracking_dynamic_point_cloud_avoidance_with_sphere_down_sample.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking_dynamic_point_cloud_avoidance_with_sphere_down_sample.xml
@@ -24,7 +24,7 @@
       />
       <Decorator ID="ForEach" vector_in="{target_poses}" out="{pose_stamped}">
         <Control ID="Sequence">
-          <Action ID="VisualizePose" pose="{stamped_pose}" />
+          <Action ID="VisualizePose" pose="{pose_stamped}" />
           <Action ID="BreakpointSubscriber" _skipIf="true" />
           <SubTree
             ID="LoadAndVisualizePointCloud"

--- a/src/lab_sim/objectives/mpc_pose_tracking_static_point_cloud_avoidance_with_sphere_down_sample.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking_static_point_cloud_avoidance_with_sphere_down_sample.xml
@@ -17,7 +17,7 @@
         pose_stamped="{pose_stamped}"
         reference_frame="world"
       />
-      <Action ID="VisualizePose" pose="{stamped_pose}" />
+      <Action ID="VisualizePose" pose="{pose_stamped}" />
       <SubTree
         ID="LoadAndVisualizePointCloud"
         _collapsed="true"


### PR DESCRIPTION
## Summary

Two `lab_sim` Objectives have a transposed-word typo on a `VisualizePose` Behavior port: it reads `{stamped_pose}` but the upstream producer writes `{pose_stamped}`. The variable doesn't exist on the blackboard at tick time, so the Behavior fails immediately and takes the Objective with it.

This is a deterministic failure that fires every CI run on `main`, contributing to the broken `integration-test-in-studio-container (humble)` job.

**Files affected:**

- `src/lab_sim/objectives/mpc_pose_tracking_dynamic_point_cloud_avoidance_with_sphere_down_sample.xml:27`
- `src/lab_sim/objectives/mpc_pose_tracking_static_point_cloud_avoidance_with_sphere_down_sample.xml:20`

In each file the producer is the line directly above (`ForEach … out="{pose_stamped}"` in the dynamic case, `CreatePoseStamped pose_stamped="{pose_stamped}"` in the static case), so the fix is a one-token swap.

**Failing log signature on `main`:**

```
[error] VisualizePose Error: Failed to get required values from input data ports:
The input port 'pose' was set to '{stamped_pose}', which was not found.
Please verify that this is the correct blackboard variable name.
```

## Test plan

- [ ] CI `integration-test-in-studio-container (humble)` runs `MPC Pose Tracking Dynamic Point Cloud Avoidance with Sphere Down Sample` and `MPC Pose Tracking Static Point Cloud Avoidance with Sphere Down Sample` to SUCCESS (was failing on `main`).
- [ ] No other Objective references `{stamped_pose}` (verified by grep — only these two files used the typo'd name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)