### PR TITLE
Fix: Widen hangar_sim linear_x_joint limits to match map extents

### DIFF
--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -75,7 +75,7 @@
     <parent link="world" />
     <child link="virtual_rail_link_1" />
     <origin xyz="0 0 0" rpy="0 0 0" />
-    <limit effort="1000.0" lower="-20.0" upper="20.0" velocity="0.175" acceleration="10.0"/>
+    <limit effort="1000.0" lower="-25.0" upper="25.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>
 


### PR DESCRIPTION
## Summary
- Widens `linear_x_joint` limits in `ur5e_ridgeback.xacro` from ±20 m to ±25 m so the robot can reach the full X extent of the hangar map.
- The hangar map (`maps/hangar_map.yaml` + 1008×1310 px @ 0.05 m/px, origin `[-25, -6.6913, 0]`) covers X ∈ [-25, +25.4] m, but the URDF was clipping the joint to ±20.
- Fixes PickNikRobotics/moveit_pro#18745.

<img width="462" height="441" alt="image" src="https://github.com/user-attachments/assets/ad2cebdb-cb56-4ed4-aa2b-2c008f5e5f7f" />


## Test plan
- [ ] Rebuild `hangar_sim` and relaunch the stack.
- [ ] Run `Navigate to Clicked Point` and confirm targets near the hangar X extents (e.g. ±22 m) succeed without "less than its lower limit of -20" errors.
- [ ] Sanity-check that the robot can still navigate the typical interior workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)