### PR TITLE
fix: push button tolerance too low

### DIFF
--- a/src/lab_sim/objectives/mpc_pose_tracking_with_static_sphere_point_cloud_avoidance.xml
+++ b/src/lab_sim/objectives/mpc_pose_tracking_with_static_sphere_point_cloud_avoidance.xml
@@ -14,9 +14,9 @@
       <Action
         ID="GetPointCloud"
         message_out="{point_cloud}"
-        message_timeout_sec="5.000000"
+        message_timeout_sec="30.000000"
         topic_name="/wrist_camera/points"
-        publisher_timeout_sec="5.000000"
+        publisher_timeout_sec="10.000000"
       />
       <Action
         ID="GetCentroidFromPointCloud"

--- a/src/lab_sim/objectives/push_button_with_a_trajectory.xml
+++ b/src/lab_sim/objectives/push_button_with_a_trajectory.xml
@@ -77,7 +77,7 @@
         admittance_parameters_msg="{admittance_parameters_msg}"
         goal_position_tolerance="0.001000"
         joint_trajectory_msg="{joint_trajectory_msg}"
-        path_position_tolerance="0.20000"
+        path_position_tolerance="0.25000"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/wrist_snap.xml
+++ b/src/lab_sim/objectives/wrist_snap.xml
@@ -11,7 +11,8 @@
       <Action
         ID="GetPointCloud"
         topic_name="/wrist_camera/points"
-        message_timeout_sec="15"
+        publisher_timeout_sec="10"
+        message_timeout_sec="30"
       />
       <Action ID="SendPointCloudToUI" />
     </Control>


### PR DESCRIPTION
this should help to actually pass the CI flake since the laptop moves in a weirder way compared to the original static button. the real test harness infrastructure needs some rethinking in future versions for physics this tight

closes [#18381](https://github.com/PickNikRobotics/moveit_pro/issues/18381)