### PR TITLE
Fix: Bump gripper and GetImage timeouts to stabilize CI

### DIFF
--- a/src/lab_sim/objectives/close_gripper.xml
+++ b/src/lab_sim/objectives/close_gripper.xml
@@ -10,7 +10,7 @@
         ID="MoveGripperAction"
         gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
         position="0.7929"
-        timeout="15.000000"
+        timeout="30.000000"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/open_gripper.xml
+++ b/src/lab_sim/objectives/open_gripper.xml
@@ -11,7 +11,7 @@
         ID="MoveGripperAction"
         gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
         position="0.05"
-        timeout="15.000000"
+        timeout="30.000000"
       />
     </Decorator>
   </BehaviorTree>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -12,7 +12,7 @@
     <Control ID="Sequence">
       <Action
         ID="GetImage"
-        message_timeout_sec="5.000000"
+        message_timeout_sec="15.000000"
         topic_name="{image_topic_name}"
         message_out="{image}"
       />


### PR DESCRIPTION
## Summary

- Bumps `MoveGripperAction` `timeout` from **15s → 30s** in `close_gripper.xml` and `open_gripper.xml`.
- Bumps `GetImage` `message_timeout_sec` from **5s → 15s** in the shared `picknik_ur_base_config` `Segment Image from No Negative Text Prompt Subtree`.

## Why

CI on `main` started flaking ~24h after the MuJoCo `3.2.7 → 3.6.0` upgrade in `moveit_pro` (`6eedef88a5`, Apr 14). The new constraint solver is heavier per step, so on CI hardware the sim runs slower than realtime and emits `Mujoco model timestep not running in realtime. Increase the model timestep.` warnings. Two previously-borderline timeouts in `lab_sim` integration tests then fall over:

| Failing test | ~ frequency | Underlying error |
|---|---|---|
| `push_button_with_a_trajectory.xml` | ~9/10 | `MoveGripperAction Error: ... gripper failed to reach the target position within 15.0s. Current values: position=0.7929` |
| `ml_segment_point_cloud.xml` | ~4/10 | `GetImage Error: Failed to get next message on topic '/wrist_camera/color': Timed out after 5 seconds` |

CI history correlates tightly with the upgrade:

| Period | Pass | Fail |
|---|---|---|
| Apr 8–14 (pre-upgrade) | 24 | 0 |
| Apr 15 (day after upgrade) | 4 | 1 |
| Apr 17 | 1 | 7 |
| Apr 20–30 | ~3 | ~37 |

This is a **mitigation**, not a root-cause fix — `moveit_pro#18534` and PR #610's description (`"the real test harness infrastructure needs some rethinking ... for physics this tight"`) call out that the durable answer is rethinking the test harness or coarsening the MuJoCo timestep (currently the default 0.002s / 500Hz; no explicit `timestep` is set in `lab_sim/description/scene.xml`). Doing that lives in a follow-up.

## Test plan

- [x] Trigger `CI` workflow on this branch and confirm `integration-test-in-studio-container (humble)` passes.
- [ ] Re-run a few times to verify the historical ~92% failure rate drops.
- [x] Manual smoke test: `Push Button With a Trajectory`, `ML Segment Point Cloud`, and `Close/Open Gripper` Objectives still execute correctly on a dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)