### PR TITLE
Fix: Description for Segment Point Cloud from Text Prompt Subtree

### DIFF
--- a/src/dual_arm_sim/objectives/segment_point_cloud_from_text.xml
+++ b/src/dual_arm_sim/objectives/segment_point_cloud_from_text.xml
@@ -6,7 +6,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Point Cloud from Text Prompt Subtree"
-    _description="Captures a point cloud and requests the user to click an object in the image to be segmented. The point cloud is then filtered to only include the selected object."
+    _description="Captures a point cloud and runs text-based segmentation on the camera image using the given text prompts. The point cloud is then filtered to only include the regions matching the prompts."
     _favorite="false"
     camera_topic_name="/wrist_camera/camera_info"
     image_topic_name="/wrist_camera/color"

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
@@ -6,7 +6,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Point Cloud from Text Prompt Subtree"
-    _description="Captures a point cloud and requests the user to click an object in the image to be segmented. The point cloud is then filtered to only include the selected object."
+    _description="Captures a point cloud and runs text-based segmentation on the camera image using the given text prompts. The point cloud is then filtered to only include the regions matching the prompts."
     _favorite="false"
     camera_topic_name="/wrist_camera/camera_info"
     image_topic_name="/wrist_camera/color"


### PR DESCRIPTION
## Summary
- The `_description` on `Segment Point Cloud from Text Prompt Subtree` was copied from the clicked-point variant and described the wrong workflow.
- Replace it with a description that matches what the subtree actually does: capture a point cloud, run text-based segmentation on the camera image, and filter the cloud to regions matching the prompts.

Fixes #15651

## Test plan
- [ ] Open the subtree in Studio and confirm the metadata description reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)