### PR TITLE
Fix: Description for "3 Waypoints Pick and Place" in lab_sim

### DIFF
--- a/src/lab_sim/objectives/3_waypoint_pick_and_place.xml
+++ b/src/lab_sim/objectives/3_waypoint_pick_and_place.xml
@@ -3,7 +3,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="3 Waypoints Pick and Place"
-    _description="Basic example of repeatedly grabbing a small (invisible) object, placing it at desired destination, and then moving back to a home position"
+    _description="Basic example of repeatedly picking a small medicine bottle from the table, placing it in the sorting tray, and then picking it back out and returning it to the original spot. Loops until cancelled."
     _favorite="true"
   >
     <Control ID="Sequence">


### PR DESCRIPTION
## Summary
- The `_description` on `lab_sim`'s `3 Waypoints Pick and Place` Objective said the picked object was "small (invisible)" — a holdover from when the scene had no physical pickable.
- `lab_sim` now contains medicine bottles and a sorting tray. Updated the description to match: pick a bottle from the table, drop it in the tray, pick it back out, return it, loop.
- `mock_sim`'s variant is intentionally untouched since it still operates on an invisible object.

## Test plan
- [ ] Open `lab_sim` → `3 Waypoints Pick and Place` in Studio and confirm the metadata description reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)