### PR TITLE
Refactor: Rename WaitForUserTrajectoryApproval to WaitForMTCSolutionApproval

### DIFF
--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_-45.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_-45.xml
@@ -32,7 +32,7 @@
           velocity_scale_factor="1.000000"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           cartesian_path_links="grasp_link"
           solution="{debug_solution}"
         />

--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_0.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_0.xml
@@ -32,7 +32,7 @@
           velocity_scale_factor="1.000000"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           cartesian_path_links="grasp_link"
           solution="{debug_solution}"
         />

--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_45.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_45.xml
@@ -32,7 +32,7 @@
           velocity_scale_factor="1.000000"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           cartesian_path_links="grasp_link"
           solution="{debug_solution}"
         />

--- a/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
@@ -133,7 +133,7 @@
               name="Optionally execute trajectory and return to start joint state"
             >
               <Action
-                ID="WaitForUserTrajectoryApproval"
+                ID="WaitForMTCSolutionApproval"
                 solution="{mtc_solution}"
                 cartesian_path_links="tool0"
               />

--- a/src/factory_sim/objectives/plan_and_execute_with_position_only.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_position_only.xml
@@ -71,7 +71,7 @@
             name="Optionally execute trajectory and return to start joint state"
           >
             <Action
-              ID="WaitForUserTrajectoryApproval"
+              ID="WaitForMTCSolutionApproval"
               solution="{debug_solution}"
               cartesian_path_links="tool0"
             />

--- a/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
@@ -77,7 +77,7 @@
             name="Optionally execute trajectory and return to start joint state"
           >
             <Action
-              ID="WaitForUserTrajectoryApproval"
+              ID="WaitForMTCSolutionApproval"
               solution="{mtc_solution}"
               cartesian_path_links="tool0"
             />

--- a/src/grinding_sim/objectives/grind_machined_part.xml
+++ b/src/grinding_sim/objectives/grind_machined_part.xml
@@ -83,7 +83,7 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
       />
       <!--Wait for user to approve the grinding path and then execute it-->
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action ID="ExecuteTrajectory" />
       <!--Move away from the part after completing the grinding path-->
       <SubTree

--- a/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
+++ b/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
@@ -71,10 +71,7 @@
           planning_group_name="manipulator"
           planning_scene_msg="{planning_scene}"
         />
-        <Action
-          ID="WaitForUserTrajectoryApproval"
-          solution="{debug_solution}"
-        />
+        <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       </Control>
     </Control>
   </BehaviorTree>

--- a/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
+++ b/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
@@ -109,7 +109,7 @@
         velocity_scale_factor="1.000000"
       />
       <Action ID="IsUserAvailable" />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteTrajectory"
         execution_pipeline="jtc"

--- a/src/hangar_sim/objectives/find_and_spray_plane.xml
+++ b/src/hangar_sim/objectives/find_and_spray_plane.xml
@@ -69,7 +69,7 @@
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteTrajectory"
         execution_pipeline="jtc"

--- a/src/hangar_sim/objectives/solution_-_find_and_spray_plane.xml
+++ b/src/hangar_sim/objectives/solution_-_find_and_spray_plane.xml
@@ -69,7 +69,7 @@
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteTrajectory"
         execution_pipeline="jtc"

--- a/src/hangar_sim/objectives/solution_draw_square.xml
+++ b/src/hangar_sim/objectives/solution_draw_square.xml
@@ -109,7 +109,7 @@
         velocity_scale_factor="1.000000"
       />
       <Action ID="IsUserAvailable" />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteTrajectory"
         execution_pipeline="jtc"

--- a/src/hangar_sim/objectives/solution_spray_plane.xml
+++ b/src/hangar_sim/objectives/solution_spray_plane.xml
@@ -59,7 +59,7 @@
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
       />
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="ExecuteTrajectory"
         execution_pipeline="jtc"

--- a/src/hangar_sim/objectives/wait_for_trajectory_approval_if_user_available.xml
+++ b/src/hangar_sim/objectives/wait_for_trajectory_approval_if_user_available.xml
@@ -12,7 +12,7 @@
         <Action ID="IsUserAvailable" />
       </Decorator>
       <Action
-        ID="WaitForUserTrajectoryApproval"
+        ID="WaitForMTCSolutionApproval"
         solution="{solution}"
         cartesian_path_links="ridgeback_base_link;grasp_link"
       />

--- a/src/kitchen_sim/objectives/write_text.xml
+++ b/src/kitchen_sim/objectives/write_text.xml
@@ -46,7 +46,7 @@
             ik_joint_space_density="0.050000"
           />
           <Action
-            ID="WaitForUserTrajectoryApproval"
+            ID="WaitForMTCSolutionApproval"
             solution="{debug_solution}"
             cartesian_path_links="grasp_link"
           />

--- a/src/lab_sim/objectives/plan_and_save_trajectory.xml
+++ b/src/lab_sim/objectives/plan_and_save_trajectory.xml
@@ -37,7 +37,7 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
       />
       <!--Preview the trajectory for approval and save if approved-->
-      <Action ID="WaitForUserTrajectoryApproval" solution="{debug_solution}" />
+      <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       <Action
         ID="SaveJointTrajectoryToYaml"
         yaml_filename="~/user_ws/src/lab_sim/objectives/joint_trajectory"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/april_tag_object_registration.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/april_tag_object_registration.xml
@@ -241,13 +241,13 @@
           tip_offset="0;0;0.05;0;0;0"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           solution="{debug_solution}"
           cartesian_path_links="grasp_link"
         />
       </Control>
       <Action
-        ID="WaitForUserTrajectoryApproval"
+        ID="WaitForMTCSolutionApproval"
         solution="{debug_solution}"
         cartesian_path_links="grasp_link"
       />

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
@@ -92,10 +92,7 @@
             cartesian_space_step="0.02"
             debug_solution="{debug_solution}"
           />
-          <Action
-            ID="WaitForUserTrajectoryApproval"
-            solution="{debug_solution}"
-          />
+          <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
           <Action
             ID="SetAdmittanceParameters"
             config_file_name="jtac_parameters.yaml"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/write_picknik.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/write_picknik.xml
@@ -65,7 +65,7 @@
               ik_joint_space_density="0.100000"
             />
             <Action
-              ID="WaitForUserTrajectoryApproval"
+              ID="WaitForMTCSolutionApproval"
               solution="{debug_solution}"
               cartesian_path_links="grasp_link"
             />

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_path_ik_example.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_path_ik_example.xml
@@ -79,10 +79,7 @@
           trajectory_sampling_rate="100"
           velocity_scale_factor="1.000000"
         />
-        <Action
-          ID="WaitForUserTrajectoryApproval"
-          solution="{debug_solution}"
-        />
+        <Action ID="WaitForMTCSolutionApproval" solution="{debug_solution}" />
       </Control>
       <Action ID="ExecuteTrajectory" />
     </Control>

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/wait_for_trajectory_approval_if_user_available.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/wait_for_trajectory_approval_if_user_available.xml
@@ -12,7 +12,7 @@
         <Action ID="IsUserAvailable" />
       </Decorator>
       <Action
-        ID="WaitForUserTrajectoryApproval"
+        ID="WaitForMTCSolutionApproval"
         solution="{solution}"
         cartesian_path_links="first_grasp_link;second_grasp_link;third_grasp_link;fourth_grasp_link"
       />

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
@@ -96,7 +96,7 @@
           solution_out_2="{push_solution}"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           solution="{full_push_button_solution}"
         />
         <SubTree

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
@@ -147,7 +147,7 @@
           solution_out_2="{push_solution}"
         />
         <Action
-          ID="WaitForUserTrajectoryApproval"
+          ID="WaitForMTCSolutionApproval"
           solution="{full_push_along_axis_solution}"
         />
         <SubTree


### PR DESCRIPTION
Addresses part of https://github.com/PickNikRobotics/moveit_pro/issues/19012

## Summary

MoveIt Pro 9.3 deprecates `WaitForUserTrajectoryApproval` in favor of `WaitForMTCSolutionApproval`. The two Behaviors have identical ports (`solution` and `cartesian_path_links`) and identical defaults, so the migration is a pure `ID="..."` attribute rename. Existing Objectives continue to work but emit a deprecation warning on every tick.

This PR updates the 23 in-repo Objectives that reference the deprecated Behavior. Submodule files under `src/external_dependencies/phoebe_ws/` (6 additional Objectives) are intentionally not touched — those need an upstream PR against `phoebe_ws`.

## Design notes

- **Problem**: Running affected Objectives in 9.3 logs a deprecation warning per tick of the wait node.
- **Alternative considered**: Keep the legacy name and rely on the back-compat shim until 10.0. Rejected — the rename is mechanical, low-risk, and clears the warning now rather than deferring 23 files of work to the 10.0 release crunch.
- **Chosen approach**: Pure `sed` rename across in-repo `.xml` Objectives. `prettier` collapsed three multi-line `<Action>` blocks into single lines because the shorter new name fits within the line-width limit — those reformats are kept since they are direct, intentional consequences of the rename.

Follow-up: A separate PR will handle the `CreateStampedX` → `CreateXStamped` migration (more involved — output port names change too). The phoebe submodule needs its own upstream PR.

## Verification

- `pre-commit run` passes on all modified files.
- No remaining in-repo references to `WaitForUserTrajectoryApproval` (confirmed with grep, excluding `external_dependencies/`).
- Affected configs: `april_tag_sim`, `factory_sim`, `grinding_sim`, `hangar_sim`, `kitchen_sim`, `lab_sim`, `moveit_pro_kinova_configs/kinova_sim`, `moveit_pro_ur_configs/{multi_arm_sim,picknik_ur_site_config}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)