### PR TITLE
Refactor: Rename CreateStampedX Behaviors to CreateXStamped

### DIFF
--- a/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
@@ -11,9 +11,9 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="base_link"
-        stamped_pose="{start}"
+        pose_stamped="{start}"
       />
       <Action
         ID="SwitchController"

--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -114,9 +114,9 @@
       <!--Retract upward after grasping (Cartesian path, 0.305m = 12 inches)-->
       <Control ID="Sequence" name="Pick Retract">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="grasp_link"
-          stamped_pose="{pick_retract_pose}"
+          pose_stamped="{pick_retract_pose}"
           position_xyz="0;0;-0.305"
         />
         <Action ID="ResetPoseStampedVector" vector="{pick_retract_path}" />
@@ -179,23 +179,23 @@
           service_name="/velocity_force_controller/zero_fts"
         />
         <Action
-          ID="CreateStampedWrench"
-          stamped_wrench="{desired_wrench}"
+          ID="CreateWrenchStamped"
+          wrench_stamped="{desired_wrench}"
           reference_frame="grasp_link"
           torque_xyz="0;0;0"
           force_xyz="0;0;0"
         />
         <Action
-          ID="CreateStampedTwist"
+          ID="CreateTwistStamped"
           reference_frame="grasp_link"
-          stamped_twist="{desired_twist}"
+          twist_stamped="{desired_twist}"
           angular_velocity_xyz="0;0;0"
           linear_velocity_xyz="0.0;0;0.05"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="grasp_link"
-          stamped_pose="{initial_pose}"
+          pose_stamped="{initial_pose}"
         />
         <Action
           ID="TransformPoseFrame"
@@ -237,9 +237,9 @@
         <Control ID="Sequence" name="Release and Retract">
           <SubTree ID="Open Gripper" />
           <Action
-            ID="CreateStampedPose"
+            ID="CreatePoseStamped"
             reference_frame="grasp_link"
-            stamped_pose="{place_retract_pose}"
+            pose_stamped="{place_retract_pose}"
             position_xyz="0;0;-0.08"
           />
           <Action ID="ResetPoseStampedVector" vector="{place_retract_path}" />

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -12,9 +12,9 @@
         planning_scene_msg="{planning_scene}"
       />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="world"
-        stamped_pose="{back_wall_pose}"
+        pose_stamped="{back_wall_pose}"
         position_xyz="0.15; 0.83; 0.85"
         orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
       />
@@ -167,9 +167,9 @@
             <Control ID="Sequence" name="Retract" _collapsed="false">
               <!--Retract away from the grasp-->
               <Action
-                ID="CreateStampedPose"
+                ID="CreatePoseStamped"
                 reference_frame="grasp_link"
-                stamped_pose="{retract_pose}"
+                pose_stamped="{retract_pose}"
                 position_xyz="0;0;-0.25"
                 orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
               />
@@ -276,23 +276,23 @@
                   wait_for_server_available_timeout="3.000000"
                 />
                 <Action
-                  ID="CreateStampedWrench"
-                  stamped_wrench="{desired_wrench}"
+                  ID="CreateWrenchStamped"
+                  wrench_stamped="{desired_wrench}"
                   reference_frame="grasp_link"
                   torque_xyz="0;0;0"
                   force_xyz="0;0;0"
                 />
                 <Action
-                  ID="CreateStampedTwist"
+                  ID="CreateTwistStamped"
                   reference_frame="grasp_link"
-                  stamped_twist="{desired_twist}"
+                  twist_stamped="{desired_twist}"
                   angular_velocity_xyz="0;0;0"
                   linear_velocity_xyz="0.0;0;0.05"
                 />
                 <Action
-                  ID="CreateStampedPose"
+                  ID="CreatePoseStamped"
                   reference_frame="grasp_link"
-                  stamped_pose="{initial_pose}"
+                  pose_stamped="{initial_pose}"
                   orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
                   position_xyz="0.000000;0.000000;0.000000"
                 />
@@ -360,9 +360,9 @@
                     <SubTree ID="Open Gripper" _collapsed="true" />
                     <!--Retract upward after releasing the bottle-->
                     <Action
-                      ID="CreateStampedPose"
+                      ID="CreatePoseStamped"
                       reference_frame="grasp_link"
-                      stamped_pose="{place_retract_pose}"
+                      pose_stamped="{place_retract_pose}"
                       position_xyz="0;0;-0.08"
                       orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
                     />

--- a/src/lab_sim/objectives/pick_all_pill_bottles.xml
+++ b/src/lab_sim/objectives/pick_all_pill_bottles.xml
@@ -152,12 +152,12 @@
             _collapsed="true"
           >
             <Action
-              ID="CreateStampedPose"
+              ID="CreatePoseStamped"
               name="Gripper origin in gripper frame"
               position_xyz="0;0;0"
               orientation_xyzw="0;0;0;1"
               reference_frame="grasp_link"
-              stamped_pose="{gripper_local_pose}"
+              pose_stamped="{gripper_local_pose}"
             />
             <Action
               ID="TransformPoseFrame"
@@ -179,12 +179,12 @@
               visualize_pose="false"
             />
             <Action
-              ID="CreateStampedPose"
+              ID="CreatePoseStamped"
               name="Build predrop hover pose"
               position_xyz="0.95;0.5568;0.805"
               orientation_xyzw="-0.0436;0.9990;0;0"
               reference_frame="world"
-              stamped_pose="{predrop_hover_pose}"
+              pose_stamped="{predrop_hover_pose}"
             />
             <SubTree
               ID="CreateVector"
@@ -308,12 +308,12 @@
             />
             <SubTree ID="Open Gripper" _collapsed="true" />
             <Action
-              ID="CreateStampedPose"
+              ID="CreatePoseStamped"
               name="Post-place retract pose (10 cm up in tool frame)"
               position_xyz="0;0;-0.1"
               orientation_xyzw="0;0;0;1"
               reference_frame="grasp_link"
-              stamped_pose="{post_place_retract_pose}"
+              pose_stamped="{post_place_retract_pose}"
             />
             <SubTree
               ID="CreateVector"

--- a/src/lab_sim/objectives/pick_from_pose_vector.xml
+++ b/src/lab_sim/objectives/pick_from_pose_vector.xml
@@ -60,9 +60,9 @@
       <SubTree ID="Execute MTC Solution" solution="{mtc_solution}" />
       <SubTree ID="Close Gripper" _collapsed="true" />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="grasp_link"
-        stamped_pose="{retract_pose}"
+        pose_stamped="{retract_pose}"
         position_xyz="{retract_xyz}"
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />

--- a/src/lab_sim/objectives/place_at_pose_vector.xml
+++ b/src/lab_sim/objectives/place_at_pose_vector.xml
@@ -60,9 +60,9 @@
       <SubTree ID="Execute MTC Solution" solution="{mtc_solution}" />
       <SubTree ID="Open Gripper" _collapsed="true" />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="grasp_link"
-        stamped_pose="{retract_pose}"
+        pose_stamped="{retract_pose}"
         position_xyz="{retract_xyz}"
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />

--- a/src/lab_sim/objectives/segment_bottle_subtree.xml
+++ b/src/lab_sim/objectives/segment_bottle_subtree.xml
@@ -15,12 +15,12 @@
         _collapsed="false"
       >
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           name="Define source-workspace crop box pose"
           reference_frame="world"
           position_xyz="0.17;0.6;0.55"
           orientation_xyzw="0;0;0;1"
-          stamped_pose="{source_crop_box_pose}"
+          pose_stamped="{source_crop_box_pose}"
         />
         <!--Flush any cached snapshot so the captured image and point
              cloud come from the current camera pose, not stale from
@@ -140,12 +140,12 @@
         _collapsed="false"
       >
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           name="Define table-removal box pose"
           reference_frame="world"
           position_xyz="0;0;-0.5"
           orientation_xyzw="0;0;0;1"
-          stamped_pose="{table_remove_box_pose}"
+          pose_stamped="{table_remove_box_pose}"
         />
         <Action
           ID="RemovePointsInBox"


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/moveit_pro/issues/19012

## Summary

MoveIt Pro 9.3 deprecates the `CreateStampedPose`, `CreateStampedTwist`, and `CreateStampedWrench` Behaviors in favor of `CreatePoseStamped`, `CreateTwistStamped`, and `CreateWrenchStamped` — names that match the underlying `geometry_msgs` message types. The deprecated Behaviors emit a deprecation warning when used and will be removed in a future release.

Unlike the `WaitForUserTrajectoryApproval` rename (PR #622), this migration also renames the **output port attribute**: `stamped_pose` → `pose_stamped`, `stamped_twist` → `twist_stamped`, `stamped_wrench` → `wrench_stamped`. Each port is only used on its own `CreateStamped*` Action — verified — and no downstream Behavior reads the legacy `{stamped_pose}` / `{stamped_twist}` / `{stamped_wrench}` default-key blackboard entries in any in-repo Objective, so the rename is safe.

This PR updates the 7 in-repo Objectives that reference the deprecated Behaviors. Submodule files under `src/external_dependencies/phoebe_ws/` (6 additional Objectives that use `CreateStampedPose`) are intentionally not touched — those need an upstream PR against `phoebe_ws`.

## Design notes

- **Problem**: Running affected Objectives in 9.3 logs a deprecation warning per tick.
- **Alternative considered**: Treat the output-port-name change as a breaking change and split into a multi-PR sequence with the new keys first as aliases. Rejected — no in-repo consumers read the default keys, and the per-action attribute rename is co-located in the same XML block as the ID rename, so a single mechanical migration is cleaner than a phased one.
- **Chosen approach**: Six `sed` substitutions per file (3 ID renames + 3 port-attribute renames), then `pre-commit run`. Pre-audit confirmed (a) every `stamped_pose=` / `stamped_twist=` / `stamped_wrench=` attribute in the workspace appears inside a `CreateStamped*` Action, and (b) no Objective references `{stamped_pose}` / `{stamped_twist}` / `{stamped_wrench}` as a blackboard read. So both halves of the rename are localized to the Action being deprecated.

## Verification

- `pre-commit run` passes on all modified files; prettier did not reformat further.
- Zero remaining in-repo references to `CreateStampedPose|Twist|Wrench` or to the legacy `stamped_*=` attributes (confirmed with grep, excluding `external_dependencies/`).
- Affected configs: `lab_sim` (6 files), `hangar_sim` (1 file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)