### PR TITLE
Fix: Coarsen MuJoCo timestep on CI to stop slower-than-realtime flakes (backport #615 to v9.3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,15 @@ on:
 
 jobs:
   integration-test-in-studio-container:
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@01ac7e19a9e4eeeff4965556e2be37159025e893 # v0.0.8
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@81223807e77a3ebfebcf2254ac830cfb4cc67a70 # v0.0.9
     with:
       image_tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
       colcon_test_args: "--executor sequential"
       runner: "picknik-16-amd64"
+      # Coarsen MuJoCo timestep on CI (default 0.002s = 500Hz) so the heavier 3.6.0
+      # constraint solver stays at-or-under realtime on CI runners. See
+      # PickNikRobotics/moveit_pro#18534 for the underlying flake history.
+      mujoco_ci_timestep: "0.003"
     secrets:
       moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
 

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -34,6 +34,7 @@ from moveit_pro_test_utils.objective_test_fixture import (
     ExecuteObjectiveResource,
     execute_objective_resource as execute_objective_resource,
     get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
     run_objective,
 )
 
@@ -70,6 +71,10 @@ skip_objectives = {
     "Pick All Pill Bottles",
     "Pick up Object",
     "Place Object",
+    # Flaky on CI after the MuJoCo 3.2.7 -> 3.6.0 upgrade: the JTAC compliance loop
+    # is sensitive to the simulator falling under realtime, and we see ~50% flake
+    # rate even with mujoco_ci_timestep coarsening and CPU pinning. See PR #615.
+    "Push Button With a Trajectory",
     "Record Square Trajectory",
     "Scan Scene - Multiple Point Clouds",
     "Stack Objects with ICP",  # Skipped because there is no primary ui to switch to in ci


### PR DESCRIPTION
Cherry-picks #615 (`6740d124`) onto `v9.3`. Clean apply, no conflicts. Same change as on `main`: bump the integration-test reusable workflow pin to `moveit_pro_ci v0.0.9`, pass `mujoco_ci_timestep: "0.003"`, re-export `reset_simulation_before_test`, and skip `Push Button With a Trajectory` in CI.

Full rationale, alternatives considered, and tradeoffs are in #615's description — they apply unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
