### PR TITLE
Fix: Prevent dual odom TF publication when use_fuse is true

### DIFF
--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -20,6 +20,9 @@ hardware:
           package: "hangar_sim"
           path: "config/moveit/joint_limits.yaml"
       - mujoco_model: "description/hangar_scene.xml"
+      # Set to false when use_fuse:=true so fuse is the sole odom -> ridgeback_base_link publisher.
+      # Rebuild hangar_sim after changing this value.
+      - publish_odom: true
 
   # Specify any additional launch files for running the robot in simulation mode.
   # Used when hardware.simulated is True.

--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="picknik_ur_mujoco_ros2_control" params="mujoco_model mujoco_viewer:=false">
+  <xacro:macro name="picknik_ur_mujoco_ros2_control" params="mujoco_model mujoco_viewer:=false publish_odom:=true">
 
     <ros2_control name="ur_mujoco_control" type="system">
       <!-- Per-LiDAR topic routing. Sensor names match the MJCF site-name prefix
@@ -20,7 +20,7 @@
           <param name="render_publish_rate">20</param>
           <param name="tf_publish_rate">60</param>
           <param name="lidar_publish_rate">10</param>
-          <param name="publish_odom">true</param>
+          <param name="publish_odom">${publish_odom}</param>
           <param name="odom_child_frame">ridgeback_base_link</param>
           <param name="odom_rate">150</param>
           <param name="odom_zero_z">true</param>

--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -19,6 +19,8 @@
   <xacro:arg name="initial_positions_file" default="$(find picknik_ur_base_config)/config/initial_positions.yaml"/>
   <xacro:arg name="mujoco_model" default="description/bar_scene.xml"/>
   <xacro:arg name="mujoco_viewer" default="false" />
+  <!-- Set to false when use_fuse:=true so fuse is the sole odom → ridgeback_base_link publisher. -->
+  <xacro:arg name="publish_odom" default="true"/>
 
   <!-- Import UR and environment macros -->
   <xacro:include filename="$(find picknik_ur_base_config)/description/picknik_ur_macro.xacro"/>
@@ -109,6 +111,6 @@
   <xacro:vacuum_urdf parent="tool0"/>
 
   <!-- MuJoCo Hardware interface -->
-  <xacro:picknik_ur_mujoco_ros2_control mujoco_model="$(arg mujoco_model)" mujoco_viewer="$(arg mujoco_viewer)"/>
+  <xacro:picknik_ur_mujoco_ros2_control mujoco_model="$(arg mujoco_model)" mujoco_viewer="$(arg mujoco_viewer)" publish_odom="$(arg publish_odom)"/>
 
 </robot>

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -28,6 +28,7 @@
 
 import os
 
+import yaml
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
@@ -35,7 +36,10 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
+    LogInfo,
+    OpaqueFunction,
     SetEnvironmentVariable,
+    Shutdown,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -49,6 +53,52 @@ from launch_ros.actions import PushRosNamespace
 from launch_ros.descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
 from nav2_common.launch import RewrittenYaml, ReplaceString
+
+
+def _check_fuse_publish_odom(context, *args, **kwargs):
+    """Fail fast if use_fuse:=true but MuJoCo is still configured to publish odom TF.
+
+    When fuse is enabled it is the sole authority on odom → ridgeback_base_link.
+    MuJoCo must not also publish that edge or consumers will see jittery, interleaved updates.
+    Set 'publish_odom: "false"' in config.yaml under hardware.robot_description.urdf_params.
+    """
+    if LaunchConfiguration("use_fuse").perform(context).lower() != "true":
+        return []
+
+    config_path = os.path.join(
+        get_package_share_directory("hangar_sim"), "config", "config.yaml"
+    )
+    with open(config_path) as f:
+        robot_config = yaml.safe_load(f)
+
+    urdf_params = (
+        robot_config.get("hardware", {})
+        .get("robot_description", {})
+        .get("urdf_params", [])
+    )
+    publish_odom = True  # MuJoCo default
+    for param in urdf_params:
+        if isinstance(param, dict) and "publish_odom" in param:
+            publish_odom = str(param["publish_odom"]).lower() not in (
+                "false",
+                "0",
+                "no",
+            )
+            break
+
+    if publish_odom:
+        return [
+            LogInfo(
+                msg=(
+                    "use_fuse:=true but MuJoCo is still configured to publish"
+                    " odom -> ridgeback_base_link. When fuse is enabled, fuse must be the sole"
+                    " publisher of that TF edge. Set 'publish_odom: false' in config.yaml under"
+                    " hardware.robot_description.urdf_params, then rebuild hangar_sim."
+                )
+            ),
+            Shutdown(reason="publish_odom must be false when use_fuse:=true"),
+        ]
+    return []
 
 
 def generate_launch_description():
@@ -347,7 +397,7 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
 
-    # Declare the launch options
+    # Declare the launch options — all args must be declared before the OpaqueFunction runs.
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)
@@ -359,6 +409,7 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
     ld.add_action(declare_use_fuse_cmd)
+    ld.add_action(OpaqueFunction(function=_check_fuse_publish_odom))
 
     # Add the actions to launch all of the navigation nodes
     ld.add_action(bringup_cmd_group)


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/moveit_pro/issues/18174

## Problem

When `use_fuse:=true`, both the MuJoCo hardware plugin (`publish_odom: true`) and fuse (`publish_tf: true`) published the `odom → ridgeback_base_link` TF edge simultaneously. TF takes the most recent message, producing jittery, interleaved odometry estimates for all consumers (nav2, slam_toolbox, MoveIt).

The original issue identified the platform velocity controller as the source of the conflict — that was already fixed via `enable_odom_tf: false` on both controllers. This PR addresses the remaining conflict: MuJoCo's unconditional TF publishing.

## Approach

- Made `publish_odom` a xacro arg in `picknik_ur_mujoco_ros2_control.xacro` (default `true`) and forwarded it through `ur5e_ridgeback.xacro`
- Exposed `publish_odom` in `config.yaml` `urdf_params` so users can set it to `false` when enabling fuse
- Added a launch-time guard (`OpaqueFunction`) in `robot_drivers_to_persist_sim.launch.py` that shuts down with a clear message if `use_fuse:=true` but `publish_odom` is still `true` in `config.yaml`

## Alternatives considered

- **Disable fuse's `publish_tf` in sim**: rejected — when testing fuse, you want fuse's filtered estimate in the TF tree, not MuJoCo ground truth.
- **Runtime self-suppression in MuJoCo** (detect fuse node, auto-disable odom): cleaner long-term but requires plugin changes; the config + launch guard is sufficient for now.
- **Read config via `SystemConfigParser`** in the guard: would handle `based_on_package` chains correctly but adds a dependency; acceptable tradeoff given hangar_sim is the only user of this pattern today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)