### PR TITLE
Fix(factory_sim) - align bracket-detection ICP with new spawn positions

### DIFF
--- a/src/factory_sim/objectives/look_for_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/look_for_bracket_part_subtree.xml
@@ -12,7 +12,7 @@
       <!--Get the bracket pointcloud from the CAD file and make a guess as to where it might be-->
       <Action
         ID="CreatePoseStamped"
-        position_xyz="-0.35;0.8;0.4"
+        position_xyz="-0.42;0.55;0.4"
         orientation_xyzw="0.000;0.000;0.0;1"
         name="Initial guess for bracket pose, somewhere above left bin"
         pose_stamped="{guess_pose}"
@@ -79,7 +79,7 @@
         base_point_cloud="{blue_bracket_part_cloud}"
         max_iterations="100"
         target_pose_in_base_frame="{registered_to_guess_pose}"
-        max_correspondence_distance="0.5"
+        max_correspondence_distance="0.15"
         name="Produce updated pose, relative to the initial guess pose"
       />
       <Action


### PR DESCRIPTION
## Problem

  `Pick and Place Brackets from Left Bin` (and `Pick Brackets from Left Bin`) fail on the first Repeat iteration with `PlanMTCTask Error:
  PLANNING_FAILED` (`pose IK (0/1)`) in `Vacuum Pick Bracket Part Subtree`. Reported as
  [PickNikRobotics/moveit_pro#19096](https://github.com/PickNikRobotics/moveit_pro/issues/19096).

  ## Root cause

  Commit e6b9b2f2 ("fix(factory_sim): 18180 Pick and Place Brackets sim setup and tool-handling cartesian fixes") moved bracket spawn positions from the buggy `<replicate>` layout into explicit `<include>` blocks at known positions, but did not update the ICP guess pose or correspondence window in `Look for Bracket Part Subtree`. Both stayed tuned for the prior buggy spawn behavior.

  - Guess `(-0.35, 0.8, 0.4)` is ~30 cm in Y away from the new bracket-0 spawn `(-0.42, 0.5, 0.35)`.
  - `max_correspondence_distance=0.5` (50 cm) is wider than the entire left-bin interior (~30 cm), so ICP pairs the CAD with bin floor / wall points and returns a registered pose ~25 cm below reality.
  - Approach pose lands underneath the bin → MTC `pose IK (0/1)` → `PLANNING_FAILED`.

  Confirmed by reading the failing `approach_pose` from the blackboard: position `(-0.387, 0.750, 0.264)` → reverse-derived registered pose `(-0.51, 0.82, 0.10)` vs the actual bracket-0 location `(-0.42, 0.5, 0.35)`.

  ## Approach

  Two changes in `look_for_bracket_part_subtree.xml`:

  1. **Move the guess** to `(-0.42, 0.55, 0.4)` — midpoint of the three bracket spawn positions (`Y = 0.50, 0.56, 0.62`), within 5 cm of any of them.
  2. **Tighten `max_correspondence_distance`** from `0.5` → `0.15`. The left-bin volume is `0.32 × 0.55 × 0.28 m` per `crop_box_size`; 15 cm covers a single bracket and rejects unrelated features. Swaps silent misregistration for a clean fail-loud miss if the guess ever drifts more than 15 cm from the part.

  ## Alternatives considered

  - **Update only the guess pose.** Sufficient for the immediate failure, but leaves the 50 cm correspondence window — a future scene change or camera drift could re-introduce misregistration silently. Rejected because the 50 cm tolerance is the deeper footgun.
  - **Update only `max_correspondence_distance`.** Would break ICP entirely with the current guess (30 cm away from any bracket) instead of producing a wrong result. Rejected — needs the guess fix too.

  ## Manual verification

  - `Pick and Place Brackets from Left Bin`: all three Repeat iterations complete and pick all three brackets.
  - Video

[Screencast from 2026-05-15 14-09-05.webm](https://github.com/user-attachments/assets/8af6039e-3a65-4d81-a60a-3ef709a2ee9c)


Fixes PickNikRobotics/moveit_pro#19096