### PR TITLE
Fix: lab_sim Tutorial 1 walk-through bugs

### DIFF
--- a/src/lab_sim/objectives/ml_find_objects_on_table.xml
+++ b/src/lab_sim/objectives/ml_find_objects_on_table.xml
@@ -26,6 +26,11 @@
         bounding_box_labels="{confidence_scores_str}"
         image="{wrist_camera_image}"
       />
+      <!--Auto-switch a view pane to the masks visualization so users can immediately see the output.-->
+      <Action
+        ID="SwitchUIPrimaryView"
+        primary_view_name="/masks_visualization"
+      />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -123,39 +123,6 @@
         <SubTree ID="Look at Table" _collapsed="true" />
         <SubTree ID="Take Wrist Camera Snapshot" _collapsed="true" />
       </Control>
-      <!--Warm up velocity_force_controller so the first placement is not a cold start-->
-      <Control ID="Sequence" _collapsed="false">
-        <Action
-          ID="SwitchController"
-          activate_controllers="velocity_force_controller"
-          controller_switch_action_name="/controller_manager/switch_controller"
-          timeout="-1.000000"
-          activate_asap="true"
-          strictness="1"
-          controller_list_action_name="/controller_manager/list_controllers"
-          automatic_deactivation="true"
-          automatic_activation="true"
-          deactivate_controllers=""
-        />
-        <Action
-          ID="CallTriggerService"
-          service_name="/velocity_force_controller/zero_fts"
-          response_timeout="3.000000"
-          wait_for_server_available_timeout="3.000000"
-        />
-        <Action
-          ID="SwitchController"
-          activate_controllers="joint_trajectory_admittance_controller"
-          controller_switch_action_name="/controller_manager/switch_controller"
-          timeout="-1.000000"
-          activate_asap="true"
-          strictness="1"
-          controller_list_action_name="/controller_manager/list_controllers"
-          automatic_deactivation="true"
-          automatic_activation="true"
-          deactivate_controllers=""
-        />
-      </Control>
       <Decorator ID="ForceSuccess" _collapsed="false">
         <Decorator ID="KeepRunningUntilFailure" _collapsed="false">
           <Control ID="Sequence" name="TopLevelSequence" _collapsed="false">

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -353,62 +353,56 @@
               name="Release and Retract"
               _collapsed="false"
             >
-              <Control ID="Sequence" _collapsed="false">
-                <Control ID="Sequence" _collapsed="false">
-                  <Control ID="Sequence" _collapsed="false">
-                    <!--Release the bottle-->
-                    <SubTree ID="Open Gripper" _collapsed="true" />
-                    <!--Retract upward after releasing the bottle-->
-                    <Action
-                      ID="CreatePoseStamped"
-                      reference_frame="grasp_link"
-                      pose_stamped="{place_retract_pose}"
-                      position_xyz="0;0;-0.08"
-                      orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
-                    />
-                    <Action
-                      ID="ResetPoseStampedVector"
-                      vector="{place_retract_path}"
-                    />
-                    <Action
-                      ID="AddPoseStampedToVector"
-                      input="{place_retract_pose}"
-                      vector="{place_retract_path}"
-                    />
-                    <Action
-                      ID="PlanCartesianPath"
-                      acceleration_scale_factor="1.000000"
-                      blending_radius="0.020000"
-                      debug_solution="{debug_solution}"
-                      ik_cartesian_space_density="0.010000"
-                      ik_joint_space_density="0.100000"
-                      joint_trajectory_msg="{joint_trajectory_msg}"
-                      path="{place_retract_path}"
-                      planning_group_name="manipulator"
-                      position_only="true"
-                      tip_links="grasp_link"
-                      trajectory_sampling_rate="100"
-                      velocity_scale_factor="1.000000"
-                      max_optimizer_iterations="1"
-                      tip_offset="0.000000;0.000000;0.000000;0.000000;0.000000;0.000000"
-                    />
-                    <Action
-                      ID="ExecuteTrajectory"
-                      goal_duration_tolerance="-1.000000"
-                      joint_trajectory_msg="{joint_trajectory_msg}"
-                      controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
-                      execution_pipeline="jtac"
-                    />
-                    <!--Remove the used pose so the next iteration gets a fresh position-->
-                    <Action
-                      ID="RemoveFromVector"
-                      input_vector="{place_positions}"
-                      index="0"
-                      output_vector="{place_positions}"
-                    />
-                  </Control>
-                </Control>
-              </Control>
+              <!--Release the bottle-->
+              <SubTree ID="Open Gripper" _collapsed="true" />
+              <!--Retract upward after releasing the bottle-->
+              <Action
+                ID="CreatePoseStamped"
+                reference_frame="grasp_link"
+                pose_stamped="{place_retract_pose}"
+                position_xyz="0;0;-0.08"
+                orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
+              />
+              <Action
+                ID="ResetPoseStampedVector"
+                vector="{place_retract_path}"
+              />
+              <Action
+                ID="AddPoseStampedToVector"
+                input="{place_retract_pose}"
+                vector="{place_retract_path}"
+              />
+              <Action
+                ID="PlanCartesianPath"
+                acceleration_scale_factor="1.000000"
+                blending_radius="0.020000"
+                debug_solution="{debug_solution}"
+                ik_cartesian_space_density="0.010000"
+                ik_joint_space_density="0.100000"
+                joint_trajectory_msg="{joint_trajectory_msg}"
+                path="{place_retract_path}"
+                planning_group_name="manipulator"
+                position_only="true"
+                tip_links="grasp_link"
+                trajectory_sampling_rate="100"
+                velocity_scale_factor="1.000000"
+                max_optimizer_iterations="1"
+                tip_offset="0.000000;0.000000;0.000000;0.000000;0.000000;0.000000"
+              />
+              <Action
+                ID="ExecuteTrajectory"
+                goal_duration_tolerance="-1.000000"
+                joint_trajectory_msg="{joint_trajectory_msg}"
+                controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+                execution_pipeline="jtac"
+              />
+              <!--Remove the used pose so the next iteration gets a fresh position-->
+              <Action
+                ID="RemoveFromVector"
+                input_vector="{place_positions}"
+                index="0"
+                output_vector="{place_positions}"
+              />
             </Control>
           </Control>
         </Decorator>


### PR DESCRIPTION
## Summary

`lab_sim` Objective cleanups surfaced by a Tutorial 1 walk-through on 9.2.1.

## Problem

1. **`/masks_visualization` doesn't auto-show.** The `ML Find Objects on Table` Objective publishes masks but never calls `SwitchUIPrimaryView`, so a first-time user runs the Objective and sees nothing happen unless they know to manually switch a pane to `/masks_visualization`. The other ML Objectives in `lab_sim` (`ml_segment_image`, `ml_find_bottles_on_table_from_image_exemplar`) already auto-switch — this one is an outlier.
2. **Deeply nested redundant `Sequence` wrappers in `pick_all_bottles_with_apriltags.xml`.** The `Release and Retract` subtree had a Sequence containing a Sequence containing a Sequence containing a Sequence with the actual actions. Each intermediate wrapper had exactly one child, so the nesting carries no behavior — but it is genuinely confusing when a tutorial reader opens the tree.
3. **Warm-up `velocity_force_controller` block at the top of `Pick All Bottles with AprilTags`.** The objective starts with `SwitchController → velocity_force_controller`, `zero_fts`, `SwitchController → joint_trajectory_admittance_controller` *before* doing any picking, ostensibly to dodge a "cold start" on the first placement. The two controller swaps add a few seconds of dead time at the start of every run and the cost being guarded against is essentially zero — the same swap happens inside the place loop anyway.

## Approach

Two commits:

1. **`fix(lab_sim): Tutorial 1 walk-through fixes`**
   - `ml_find_objects_on_table.xml`: append `SwitchUIPrimaryView primary_view_name="/masks_visualization"` to the top-level Sequence, mirroring the pattern used by the other ML Objectives in `lab_sim`.
   - `pick_all_bottles_with_apriltags.xml`: remove the three redundant `Sequence` wrappers inside `Release and Retract` — multiple unnamed Sequences nested in a row, each with a single child. The outer `Release and Retract` Sequence (with `name=`) is preserved.
2. **`fix(lab_sim): Remove warm-up velocity_force_controller block`**
   - `pick_all_bottles_with_apriltags.xml`: delete the entire warm-up Sequence (`SwitchController` → `velocity_force_controller`, `CallTriggerService /velocity_force_controller/zero_fts`, `SwitchController → joint_trajectory_admittance_controller`).

> **Note on Sequence wrappers.** Per [Dave's review feedback](https://github.com/PickNikRobotics/moveit_pro_example_ws/pull/634#pullrequestreview-...), Sequences used for *organization* (grouping related siblings under a meaningful chunk) stay even when unnamed. Only Sequences that are stacked in a row with single children (no actual grouping work) are removed.

### Alternatives considered

- Adding a docs note saying "manually switch your view pane" instead of fixing the Objective — pushes the friction onto every reader and is inconsistent with the other ML Objectives.
- Keeping the warm-up block but moving it inside the loop's first iteration only — overcomplicates the tree for a problem that doesn't appear to exist in practice.
- Auto-deduping unary-Sequence nesting via a pre-commit hook — would catch other Objectives that have similar redundant wrapping, but is out of scope for this fix.

## Validation

- `pre-commit run --files src/lab_sim/objectives/ml_find_objects_on_table.xml src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml` — passes (prettier, Validate Objective favorites, codespell, mixed line endings, EOF).
- XML well-formedness verified by `prettier` and `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` on both files.

## Manual verification

- Run `ML Find Objects on Table` in `lab_sim` and confirm the view pane swaps to `/masks_visualization` automatically once `PublishMask2D` returns.
- Run `Pick All Bottles with AprilTags` and confirm: the picking loop still places bottles in the tray; no regression versus the previous behavior on the first place (the warm-up was supposedly there to make the first place not be a cold start — verify the first place still succeeds without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)