### PR TITLE
Add overlap-warning workflow for files shared with moveit_pro_empty_ws

### DIFF
--- a/.github/workflows/warn-empty-ws-overlap.yaml
+++ b/.github/workflows/warn-empty-ws-overlap.yaml
@@ -1,0 +1,72 @@
+name: Warn on moveit_pro_empty_ws overlap
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  overlap:
+    name: Check overlap with moveit_pro_empty_ws
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const upstream = { owner: 'PickNikRobotics', repo: 'moveit_pro_empty_ws', ref: 'main' };
+            const marker = '<!-- empty-ws-overlap-warning -->';
+
+            const changed = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: context.issue.number, per_page: 100 },
+              (res) => res.data.filter((f) => f.status !== 'removed').map((f) => f.filename),
+            );
+
+            const branch = await github.rest.repos.getBranch({ owner: upstream.owner, repo: upstream.repo, branch: upstream.ref });
+            const tree = await github.rest.git.getTree({
+              owner: upstream.owner,
+              repo: upstream.repo,
+              tree_sha: branch.data.commit.commit.tree.sha,
+              recursive: 'true',
+            });
+            if (tree.data.truncated) {
+              core.warning(`Tree for ${upstream.owner}/${upstream.repo}@${upstream.ref} was truncated; overlap result may be incomplete.`);
+            }
+            const upstreamPaths = new Set(tree.data.tree.filter((e) => e.type === 'blob').map((e) => e.path));
+            const overlap = changed.filter((p) => upstreamPaths.has(p)).sort();
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 100,
+            });
+            const prior = existing.find((c) => c.body && c.body.includes(marker));
+
+            if (overlap.length === 0) {
+              if (prior) {
+                await github.rest.issues.deleteComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prior.id });
+              }
+              core.info('No overlap with moveit_pro_empty_ws.');
+              return;
+            }
+
+            const body = [
+              marker,
+              `⚠️ This PR modifies ${overlap.length} file(s) that also exist in [\`${upstream.owner}/${upstream.repo}\`](https://github.com/${upstream.owner}/${upstream.repo}/tree/${upstream.ref}).`,
+              '',
+              'Consider whether the change should land upstream in `moveit_pro_empty_ws` first so downstream forks pick it up on the next sync.',
+              '',
+              '<details><summary>Overlapping files</summary>',
+              '',
+              ...overlap.map((p) => `- \`${p}\``),
+              '',
+              '</details>',
+            ].join('\n');
+
+            if (prior) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prior.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }
+            core.warning(`Overlap with ${upstream.owner}/${upstream.repo}: ${overlap.length} file(s).`);


### PR DESCRIPTION
## Problem

Files that exist in both `moveit_pro_empty_ws` (parent) and `moveit_pro_example_ws` (fork) can drift when a change is made only to the fork. Reviewers don't always notice during PR review, and the divergence is usually discovered later during an upstream merge — at which point the fix is much more disruptive.

## Alternatives considered

1. **Sync a manifest of upstream paths into this repo via a periodic workflow in `moveit_pro_empty_ws`.** Rejected: introduces another moving part and the manifest goes stale between syncs.
2. **`git clone` `moveit_pro_empty_ws` inside the action and diff locally.** Rejected: slower, requires auth handling for a private/internal repo, and is overkill — we only need a path list, not file contents.
3. **Chosen: read `moveit_pro_empty_ws`'s tree from the GitHub API at PR time.** A single recursive `git/trees` call returns every path, the data is always current, and no checkout of either repo is needed.

## Approach

One `actions/github-script@v9.0.0` step. No `actions/checkout`. The script:

- Lists PR files via `pulls.listFiles` (paginated, ignoring deletions).
- Fetches `moveit_pro_empty_ws`'s default-branch tree via `git.getTree` with `recursive: true`.
- Intersects the two path sets.
- Posts, updates, or deletes a **sticky comment** keyed by an HTML marker (`<!-- empty-ws-overlap-warning -->`), so subsequent pushes update one comment instead of spamming the PR. If a later push removes the overlap entirely, the comment is deleted.
- Emits a `core.warning` if the upstream tree response is ever truncated (current size is well under GitHub's ~100k-entry limit, so this is precautionary).

### Tradeoffs

- The warning is **advisory only** — it never blocks a PR. Sometimes a fork-only change is the correct choice (e.g., example-specific tuning of a shared config), so failing the check would create false-positive friction.
- Uses the default `GITHUB_TOKEN`. This works because both repos are in the same org and visible to the workflow. If `moveit_pro_empty_ws` access ever tightens, the token can be swapped for a fine-grained PAT secret without other changes.
- Action pins use the `actions/checkout@<SHA> # v<version>` style used elsewhere in `ci.yaml`.