### PR TITLE
Fix: Move Forward 2m Objective fails immediately in hangar_sim

### DIFF
--- a/src/hangar_sim/objectives/solution_move_forward_2m.xml
+++ b/src/hangar_sim/objectives/solution_move_forward_2m.xml
@@ -1,31 +1,63 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Solution - Move Forward 2m">
   <!--//////////-->
   <BehaviorTree
     ID="Solution - Move Forward 2m"
-    _description=""
+    _description="Drive the mobile base 2 m forward along its current heading using Nav2."
     _favorite="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="CreatePoseStamped"
-        reference_frame="grasp_link"
-        pose_stamped="{pose_stamped}"
+        reference_frame="base_link"
+        pose_stamped="{start}"
+      />
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="base_link"
+        pose_stamped="{goal}"
         orientation_xyzw="0;0;0;1"
-        position_xyz="0;0;2"
+        position_xyz="2;0;0"
       />
       <Action
         ID="VisualizePose"
         marker_lifetime="0.000000"
-        marker_name="pose"
+        marker_name="goal"
         marker_size="0.100000"
-        pose="{pose_stamped}"
+        pose="{goal}"
       />
-      <SubTree
-        ID="Move to a StampedPose"
-        _collapsed="true"
-        controller_names="joint_trajectory_controller"
-        target_pose="{pose_stamped}"
+      <Action
+        ID="SwitchController"
+        activate_controllers="platform_velocity_controller_nav2"
+        deactivate_controllers="velocity_force_controller;joint_trajectory_controller;platform_velocity_controller"
+      />
+      <Action
+        ID="ComputePathToPoseAction"
+        action_name="/compute_path_to_pose"
+        goal="{goal}"
+        ignore_stamp_time="true"
+        path="{path}"
+        planning_time="{planning_time}"
+        start="{start}"
+        timeout_sec="-1.000000"
+        use_start="false"
+        planner_id="GridBased"
+      />
+      <Action ID="WaitForUserPathApproval" path="{path}" />
+      <Action
+        ID="FollowPathAction"
+        action_name="/follow_path"
+        controller_id="FollowPath"
+        distance_to_goal="{distance_to_goal}"
+        goal_checker_id="general_goal_checker"
+        path="{path}"
+        speed="{speed}"
+        timeout_sec="-1.000000"
+      />
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+        deactivate_controllers="platform_velocity_controller_nav2"
       />
     </Control>
   </BehaviorTree>


### PR DESCRIPTION
Closes PickNikRobotics/moveit_pro#19119

## Problem

In `hangar_sim`, the *Solution - Move Forward 2m* Objective failed every IK sample (`pose: 0/4863`) and never produced any motion. The Objective built its target as `(0, 0, 2)` in `grasp_link` frame and handed it to `Move to a StampedPose` (MTC pose IK). From the *Initial Pose* arm configuration the gripper's local +Z projects below the floor / outside the workspace, so every IK candidate failed the collision check.

The deeper issue: the Objective is in the *Training Examples* subcategory, named "Move Forward 2m", and is meant to demonstrate driving the mobile base 2 m. There's no reason to plumb that intent through MTC pose IK on `grasp_link` — it's fundamentally a 2D base-navigation problem.

## Alternatives considered

- **Keep MTC, fix the target frame.** Switch `reference_frame` to `base_link` / `world` with a sensible static pose. Plans, but still pins a gripper pose for a base move — the IK is under-constrained and could find non-base-only solutions, and the demo's *name* lies about what it does.
- **Joint-space goal on `linear_actuator` group.** The base is mecanum / velocity-commanded (`platform_velocity_controller` / `_nav2`), not position-commanded — no clean joint-space target for "forward 2 m." Wrong primitive.
- **Bespoke "relative base move" behavior.** Doesn't exist in this codebase, would skip costmap collision checking, and would diverge from the established pattern. Not worth introducing for a single training example.

## Chosen approach

Rewrite the Objective as a Nav2 base motion, modeled on the existing `objectives/navigate_to_clicked_point.xml` in the same workspace:

- Goal of `(2, 0, 0)` in `base_link` with `ignore_stamp_time="true"` — Nav2 resolves it to the planner frame at action time, so it lands 2 m ahead of the base's current heading.
- Standard controller handoff: deactivate the arm / base controllers, activate `platform_velocity_controller_nav2`, plan with `ComputePathToPoseAction` (GridBased), wait for user approval, follow with `FollowPathAction`, then switch back to `joint_trajectory_controller`.
- The final `SwitchController` also deactivates `platform_velocity_controller_nav2` — small improvement over the reference, which leaves the nav controller running after handoff.

This matches the established Nav2 demo in the same workspace, gets collision-aware planning, and makes the Objective do what its name promises.

## Known limitations

These apply equally to the reference `navigate_to_clicked_point.xml` and are out of scope for this fix — flagging for future cleanup:

- **Controller handoff is not exception-safe.** If `ComputePathToPoseAction` / `FollowPathAction` / user-approval fails, the cleanup `SwitchController` doesn't run and the robot is left with `platform_velocity_controller_nav2` active. Would need a fallback / `ForceSuccess`-style wrapper.
- **`WaitForUserPathApproval` is kept for parity** with the reference demo. Reasonable case for dropping it from a "Solution" Objective so it's truly one-shot.
- **Does not address #19132** (robot spawning at `linear_y ≈ 10.94` instead of the keyframe origin). Until that lands, the Initial Pose is in self-collision and Nav2 will refuse to plan; reset the keyframe (`/mujoco_system/reset_keyframe '{keyframe_name: default}'`) before running this Objective.

## Manual verification

The 8.10 workspace variant (`workspaces/moveit_pro_example_ws_8_10/src/hangar_sim/objectives/solution_move_forward_2m.xml`) has the same broken pattern and likely needs the same fix on the 8.10 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)