### PR TITLE
Fix: Launch fuse and AprilTag detectors for space_satellite_sim in dev

### DIFF
--- a/src/moveit_pro_kinova_configs/space_satellite_sim/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/config/config.yaml
@@ -10,6 +10,14 @@ based_on_package: kinova_sim
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
+  # Launched by the main agent when `simulated: True`. Hosts the AprilTag
+  # detectors and the fuse state estimator so /odom_filtered is published in
+  # dev — not just in prod / e2e where `agent_bridge.launch.xml` runs
+  # standalone.
+  simulated_hardware_launch_file:
+    package: "space_satellite_sim"
+    path: "launch/simulated_extras.launch.xml"
+
   # Parameters used to configure the robot description through XACRO.
   # A URDF and SRDF are both required.
   # [Required]

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/launch/agent_bridge.launch.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/launch/agent_bridge.launch.xml
@@ -2,11 +2,4 @@
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <include
-    file="$(find-pkg-share space_satellite_sim)/launch/36h11.launch.yml"
-  />
-  <include
-    file="$(find-pkg-share space_satellite_sim)/launch/36h11_wrist.launch.yml"
-  />
-  <include file="$(find-pkg-share space_satellite_sim)/launch/fuse.launch.py" />
 </launch>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/launch/simulated_extras.launch.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/launch/simulated_extras.launch.xml
@@ -1,0 +1,14 @@
+<launch>
+  <!--Sim-only extras launched by the agent via the
+      `hardware.simulated_hardware_launch_file` key in config.yaml. The agent's
+      `agent_launch_setup` function picks this up in both dev
+      (`agent_robot.app`) and prod / e2e (`agent_bridge.launch.xml`), so a
+      single config key drives both paths.-->
+  <include
+    file="$(find-pkg-share space_satellite_sim)/launch/36h11.launch.yml"
+  />
+  <include
+    file="$(find-pkg-share space_satellite_sim)/launch/36h11_wrist.launch.yml"
+  />
+  <include file="$(find-pkg-share space_satellite_sim)/launch/fuse.launch.py" />
+</launch>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
@@ -176,14 +176,9 @@
             </Control>
           </Decorator>
           <Action
-            ID="LogMessage"
-            log_level="info"
-            message="'Waiting for operator approval'"
-          />
-          <Action
             ID="BreakpointSubscriber"
             breakpoint_topic="/moveit_pro_breakpoint"
-            message=""
+            message="Approve satellite grappling"
           />
           <Action
             ID="CreatePoseStamped"
@@ -210,6 +205,7 @@
           <SubTree ID="Close Gripper" _collapsed="true" />
         </Control>
       </Control>
+      <Action ID="LogMessage" log_level="info" message="'Mission complete'" />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>


### PR DESCRIPTION
In dev mode (`agent_robot.app`), the `space_satellite_sim` configuration never started the fuse `state_estimator` or the AprilTag detectors. `/odom_filtered` was never published, so `Grapple Moving Satellite via Fiducial Tracking`'s `GetOdom` only ever produced a default-constructed `PoseStamped` with an empty `frame_id`, surfacing as a rapid stream of:

```
[ERROR] odom pose for debug Error: Cannot find transform between frames `world` (target) and `` (source).
```

Verified with `ros2 node list` (no `state_estimator`, no `apriltag_*`) and `ros2 topic echo --once /odom_filtered` ("topic does not appear to be published yet").

`agent_bridge.launch.xml` is only launched as a standalone container in prod / e2e (`docker-compose-prod.yaml:120`, `docker-compose.e2e.yaml:73`). The mechanism that makes `agent_robot.app` include extra simulation nodes in dev is the `hardware.simulated_hardware_launch_file` key (see `moveit_studio_agent/launch_description.py:302-312`'s `if is_simulated:` block). That key was never set for `space_satellite_sim`, so fuse + AprilTag detectors were dev-invisible since PR #225.

## Changes

- New `simulated_extras.launch.xml` holding the AprilTag + fuse includes.
- `agent_bridge.launch.xml` delegates to it, so prod / e2e and dev share one source.
- `config/config.yaml` sets `hardware.simulated_hardware_launch_file` so `agent_robot.app` picks it up automatically when running simulated.

## Commit structure

Two commits, kept separate intentionally (please do **not** squash):

1. `fix(space_satellite_sim): launch fuse and apriltag detectors in dev` — the launch-wiring fix described above.
2. `chore(space_satellite_sim): clarify operator approval breakpoint message` — small UX tweak to the grappling objective: replaces a `LogMessage` console line with a descriptive `BreakpointSubscriber` message ("Approve satellite grappling") so the prompt shows up in the operator UI.

The two changes are unrelated; splitting them keeps the launch fix bisect-clean and lets the UX tweak be reverted independently if needed.