### PR TITLE
Update Kinova site config to accept non-embedded realsense wrist cam

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
@@ -26,6 +26,9 @@ hardware:
       # When set to true, will route gripper comms through kinova and gripper_com_port is unused.
       - use_internal_bus_gripper_comm: "true"
       - gripper_com_port: "/dev/ttyUSB0"  # Must be 1st serial device plugged in to populate as ttyUSB0
+      # Wrist camera selection: none | kinova_integrated | realsense_usb.
+      # Must match the wrist_camera_type arg in launch/agent_bridge.launch.xml.
+      - wrist_camera_type: "none"
 
 # This Configures moveit params that are in moveit_config.py
 moveit_params:

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/description/kinova_gen3.xacro
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/description/kinova_gen3.xacro
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <robot name="gen3" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Arguments for Kinova -->
-  <xacro:arg name="vision" default="false" />
   <xacro:arg name="robot_ip" default="yyy.yyy.yyy.yyy" />
   <xacro:arg name="robotiq_gripper" default="robotiq_2f_85" />
   <xacro:arg name="username" default="admin" />
@@ -20,8 +19,17 @@
   <xacro:arg name="gripper_max_force" default="100.0" />
   <xacro:arg name="gripper_com_port" default="/dev/ttyUSB0" />
 
+  <!-- Wrist camera selection: none | kinova_integrated | realsense_usb.
+       kinova_integrated turns on the kortex vision module (bracelet-with-vision
+       mesh + camera_link/camera_color_frame/camera_depth_frame added by
+       kortex_description). The other modes leave the bracelet unmodified. -->
+  <xacro:arg name="wrist_camera_type" default="none" />
+  <xacro:property name="wrist_camera_type" value="$(arg wrist_camera_type)" />
+  <xacro:property name="vision_effective" value="${wrist_camera_type == 'kinova_integrated'}" />
+
   <!-- Import environment macros -->
   <xacro:include filename="$(find picknik_accessories)/descriptions/geometry/cube.urdf.xacro"/>
+  <xacro:include filename="$(find picknik_accessories)/descriptions/sensors/realsense_d415.urdf.xacro"/>
 
   <!-- World is centered under base_link of the robot, on the ground -->
   <link name="world"/>
@@ -38,7 +46,7 @@
   <xacro:load_arm
     parent="world"
     dof="7"
-    vision="$(arg vision)"
+    vision="${vision_effective}"
     robot_ip="$(arg robot_ip)"
     username="$(arg username)"
     password="$(arg password)"
@@ -69,6 +77,21 @@
     use_internal_bus_gripper_comm="$(arg use_internal_bus_gripper_comm)"
     com_port="$(arg gripper_com_port)">
   </xacro:load_gripper>
+
+  <!-- USB-attached wrist RealSense. The kinova_integrated case is handled by
+       the kortex URDF via the vision flag and adds no links here. -->
+  <xacro:if value="${wrist_camera_type == 'realsense_usb'}">
+    <link name="wrist_camera_mount_link"/>
+    <joint name="wrist_camera_mount_joint" type="fixed">
+      <parent link="bracelet_link"/>
+      <child  link="wrist_camera_mount_link"/>
+      <!-- Defaults to the Kinova factory bracket pose; tune to your bracket. -->
+      <origin xyz="0 -0.06841 -0.05044" rpy="0 ${3.14 / 180.0 * 100} -1.5708"/>
+    </joint>
+    <xacro:realsense_d415 parent="wrist_camera_mount_link" name="wrist_camera">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </xacro:realsense_d415>
+  </xacro:if>
 
   <!-- Environment -->
   <xacro:cube link_name="table" connected_to="world" length="2.00" width="2.00" height="0.25" alpha="0.3">

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/launch/agent_bridge.launch.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/launch/agent_bridge.launch.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <launch>
+  <!-- Wrist camera selection: none | kinova_integrated | realsense_usb.
+       Must match urdf_params.wrist_camera_type in config.yaml. -->
+  <arg name="wrist_camera_type" default="none" />
+
   <include
     file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
   />
-  <!-- Uncomment the next line for kinovas with an embedded realsense wrist camera -->
-  <!-- <include file="$(find-pkg-share kinova_gen3_site_config)/launch/cameras.launch.xml" /> -->
+  <include
+    file="$(find-pkg-share kinova_gen3_site_config)/launch/cameras.launch.xml"
+  >
+    <arg name="wrist_camera_type" value="$(var wrist_camera_type)" />
+  </include>
 </launch>

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/launch/cameras.launch.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/launch/cameras.launch.xml
@@ -1,11 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <launch>
-  <include
-    file="$(find-pkg-share kinova_vision)/launch/kinova_vision.launch.py"
+  <!-- Match this to urdf_params.wrist_camera_type in config.yaml: none | kinova_integrated | realsense_usb -->
+  <arg name="wrist_camera_type" default="none" />
+  <arg name="realsense_serial_no" default="_135322065444" />
+
+  <!-- Integrated Kinova vision module, driven over RTSP by kinova_vision.
+       Frame ids are left at kinova_vision defaults (camera_link / camera_color_frame /
+       camera_depth_frame) so they match the links added by kortex_description
+       when vision=true. -->
+  <group
+    if="$(eval &quot;'$(var wrist_camera_type)' == 'kinova_integrated'&quot;)"
   >
-    <arg name="camera" value="wrist_camera" />
-    <arg name="depth_registration" value="true" />
-    <arg name="max_color_pub_rate" value="6.0" />
-    <arg name="max_depth_pub_rate" value="6.0" />
-  </include>
+    <include
+      file="$(find-pkg-share kinova_vision)/launch/kinova_vision.launch.py"
+    >
+      <arg name="camera" value="wrist_camera" />
+      <arg name="depth_registration" value="true" />
+      <arg name="max_color_pub_rate" value="6.0" />
+      <arg name="max_depth_pub_rate" value="6.0" />
+    </include>
+  </group>
+
+  <!-- USB-attached RealSense, driven by realsense2_camera -->
+  <group if="$(eval &quot;'$(var wrist_camera_type)' == 'realsense_usb'&quot;)">
+    <include file="$(find-pkg-share realsense2_camera)/launch/rs_launch.py">
+      <arg name="camera_name" value="wrist_camera" />
+      <arg name="camera_namespace" value="" />
+      <arg name="serial_no" value="$(var realsense_serial_no)" />
+      <arg name="enable_color" value="true" />
+      <arg name="enable_depth" value="true" />
+      <arg name="align_depth.enable" value="true" />
+      <arg name="pointcloud.enable" value="true" />
+      <arg name="publish_tf" value="false" />
+    </include>
+  </group>
 </launch>


### PR DESCRIPTION
Adds a `wrist_camera_type` to the Kinova HW config, accepting `none` (default). `kinova_integrated` for Kinovas with an integrated wrist camera, or `realsense_usb` for Kinovas with a wrist camera plugged to the host USB via external cable (my case).
