### PR TITLE
Fix: ML Move Boxes to Loading Zone exits cleanly when scene drained

### DIFF
--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -14,33 +14,96 @@
         orientation_xyzw="0;1.0;0;0"
         position_xyz="-4.5;8.4;0.5"
       />
-      <Decorator ID="RetryUntilSuccessful" num_attempts="1000">
-        <Decorator ID="ForceFailure">
+      <!--
+        Initialize the drained signal and the per-iteration pick flags.
+
+        `drained := false` is the load-bearing one — if the very first iteration of the
+        loop below fails before the in-loop `Script(drained := ...)` runs, the
+        post-loop `ScriptCondition(drained)` would otherwise read an undefined value.
+
+        `picked_at_wp1 := false` / `picked_at_wp2 := false` are defensive. Each pick
+        waypoint Subtree resets its `picked_box` output port at the top of its own
+        body and again before wp2 below, so the in-loop reads are always fresh; this
+        outer init only matters if the Subtree fails before either of those resets
+        runs.
+
+        Compatibility note: this Objective relies on three runtime contracts that the
+        loaded `moveit_pro` build must satisfy — `ScriptCondition` (built-in BT.CPP 4),
+        `GetSizeOfVector` and `RepeatUnlessFailureEachTick` (both in `moveit_pro` core
+        Behaviors as of 9.3), and BT.CPP 4's SKIPPED-status propagation through
+        `_skipIf`-decorated nodes and parent Sequences. Older runtimes will either
+        fail to load the tree or behave incorrectly on the `_skipIf` paths below.
+      -->
+      <Action
+        ID="Script"
+        code="picked_at_wp1 := false; picked_at_wp2 := false; drained := false"
+      />
+      <!--
+        Loop the pick cycle until the scene is drained (drained=true), and surface
+        real pick errors as Objective FAILURE.
+
+        Each iteration: visit `View Boxes`, then `View Boxes 2` (only if the first
+        did not pick — saves a redundant scan once the first waypoint is the
+        productive one). Each Subtree returns SUCCESS with `picked_box` set true or
+        false on the happy path, and FAILURE only on real pick errors (the inner
+        Subtree's `Inverter > ForEach > Inverter` retains the existing "try each
+        mask, succeed if any" resilience — see that Subtree for the per-mask
+        FAILURE caveat).
+
+        The Script step computes whether anything was picked this cycle; the inner
+        `ScriptCondition(!drained)` converts a "nothing picked" cycle into FAILURE
+        that breaks the `RepeatUnlessFailureEachTick(-1)` loop.
+
+        The outer Fallback then distinguishes the two FAILURE causes of the loop:
+          - drained=true  → expected exit, the post-loop ScriptCondition succeeds → SUCCESS.
+          - drained=false → real pick error propagated from a Subtree, the post-loop
+                            ScriptCondition also fails → Objective FAILURE.
+      -->
+      <Control ID="Fallback">
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
           <Control ID="Sequence">
-            <Control ID="Fallback">
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes"
-                _collapsed="true"
-                threshold="0.25"
-                prompt="a small brown box"
-                negative_prompts="yellow ladder;"
-                prompts="small boxes"
-                place_pose="{place_pose}"
-                erosion_size="10"
-              />
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes 2"
-                place_pose="{place_pose}"
-                threshold="0.4"
-                _collapsed="true"
-                prompts="small boxes"
-                negative_prompts="gray;gray;rails"
-                erosion_size="2"
-                prompt="{prompt}"
-              />
-            </Control>
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              waypoint_name="View Boxes"
+              _collapsed="true"
+              threshold="0.25"
+              prompt="a small brown box"
+              negative_prompts="yellow ladder;"
+              prompts="small boxes"
+              place_pose="{place_pose}"
+              erosion_size="10"
+              picked_box="{picked_at_wp1}"
+            />
+            <!--
+              Reset picked_at_wp2 before the (possibly-skipped) wp2 SubTree so the
+              "did wp2 contribute this iteration?" reading is never stale from a prior
+              iteration. Without this, `_skipIf="picked_at_wp1"` would leave the wp2
+              SubTree's output port unwritten and the next Script would OR against a
+              stale value. The drained computation happens to be correct today (wp1
+              picked, so the OR short-circuits true), but any future read of
+              picked_at_wp2 — telemetry, an extra waypoint, etc. — would see stale
+              data and the invariant "picked_at_wpN iff wpN picked in this iteration"
+              would silently break.
+            -->
+            <Action ID="Script" code="picked_at_wp2 := false" />
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              waypoint_name="View Boxes 2"
+              place_pose="{place_pose}"
+              threshold="0.4"
+              _collapsed="true"
+              prompts="small boxes"
+              negative_prompts="gray;gray;rails"
+              erosion_size="2"
+              prompt="a small brown box"
+              picked_box="{picked_at_wp2}"
+              _skipIf="picked_at_wp1"
+            />
+            <Action
+              ID="Script"
+              code="drained := !(picked_at_wp1 || picked_at_wp2)"
+            />
+            <Action ID="ScriptCondition" code="!drained" />
             <Action
               ID="TransformPose"
               input_pose="{place_pose}"
@@ -49,7 +112,8 @@
             />
           </Control>
         </Decorator>
-      </Decorator>
+        <Action ID="ScriptCondition" code="drained" />
+      </Control>
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -17,6 +17,13 @@
     _favorite="false"
   >
     <Control ID="Sequence">
+      <!--
+        Reset the picked_box output port at the very top so the invariant
+        "picked_box reflects what happened on THIS Subtree invocation, not the
+        previous one" holds even if a step BEFORE the pick loop (waypoint motion,
+        point-cloud capture, image fetch, etc.) fails.
+      -->
+      <Action ID="Script" code="picked_box := false" />
       <Action
         ID="MoveGripperAction"
         position="0.0"
@@ -111,7 +118,26 @@
           masks_visualization_topic="/masks_visualization"
           opacity="0.500000"
         />
-        <Decorator ID="Inverter">
+        <Action
+          ID="GetSizeOfVector"
+          vector_in="{clip_masks2d}"
+          vector_size="{num_clip_masks}"
+        />
+        <!--
+          When no masks were detected, skip the pick loop entirely and return SUCCESS with
+          picked_box=false (the reset at the top of the Subtree's outer Sequence ensures
+          picked_box is already false here). The parent Objective uses picked_box to
+          distinguish "scanned and found nothing" (drained — exit cleanly) from "real
+          pick errors" (Subtree FAILURE — propagate).
+
+          The Inverter+ForEach+Inverter pattern below short-circuits on the first
+          successful pick and silently retries on per-mask failure; the Subtree only
+          returns FAILURE if every detected mask failed to pick. Non-recoverable
+          per-mask faults (e.g. controller deactivation, execution abort) are
+          currently indistinguishable from recoverable ones (e.g. unreachable IK)
+          inside this loop — see #19112 for the follow-up to differentiate.
+        -->
+        <Decorator ID="Inverter" _skipIf="num_clip_masks == 0">
           <Decorator
             ID="ForEach"
             vector_in="{clip_masks2d}"
@@ -343,6 +369,12 @@
                       timeout="10.000000"
                       gripper_command_action_name="/vacuum_gripper/gripper_cmd"
                     />
+                    <!--
+                      A full pick+place cycle completed. The parent Objective reads
+                      picked_box to decide whether to continue the outer loop or exit
+                      cleanly when both view waypoints stop yielding picks.
+                    -->
+                    <Action ID="Script" code="picked_box := true" />
                   </Control>
                 </Decorator>
               </Control>
@@ -360,6 +392,7 @@
       </MetadataFields>
       <input_port name="erosion_size" default="0" />
       <input_port name="negative_prompts" default="{negative_prompts}" />
+      <output_port name="picked_box" default="{picked_box}" />
       <input_port name="place_pose" default="{place_pose}" />
       <inout_port name="prompt" default="{prompt}" />
       <input_port name="prompts" default="{prompts}" />

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -135,7 +135,8 @@
           returns FAILURE if every detected mask failed to pick. Non-recoverable
           per-mask faults (e.g. controller deactivation, execution abort) are
           currently indistinguishable from recoverable ones (e.g. unreachable IK)
-          inside this loop — see #19112 for the follow-up to differentiate.
+          inside this loop — see PickNikRobotics/moveit_pro#19238 for the follow-up
+          to differentiate.
         -->
         <Decorator ID="Inverter" _skipIf="num_clip_masks == 0">
           <Decorator


### PR DESCRIPTION
Fixes PickNikRobotics/moveit_pro#19112 — paired with PickNikRobotics/moveit_pro#19239.

## Problem

The `ML Move Boxes to Loading Zone` Objective in `hangar_sim` wrapped its pick cycle in `RetryUntilSuccessful(num_attempts="1000") + ForceFailure`, which has no path to a SUCCESS exit. Even when the scene was fully drained, the robot oscillated between the two view waypoints until the 1000-attempt budget expired (~8 h) — visually indistinguishable from a stuck infinite loop.

Two contributing factors:

1. The inner waypoint Subtree returned FAILURE in two cases — "scanned, found nothing" and "every pick attempt failed" — and the outer Objective had no way to tell them apart.
2. `View Boxes 2` was wired with `prompt="{prompt}"`, a blackboard reference never set anywhere in the outer Objective.

## Alternatives considered

- **Just bound the retry count lower.** Rejected — still leaves the operator staring at "stuck looping" for minutes before the budget runs out, and turns a successful drain into a visible FAILURE instead of a SUCCESS.
- **Add a `ForceSuccess` wrap around `RepeatUnlessFailureEachTick(-1)`.** First pass — flagged by review for masking real pick errors (controller crashes, plan failures) as Objective SUCCESS. Strictly worse than the original for surfacing real problems.
- **Restructure both the inner Subtree and the outer Objective so SUCCESS and FAILURE actually mean what they say.** Chosen.

## Chosen approach

### Inner Subtree — `move_boxes_to_loading_zone_from_waypoint.xml`

- New output port `picked_box: bool`, reset to `false` at the very top of the Subtree's outer Sequence so the invariant "picked_box reflects this Subtree invocation, not the previous one" holds even on early-exit failures.
- After `GetMasks2DFromTextQuery`, count the masks with `GetSizeOfVector`. If `num_clip_masks == 0`, the existing `Inverter > ForEach > Inverter` pick loop is `_skipIf`'d entirely, the Subtree exits SUCCESS with `picked_box=false`.
- The final `Script(picked_box := true)` runs only after a full pick + place cycle completes; if every detected mask fails to pick, the Subtree returns FAILURE.

### Outer Objective — `ml_move_boxes_to_loading_zone.xml`

The inner `RepeatUnlessFailureEachTick(-1)` never returns SUCCESS, so the only path to Objective SUCCESS runs through the outer Fallback's second `ScriptCondition(drained)` — and that ScriptCondition only returns SUCCESS when `drained=true`. A real pick error from either Subtree propagates as FAILURE up through the Repeat to the Fallback, where the post-loop ScriptCondition reads the unmodified `drained=false` and the Objective fails.

The explicit `Script(picked_at_wp2 := false)` between the two Subtrees is defensive: when `_skipIf="picked_at_wp1"` causes wp2 to be SKIPPED, its output port is not written, and without this reset the next `drained` Script would OR against a stale value from the previous iteration. The OR happens to short-circuit correctly today (picked_at_wp1=true dominates) but any future change — telemetry, a third waypoint, a flipped order — would silently break the invariant.

Also fixes the dangling `prompt="{prompt}"` on the wp2 invocation by setting it to the same literal wp1 uses.

## Tradeoffs

A pre-existing design hole was surfaced during review and intentionally not addressed here: the inner Subtree's `Inverter > ForEach > Inverter` resilience pattern silently retries per-mask failures of any kind, including non-recoverable ones like controller deactivation. Fixing that properly requires splitting the per-mask logic into a recoverable "planning" phase and a non-recoverable "execution" phase, which is broader than this bug fix. Filed as PickNikRobotics/moveit_pro#19238.

## Cross-repo dependency

Requires PickNikRobotics/moveit_pro#19239 (the matching `GetMasks2DFromTextQuery` contract change) for the new "empty masks → SUCCESS with picked_box=false" path to work. The Objective also uses `ScriptCondition` (built-in BT.CPP 4), `GetSizeOfVector`, and `RepeatUnlessFailureEachTick(-1)` with BT.CPP 4 SKIPPED-status propagation — a compatibility note is embedded in the Objective XML naming the runtime requirements.

## Manual verification

Ran end-to-end in `hangar_sim` via `agent_robot.app` + `ros2 action send_goal /do_objective`:
- Start: 20:41:17.
- End: 20:48:26 (~7 min 9 s).
- 22 vacuum-gripper engagements (multiple full pick cycles).
- `error_code.val: 1` (SUCCESS), `Goal finished with status: SUCCEEDED`.
- Drained-exit Fallback branch hit (only path to SUCCESS by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
