### PR TITLE
Fix: Sort Blocks targets stale block locations

### DIFF
--- a/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
+++ b/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
@@ -12,7 +12,7 @@
     point_cloud="/wrist_camera/camera_info"
   >
     <Control ID="Sequence">
-      <Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
+      <Action ID="ResetVector" vector="{point_cloud_vector}" />
       <Decorator
         ID="ForEach"
         vector_in="{masks3d}"


### PR DESCRIPTION
## Problem

Running `Sort Blocks` in `dual_arm_sim`, the robot keeps picking the same location every cycle even when the physical block at that location has been removed and other blocks are clearly detected elsewhere (visible in `/masks_visualization`).

## Root cause

`src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml` was meant to reset the output `{point_cloud_vector}` at the start of each invocation, but the reset action targeted a different blackboard variable:

```xml
<Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
```

`{pose_stamped_vector}` is never written by this subtree, so the reset is a no-op. Meanwhile the `ForEach` below appends `point_cloud_fragment` entries to `{point_cloud_vector}` via `AddPointCloudToVector`. After N cycles the vector contains every detection ever made.

`Find with prompt` then runs:

```xml
<Action ID="GetElementOfVector" index="0" vector_in="{point_cloud_vector}" element="{object_cloud}" />
```

So index 0 is always the stalest detection in the vector — the very first block seen — even after that block is gone.

## Fix

Reset the correct vector using the generic `ResetVector` (already registered in `register_core_behaviors.cpp:276`, templated on `BT::Any`):

```xml
<Action ID="ResetVector" vector="{point_cloud_vector}" />
```

## Alternatives considered

- **Change `index="0"` to a random index in `find_with_prompt.xml`** — masks the bug, doesn't fix it. The vector would still grow unbounded across cycles and you'd still occasionally pick stale data.
- **Add a separate `ResetVector` in each caller of this subtree before invocation** — works, but pushes ownership of the vector's lifecycle outside the subtree that produces it. Easy for a future caller to forget.
- **Chosen:** fix the reset inside the subtree that owns the output vector. Single owner, callers can't forget.

## Scope

Only `dual_arm_sim` is touched in this PR. The same bug exists in `src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/create_point_cloud_vector_from_masks.xml` and should get a follow-up — that file may be vendored from `moveit_pro` proper, in which case the upstream copy needs the same fix first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)