### PR TITLE
Standardize MuJoCo timestep to 0.003 s across robot configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Each joint type contributes to qpos:
 
 After adding or removing bodies with joints, **remove the keyframe** and let MuJoCo use body `pos=` attributes for initial positions.
 
+### Velocity actuators: `armature/kv` time-constant must stay above the timestep
+
+A `<velocity kv="...">` actuator on a joint with `armature="..."` behaves like a first-order servo with time-constant `τ = armature / kv`. If `τ` is larger than the scene `timestep`, the servo cannot inject enough velocity correction per step to overcome external load, and the joint effectively **stops responding to commands** — it stays pinned near zero even at full command. The per-step velocity correction scales as `kv · timestep / armature`, so halving the timestep halves the authority.
+
+This bit `hangar_sim`'s mecanum base: the wheels had `armature="1.0"`, `kv="50"` → `τ = 0.02 s`. It worked only because the timestep was `0.025 s` (above τ). Standardizing the timestep to `0.003 s` dropped it well below τ, the wheel servos lost authority, the wheels pinned at ~0 rad/s, and the base would not drive (the whole-body `ExecuteTrajectory` then hung forever waiting for the base to reach goal). Fix was `kv: 50 → 500` (τ → 0.002 s, below the new timestep), verified in standalone MuJoCo to be stable across `timestep` 0.025→0.002. Lowering `armature` instead also raises authority but went unstable at small timesteps — prefer raising `kv`.
+
+The two coupled numbers live in different files: the actuator `kv` is in the `<velocity>` blocks of `hangar_sim/description/ur5e_ridgeback.xml` (~line 1709), and the joint `armature` is in the per-wheel includes (`hangar_sim/description/{front,rear}_{left,right}_wheel_link.xml`, the wheel `<joint>`).
+
+Rule of thumb when changing a sim `timestep`: for every velocity actuator, check `armature/kv < timestep`. The symptom of violation is a joint that ignores commands (pinned), not one that oscillates.
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/src/april_tag_sim/description/scene.xml
+++ b/src/april_tag_sim/description/scene.xml
@@ -6,7 +6,7 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
        (picknik_mujoco_ros cameras.cpp). Single shared buffer for all cameras,

--- a/src/dual_arm_sim/description/mujoco/franka3.xml
+++ b/src/dual_arm_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="fanuc scene">
   <compiler angle="radian" autolimits="true" />
-  <option integrator="implicitfast" timestep="0.01">
+  <option integrator="implicitfast" timestep="0.003">
     <flag multiccd="enable" override="enable" />
   </option>
 

--- a/src/grinding_sim/description/scene.xml
+++ b/src/grinding_sim/description/scene.xml
@@ -1,6 +1,8 @@
 <mujoco model="ur20 grinding scene">
   <compiler angle="radian" autolimits="true" assetdir="grinding_sim_assets" />
 
+  <option timestep="0.003" />
+
   <default>
     <!-- Actuator & joint defaults -->
     <joint axis="0 0 1" range="-6.28319 6.28319" armature="0.5" />

--- a/src/hangar_sim/description/hangar_scene.xml
+++ b/src/hangar_sim/description/hangar_scene.xml
@@ -7,7 +7,7 @@
   <include file="hangar.xml" />
   <option
     integrator="implicitfast"
-    timestep="0.025"
+    timestep="0.003"
     noslip_iterations="5"
     impratio="20"
     cone="elliptic"

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -1709,25 +1709,25 @@
       name="front_right_wheel"
       joint="front_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="front_left_wheel"
       joint="front_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_right_wheel"
       joint="rear_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_left_wheel"
       joint="rear_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
   </actuator>
 

--- a/src/kitchen_sim/description/mujoco/franka3.xml
+++ b/src/kitchen_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -6,7 +6,12 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" impratio="10" noslip_iterations="3" />
+  <option
+    integrator="implicitfast"
+    timestep="0.003"
+    impratio="10"
+    noslip_iterations="3"
+  />
 
   <!-- nuser_cam=1 enables per-camera user params: 0=RGB+Depth, 1=RGB-only, 2=3D-lidar -->
   <!-- memory: arena size for contacts/constraints. MuJoCo 3.3+ stopped growing the arena

--- a/src/lunar_sim/mjcf/scene.xml
+++ b/src/lunar_sim/mjcf/scene.xml
@@ -1,4 +1,6 @@
 <mujoco model="lunar sim scene">
+  <option timestep="0.003" />
+
   <default>
     <default class="visual">
       <geom

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
-  <option gravity="0 0 0" />
+  <option timestep="0.003" gravity="0 0 0" />
   <option>
     <flag multiccd="enable" />
   </option>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
@@ -1,4 +1,5 @@
 <mujoco model="kinova scene">
+  <option timestep="0.003" />
   <include file="gen3_7dof_rafti_fingers.xml" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
@@ -1,5 +1,6 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
+  <option timestep="0.003" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>
     <geom solref=".004 1" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 


### PR DESCRIPTION
Standardizes the MuJoCo `<option timestep>` to **0.003 s** across every robot config in the workspace, and fixes the `hangar_sim` mecanum base regression that the smaller timestep exposed.

This PR was originally three commits; the other two have since merged separately and now arrive from `main`, so this branch was rebased onto current `main` and reduced to the timestep change (plus the base fix below):

- **Camera resolution → 1280×720** — merged in #681.
- **CI GPU runner + live per-objective test progress** — merged in #680.

## Problem

MuJoCo `<option timestep>` was inconsistent across robot configs in this workspace:

| Config | Previous timestep (s) | Sim Hz |
|---|---|---|
| `hangar_sim` | **0.025** | **40** |
| `factory_sim` | 0.01 | 100 |
| `dual_arm_sim`, `kitchen_sim` | 0.005 | 200 |
| `lab_sim`, `april_tag_sim`, `grinding_sim`, `lunar_sim`, `kinova_sim`, `space_satellite_sim`, `space_satellite_sim_camera_cal` | 0.002 (MuJoCo default — never set) | 500 |

`hangar_sim`'s 25 ms step in particular is well outside the range stiff arm contacts can normally tolerate, and means the 600 Hz ros2_control loop is reading stale physics state for ~15 ticks at a time.

## Alternatives considered

1. **Match the MuJoCo default (0.002 s, 500 Hz).** Most stable, but the configs currently at 0.005 / 0.01 / 0.025 chose those values presumably because the smaller step was too expensive wall-clock. Going from 0.025 to 0.002 on `hangar_sim` is a **~12.5× slowdown** — likely intolerable for the mobile-base + Nav2 + lidar load.
2. **Pick a value per robot.** Leaves the same inconsistency in place; no clear rule for what each new config should pick.
3. **Standardize on 0.003 s (this PR).** Matches the value already in use in `qualcomm_sim`. Trades a ~1.5× speedup on the 8 default-0.002 configs for a ~1.67× / ~3.3× / ~8.3× slowdown on the 4 outliers, in exchange for a uniform value that's stable for all of them.

## Chosen approach

`<option timestep="0.003" />` set in every MuJoCo-using scene file in the workspace (13 files). Three edit patterns:

- **Modified an existing `timestep="..."`** (4 files): `hangar_sim`, `factory_sim`, `dual_arm_sim`, `kitchen_sim`.
- **Added a `timestep="0.003"` attribute to an existing `<option>`** (4 files): `lab_sim`, `april_tag_sim`, `space_satellite_sim`, `space_satellite_sim_camera_cal`.
- **Inserted a new `<option timestep="0.003" />`** (5 files): `grinding_sim`, `lunar_sim`, and the three `kinova_sim` scenes (`scene.xml`, `landsat_scene.xml`, `rafti_fingers_scene.xml`).

**Direction note:** the 8 configs that never set `timestep` were running at MuJoCo's default **0.002 s**, so standardizing them to 0.003 s is a 50% *coarser* step (a wall-clock speedup, but slightly worse contact resolution) — the opposite direction from the 4 outliers. Contact-rich scenes (`grinding_sim`, `lab_sim`) are the ones to eyeball at the coarser step; see Manual verification.

**Excluded:** `phoebe_sim` lives in the `phoebe_ws` external submodule and is intentionally **not** standardized here — it has no `<option timestep>` (runs at the 0.002 default) and needs a separate PR in `PickNikRobotics/phoebe_ws`. So "all configs" means all in-repo scenes, not the external submodule.

## `hangar_sim` mecanum base fix (exposed by the timestep change)

Dropping `hangar_sim` to 0.003 s broke the mobile base: it would not drive, and the whole-body `ExecuteTrajectory` hung indefinitely waiting for the base to reach its goal. This turned out to be a **latent bug the old 0.025 s timestep was masking**, not a flaw in the new value.

The mecanum wheel velocity actuators (`ur5e_ridgeback.xml`) had `armature="1.0"` and `kv="50"`, giving a first-order servo time-constant `τ = armature/kv = 0.02 s`. The per-step velocity correction scales as `kv · timestep / armature`, so the servo only has authority when `τ < timestep`. At 0.025 s (above τ) the wheels drove; at 0.003 s (below τ) the servos were starved, the wheels pinned at ~0 rad/s, and the base sat still.

**Fix:** raise wheel `kv` 50 → 500 (τ → 0.002 s, below the new timestep), matching the gain the arm actuators already use. Lowering `armature` instead also restores authority but went unstable/erratic at small timesteps, so raising `kv` is preferred.

Verified in **standalone MuJoCo** (no ros2_control) that the fix restores wheel tracking and base motion consistently across timestep 0.025 → 0.002, and **end-to-end in the backend** at 0.003 s: forward 1.03 m, lateral strafe 0.88 m, yaw ~114°, and the full **ML Move Boxes to Loading Zone** objective drives the base ~9 m to the loading zone instead of hanging. The 10× `kv` raises the wheel servo's force ceiling, so the failure mode it could introduce is wheel-contact jitter / base "skating" rather than pinning — none was observed in the forward/strafe/yaw or objective runs (motion tracked cleanly).

The `armature/kv`-vs-`timestep` coupling is now documented in `CLAUDE.md` so future timestep changes check `armature/kv < timestep` for every velocity actuator.

## Related

[moveit_pro#19223](https://github.com/PickNikRobotics/moveit_pro/issues/19223) — asked Griz / Breelyn about the reasoning behind `hangar_sim`'s prior 0.025 s value. The base fix above is the concrete answer: 0.025 s was (knowingly or not) propping up the under-authority wheel servos. With `kv` corrected, `hangar_sim` runs at the standardized 0.003 s.

## Manual verification

- [x] `hangar_sim` — base locomotion (forward / strafe / yaw) and the full mobile-manipulation objective verified driving at 0.003 s after the `kv` fix (see base fix section).
- [ ] Smoke-test `grinding_sim`, `lab_sim`, and `kinova_sim/rafti_fingers` — contact-heavy scenes that were at MuJoCo's 0.002 s default and are now at the *coarser* 0.003 s step (the direction that degrades contact resolution). `grinding_sim` in particular carries no `multiccd`/`impratio`/`noslip` hardening — confirm sustained-contact behavior still resolves.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; agents that don't apply are ticked with `SKIPPED` right after the checkbox plus a brief reason. Humans rarely need to touch these. See [`.claude/rules/agent-delegation.md`](https://github.com/PickNikRobotics/moveit_pro/blob/main/.claude/rules/agent-delegation.md) for when each agent is required.*

- [x] `code-reviewer` (required) — timestep XML reviewed on the original branch; the new `kv` sim-physics change was reviewed by `roboticist-bot` + `platform-architect-bot` below (domain-appropriate for MuJoCo config).
- [x] SKIPPED `test-runner` (required) — no compiled code in diff (XML scene configs only).
- [x] `roboticist-bot` (required — robotics-domain MuJoCo/sim change) — ran on the current diff; no required changes. kv 50→500 fix sound (τ→0.002 s). Applied: added jitter/skating-not-observed note + grinding/lab manual-verify (P1 coarser-step). Deferred P2 landsat triple-`<option>` (pre-existing, not introduced here).
- [x] `platform-architect-bot` (required for backend / C++ / ROS / build-CI changes) — re-ran on current diff; no required changes. Applied both P2s: CLAUDE.md now cites the kv/armature file:line, and PR body notes the `phoebe_ws` submodule is excluded.
- [x] SKIPPED `frontend-noah-bot` (required when `src/web/frontend/**` changes) — no frontend files changed.
- [x] SKIPPED `security-auditor` (required for security-sensitive paths) — no security-sensitive paths changed.
- [ ] `test-writer` (optional)
- [ ] `unit-test-reviewer` (optional)
