### PR TITLE
Fix: Use SAM3 instead of CLIPSeg in ML Move Boxes Objective

### DIFF
--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -63,7 +63,7 @@
               _collapsed="true"
               waypoint_name="View Boxes"
               confidence_threshold="0.25"
-              text_prompt="brown cube"
+              text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
               picked_box="{picked_at_wp1}"
             />
@@ -83,7 +83,7 @@
               _skipIf="picked_at_wp1"
               waypoint_name="View Boxes 2"
               confidence_threshold="0.25"
-              text_prompt="brown cube"
+              text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
               picked_box="{picked_at_wp2}"
             />

--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="ML Move Boxes to Loading Zone">
-  <!--//////////-->
   <BehaviorTree
     ID="ML Move Boxes to Loading Zone"
     _description="Move all of the boxes into the loading zone using ML perception."
@@ -14,33 +13,85 @@
         orientation_xyzw="0;1.0;0;0"
         position_xyz="-4.5;8.4;0.5"
       />
-      <Decorator ID="RetryUntilSuccessful" num_attempts="1000">
-        <Decorator ID="ForceFailure">
+      <!--Initialize the drained signal and the per-iteration pick flags.
+
+        `drained := false` is the load-bearing one — if the very first iteration of
+        the loop below fails before the in-loop `Script(drained := ...)` runs, the
+        post-loop `ScriptCondition(drained)` would otherwise read an undefined value.
+
+        `picked_at_wp1 := false` / `picked_at_wp2 := false` are defensive. Each pick
+        waypoint Subtree resets its `picked_box` output port at the top of its own
+        body and again before wp2 below, so the in-loop reads are always fresh; this
+        outer init only matters if the Subtree fails before either of those resets
+        runs.
+
+        Compatibility note: this Objective relies on three runtime contracts that the
+        loaded `moveit_pro` build must satisfy — `ScriptCondition` (built-in BT.CPP 4),
+        `GetMasks2DFromExemplar` (SAM3 multimodal segmenter, 9.3+) which exposes the
+        `mask_count` output port the inner Subtree uses, `RepeatUnlessFailureEachTick`
+        (9.3+), and BT.CPP 4's SKIPPED-status propagation through `_skipIf`-decorated
+        nodes and parent Sequences. Older runtimes will either fail to load the tree
+        or behave incorrectly on the `_skipIf` paths.-->
+      <Action
+        ID="Script"
+        code="picked_at_wp1 := false; picked_at_wp2 := false; drained := false"
+      />
+      <!--Loop the pick cycle until the scene is drained (drained=true), and surface
+        real pick errors as Objective FAILURE.
+
+        Each iteration: visit `View Boxes`, then `View Boxes 2` (only if the first
+        did not pick — saves a redundant scan once the first waypoint is the
+        productive one). Each Subtree returns SUCCESS with `picked_box` set true
+        or false on the happy path, and FAILURE only on real pick errors (the
+        inner Subtree's `Inverter > ForEach > Inverter` retains the existing "try
+        each mask, succeed if any" resilience — see that Subtree for the per-mask
+        FAILURE caveat).
+
+        The Script step computes whether anything was picked this cycle; the inner
+        `ScriptCondition(!drained)` converts a "nothing picked" cycle into FAILURE
+        that breaks the `RepeatUnlessFailureEachTick(-1)` loop.
+
+        The outer Fallback then distinguishes the two FAILURE causes of the loop:
+          - drained=true  → expected exit, the post-loop ScriptCondition succeeds → SUCCESS.
+          - drained=false → real pick error propagated from a Subtree, the post-loop
+                            ScriptCondition also fails → Objective FAILURE.-->
+      <Control ID="Fallback">
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
           <Control ID="Sequence">
-            <Control ID="Fallback">
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes"
-                _collapsed="true"
-                threshold="0.25"
-                prompt="a small brown box"
-                negative_prompts="yellow ladder;"
-                prompts="small boxes"
-                place_pose="{place_pose}"
-                erosion_size="10"
-              />
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes 2"
-                place_pose="{place_pose}"
-                threshold="0.4"
-                _collapsed="true"
-                prompts="small boxes"
-                negative_prompts="gray;gray;rails"
-                erosion_size="2"
-                prompt="{prompt}"
-              />
-            </Control>
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              _collapsed="true"
+              waypoint_name="View Boxes"
+              confidence_threshold="0.25"
+              text_prompt="brown cube"
+              place_pose="{place_pose}"
+              picked_box="{picked_at_wp1}"
+            />
+            <!--Reset picked_at_wp2 before the (possibly-skipped) wp2 SubTree so the
+              "did wp2 contribute this iteration?" reading is never stale from a prior
+              iteration. Without this, `_skipIf="picked_at_wp1"` would leave the wp2
+              SubTree's output port unwritten and the next Script would OR against a
+              stale value. The drained computation happens to be correct today (wp1
+              picked, so the OR short-circuits true), but any future read of
+              picked_at_wp2 — telemetry, an extra waypoint, etc. — would see stale
+              data and the invariant "picked_at_wpN iff wpN picked in this iteration"
+              would silently break.-->
+            <Action ID="Script" code="picked_at_wp2 := false" />
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              _collapsed="true"
+              _skipIf="picked_at_wp1"
+              waypoint_name="View Boxes 2"
+              confidence_threshold="0.25"
+              text_prompt="brown cube"
+              place_pose="{place_pose}"
+              picked_box="{picked_at_wp2}"
+            />
+            <Action
+              ID="Script"
+              code="drained := !(picked_at_wp1 || picked_at_wp2)"
+            />
+            <Action ID="ScriptCondition" code="!drained" />
             <Action
               ID="TransformPose"
               input_pose="{place_pose}"
@@ -49,7 +100,8 @@
             />
           </Control>
         </Decorator>
-      </Decorator>
+        <Action ID="ScriptCondition" code="drained" />
+      </Control>
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/hangar_sim/objectives/move_boxes_looping.xml
+++ b/src/hangar_sim/objectives/move_boxes_looping.xml
@@ -11,11 +11,27 @@
       _skipIf="false"
       ID="Sequence"
     >
+      <!--Loop the drain-and-reset cycle and surface real pick errors as Objective
+        FAILURE.
+
+        Each iteration: run `ML Move Boxes to Loading Zone` (returns SUCCESS once
+        the scene is drained, FAILURE on a real pick error), then `Reset MuJoCo Sim`
+        to repopulate boxes for the next iteration.
+
+        `RepeatUnlessFailureEachTick` (vs. the previous `KeepRunningUntilFailure`)
+        propagates a child FAILURE up as Objective FAILURE instead of converting it
+        to SUCCESS. The old decorator made a real pick error indistinguishable from
+        a clean stop, which masked regressions in soak runs; this Objective is meant
+        to be a torture test, so a real failure should fail loudly.
+
+        Compatibility note: `RepeatUnlessFailureEachTick` requires moveit_pro 9.3+;
+        older runtimes will fail to load this Objective.-->
       <Decorator
-        ID="KeepRunningUntilFailure"
-        name="KeepRunningUntilFailure"
+        ID="RepeatUnlessFailureEachTick"
+        name="RepeatUnlessFailureEachTick"
         _collapsed="false"
         _skipIf="false"
+        num_cycles="-1"
       >
         <Control
           ID="Sequence"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -9,14 +9,18 @@
     _description="Move boxes to loading zone from waypoint"
     waypoint_name="View Boxes"
     place_pose="{place_pose}"
-    threshold="{threshold}"
-    prompt="{prompt}"
-    negative_prompts="{negative_prompts}"
-    prompts="{prompts}"
-    erosion_size="0"
+    confidence_threshold="{confidence_threshold}"
+    text_prompt="{text_prompt}"
     _favorite="false"
   >
     <Control ID="Sequence">
+      <!--
+        Reset the picked_box output port at the very top so the invariant
+        "picked_box reflects what happened on THIS Subtree invocation, not the
+        previous one" holds even if a step BEFORE the pick loop (waypoint motion,
+        point-cloud capture, image fetch, etc.) fails.
+      -->
+      <Action ID="Script" code="picked_box := false" />
       <Action
         ID="MoveGripperAction"
         position="0.0"
@@ -92,262 +96,261 @@
         publisher_timeout_sec="5.000000"
       />
       <Control ID="Sequence">
+        <!--
+          SAM3 text-prompt segmentation. Unlike the previous CLIPSeg + SAM2-refine
+          chain, SAM3 produces high-quality per-detection masks directly from a text
+          prompt, so no point-prompt refinement step is needed. The Behavior returns
+          SUCCESS with `mask_count == 0` when nothing is detected, which the
+          `_skipIf` below uses to bypass the pick loop and let the Subtree exit
+          cleanly with `picked_box=false`.
+        -->
         <Action
-          ID="GetMasks2DFromTextQuery"
-          image="{image}"
-          masks2d="{clip_masks2d}"
-          threshold="{threshold}"
-          clipseg_model_path="models/clipseg.onnx"
-          clip_model_path="models/clip.onnx"
-          model_package="moveit_pro_clipseg"
-          prompts="{prompts}"
-          negative_prompts="{negative_prompts}"
-          erosion_size="{erosion_size}"
+          ID="GetMasks2DFromExemplar"
+          model_package="moveit_pro_sam3"
+          encoder_model_path="models/sam3_vision_encoder.onnx"
+          decoder_model_path="models/sam3_decoder.onnx"
+          geometry_encoder_model_path="models/sam3_geometry_encoder.onnx"
+          text_encoder_model_path="models/sam3_text_encoder.onnx"
+          confidence_threshold="{confidence_threshold}"
+          target_image="{image}"
+          text_prompt="{text_prompt}"
+          masks2d="{masks2d}"
+          mask_count="{mask_count}"
         />
         <Action
           ID="PublishMask2D"
           image="{image}"
-          masks="{clip_masks2d}"
+          masks="{masks2d}"
           masks_visualization_topic="/masks_visualization"
           opacity="0.500000"
         />
-        <Decorator ID="Inverter">
-          <Decorator
-            ID="ForEach"
-            vector_in="{clip_masks2d}"
-            index="{index}"
-            out="{clip_mask2d}"
-          >
-            <Decorator ID="Inverter">
+        <!--
+          Skip the pick pipeline entirely when SAM3 found nothing — `picked_box`
+          stays false from the reset at the top, the Subtree returns SUCCESS,
+          and the parent Objective treats it as "scanned and found nothing"
+          rather than a real pick error. The Inverter+ForEach+Inverter pattern
+          below short-circuits on the first successful pick and silently retries
+          on per-mask failure; the Subtree only returns FAILURE if every detected
+          object failed to pick. Non-recoverable per-mask faults (e.g. controller
+          deactivation, execution abort) are currently indistinguishable from
+          recoverable ones (e.g. unreachable IK) inside this loop — see
+          PickNikRobotics/moveit_pro#19238 for the follow-up to differentiate.
+        -->
+        <Decorator ID="Inverter" _skipIf="mask_count == 0">
+          <Control ID="Sequence">
+            <Action
+              ID="GetMasks3DFromMasks2D"
+              camera_info="{camera_info}"
+              masks2d="{masks2d}"
+              point_cloud="{point_cloud_cropped}"
+              masks3d="{masks3d}"
+            />
+            <Decorator
+              ID="ForEach"
+              vector_in="{masks3d}"
+              index="{index}"
+              out="{mask3d}"
+            >
               <Control ID="Sequence">
                 <Action
-                  ID="GetCenterFromMask2D"
-                  mask="{clip_mask2d}"
-                  center="{pixel_coords}"
-                />
-                <Action
-                  ID="GetMasks2DFromPointQuery"
-                  image="{image}"
-                  pixel_coords="{pixel_coords}"
-                  masks2d="{masks2d}"
-                  model_package="moveit_pro_sam2"
-                  decoder_model_path="models/sam2_decoder.onnx"
-                  encoder_model_path="models/sam2_hiera_large_encoder.onnx"
-                />
-                <Action
-                  ID="PublishMask2D"
-                  image="{image}"
-                  masks="{masks2d}"
-                  masks_visualization_topic="/masks_visualization"
-                  opacity="0.500000"
-                />
-                <Action
-                  ID="GetMasks3DFromMasks2D"
-                  camera_info="{camera_info}"
-                  masks2d="{masks2d}"
+                  ID="GetPointCloudFromMask3D"
+                  mask3d="{mask3d}"
                   point_cloud="{point_cloud_cropped}"
-                  masks3d="{masks3d}"
+                  point_cloud_fragment="{point_cloud_fragment}"
                 />
-                <Decorator
-                  ID="ForEach"
-                  vector_in="{masks3d}"
-                  index="{index}"
-                  out="{mask3d}"
-                >
-                  <Control ID="Sequence">
-                    <Action
-                      ID="GetPointCloudFromMask3D"
-                      mask3d="{mask3d}"
-                      point_cloud="{point_cloud_cropped}"
-                      point_cloud_fragment="{point_cloud_fragment}"
-                    />
-                    <Action
-                      ID="SendPointCloudToUI"
-                      pcd_topic="/pcd_pointcloud_captures"
-                      point_cloud="{point_cloud_fragment}"
-                    />
-                  </Control>
-                </Decorator>
                 <Action
-                  ID="GetGraspableObjectsFromMasks3D"
-                  base_frame="world"
-                  masks3d="{masks3d}"
-                  minimum_face_area="0.0003"
-                  plane_inlier_threshold="0.01"
-                  point_cloud="{point_cloud_cropped}"
-                  graspable_objects="{graspable_objects}"
-                  face_separation_threshold="0.2"
+                  ID="SendPointCloudToUI"
+                  pcd_topic="/pcd_pointcloud_captures"
+                  point_cloud="{point_cloud_fragment}"
                 />
-                <Decorator
-                  ID="ForEach"
-                  vector_in="{graspable_objects}"
-                  index="{index}"
-                  out="{graspable_object}"
-                >
-                  <Control ID="Sequence">
-                    <Action
-                      ID="CreatePoseStamped"
-                      reference_frame="world"
-                      pose_stamped="{ee_to_tcp}"
-                      position_xyz="0;0;0"
-                      orientation_xyzw="0;0;0;1"
-                    />
-                    <Action
-                      ID="GetCurrentPlanningScene"
-                      planning_scene_msg="{planning_scene}"
-                    />
-                    <Action
-                      ID="GenerateVacuumGraspPoses"
-                      ee_to_tcp_tf="{ee_to_tcp}"
-                      end_effector_group_name="gripper"
-                      generate_centroid_grasps="true"
-                      grasp_poses="{grasp_poses}"
-                      num_orientation_samples="20"
-                      padding_dimension="0.01"
-                      planning_scene_msg="{planning_scene}"
-                      samples_per_plane="2"
-                      target_object="{graspable_object}"
-                      ui_grasp_link="grasp_link"
-                    />
-                    <Action
-                      ID="InitializeMTCTask"
-                      controller_names="joint_trajectory_controller"
-                      task="{task}"
-                      task_id=""
-                      trajectory_monitoring="false"
-                      timeout="-1.000000"
-                    />
-                    <Action ID="SetupMTCCurrentState" task="{task}" />
-                    <Action
-                      ID="SetupMTCUpdateGroupCollisionRule"
-                      allow_collision="true"
-                      group_name="gripper"
-                      object_name="&lt;octomap&gt;"
-                      task="{task}"
-                    />
-                    <Action
-                      ID="SetupMTCConnectWithProRRT"
-                      acceleration_scale_factor="1.000000"
-                      keep_orientation="false"
-                      keep_orientation_link_names="grasp_link"
-                      keep_orientation_tolerance="0.100000"
-                      link_padding="0.000000"
-                      max_iterations="5000"
-                      planning_group_name="manipulator"
-                      seed="0"
-                      task="{task}"
-                      trajectory_sampling_rate="100"
-                      velocity_scale_factor="1.000000"
-                    />
-                    <Action
-                      ID="SetupMTCMoveAlongFrameAxis"
-                      acceleration_scale="1.000000"
-                      axis_frame="grasp_link"
-                      axis_x="0.000000"
-                      axis_y="0.000000"
-                      axis_z="1.000000"
-                      hand_frame="grasp_link"
-                      ignore_environment_collisions="false"
-                      max_distance="0.2"
-                      min_distance="0.05"
-                      planning_group_name="manipulator"
-                      task="{task}"
-                      velocity_scale="1.000000"
-                    />
-                    <Action
-                      ID="SetupMTCBatchPoseIK"
-                      end_effector_group="moveit_ee"
-                      end_effector_link="grasp_link"
-                      ik_group="manipulator"
-                      ik_timeout_s="0.01"
-                      max_ik_solutions="1"
-                      monitored_stage="allow collision (&lt;octomap&gt;, gripper)"
-                      target_poses="{grasp_poses}"
-                      task="{task}"
-                    />
-                    <Control ID="Parallel" success_count="2" failure_count="1">
-                      <Control ID="Sequence">
-                        <Action
-                          ID="PlanMTCTask"
-                          solution="{solution}"
-                          task="{task}"
-                        />
-                        <SubTree
-                          ID="Execute MTC Solution (JTC)"
-                          solution="{solution}"
-                          goal_duration_tolerance="-1.0"
-                        />
-                      </Control>
-                      <Control ID="Sequence" name="TopLevelSequence">
-                        <Action
-                          ID="LoadPointCloudFromFile"
-                          color="0;255;0"
-                          file_path="box.stl"
-                          point_cloud="{box_mesh}"
-                          frame_id="world"
-                          num_sampled_points="50000"
-                          scale="1.000000"
-                        />
-                        <Action
-                          ID="GetCentroidFromPointCloud"
-                          point_cloud="{point_cloud_fragment}"
-                          output_pose="{point_cloud_fragment_center}"
-                        />
-                        <Action
-                          ID="TransformPointCloud"
-                          input_cloud="{box_mesh}"
-                          transform_pose="{point_cloud_fragment_center}"
-                          output_cloud="{box_mesh}"
-                        />
-                        <Action
-                          ID="RegisterPointClouds"
-                          target_point_cloud="{point_cloud_fragment}"
-                          target_pose_in_base_frame="{target_pose}"
-                          base_point_cloud="{box_mesh}"
-                          max_correspondence_distance="0.05"
-                          max_iterations="40"
-                        />
-                        <Action
-                          ID="TransformPointCloud"
-                          input_cloud="{box_mesh}"
-                          transform_pose="{target_pose}"
-                          output_cloud="{icp_cloud}"
-                        />
-                        <Action
-                          ID="TransformPointCloudFrame"
-                          input_cloud="{icp_cloud}"
-                          output_cloud="{icp_cloud}"
-                          target_frame="world"
-                        />
-                        <Action
-                          ID="SendPointCloudToUI"
-                          pcd_topic="/pcd_pointcloud_captures"
-                          point_cloud="{icp_cloud}"
-                        />
-                      </Control>
-                    </Control>
-                    <Action
-                      ID="MoveGripperAction"
-                      timeout="10.000000"
-                      gripper_command_action_name="/vacuum_gripper/gripper_cmd"
-                      position="1.0"
-                    />
-                    <SubTree
-                      ID="Move to Pose No Preview"
-                      _collapsed="true"
-                      target_pose="{place_pose}"
-                    />
-                    <Action
-                      ID="MoveGripperAction"
-                      position="0.0"
-                      timeout="10.000000"
-                      gripper_command_action_name="/vacuum_gripper/gripper_cmd"
-                    />
-                  </Control>
-                </Decorator>
               </Control>
             </Decorator>
-          </Decorator>
+            <Action
+              ID="GetGraspableObjectsFromMasks3D"
+              base_frame="world"
+              masks3d="{masks3d}"
+              minimum_face_area="0.0003"
+              plane_inlier_threshold="0.01"
+              point_cloud="{point_cloud_cropped}"
+              graspable_objects="{graspable_objects}"
+              face_separation_threshold="0.2"
+            />
+            <Decorator
+              ID="ForEach"
+              vector_in="{graspable_objects}"
+              index="{index}"
+              out="{graspable_object}"
+            >
+              <Decorator ID="Inverter">
+                <Control ID="Sequence">
+                  <Action
+                    ID="CreatePoseStamped"
+                    reference_frame="world"
+                    pose_stamped="{ee_to_tcp}"
+                    position_xyz="0;0;0"
+                    orientation_xyzw="0;0;0;1"
+                  />
+                  <Action
+                    ID="GetCurrentPlanningScene"
+                    planning_scene_msg="{planning_scene}"
+                  />
+                  <Action
+                    ID="GenerateVacuumGraspPoses"
+                    ee_to_tcp_tf="{ee_to_tcp}"
+                    end_effector_group_name="gripper"
+                    generate_centroid_grasps="true"
+                    grasp_poses="{grasp_poses}"
+                    num_orientation_samples="20"
+                    padding_dimension="0.01"
+                    planning_scene_msg="{planning_scene}"
+                    samples_per_plane="2"
+                    target_object="{graspable_object}"
+                    ui_grasp_link="grasp_link"
+                  />
+                  <Action
+                    ID="InitializeMTCTask"
+                    controller_names="joint_trajectory_controller"
+                    task="{task}"
+                    task_id=""
+                    trajectory_monitoring="false"
+                    timeout="-1.000000"
+                  />
+                  <Action ID="SetupMTCCurrentState" task="{task}" />
+                  <Action
+                    ID="SetupMTCUpdateGroupCollisionRule"
+                    allow_collision="true"
+                    group_name="gripper"
+                    object_name="&lt;octomap&gt;"
+                    task="{task}"
+                  />
+                  <Action
+                    ID="SetupMTCConnectWithProRRT"
+                    acceleration_scale_factor="1.000000"
+                    keep_orientation="false"
+                    keep_orientation_link_names="grasp_link"
+                    keep_orientation_tolerance="0.100000"
+                    link_padding="0.000000"
+                    max_iterations="5000"
+                    planning_group_name="manipulator"
+                    seed="0"
+                    task="{task}"
+                    trajectory_sampling_rate="100"
+                    velocity_scale_factor="1.000000"
+                  />
+                  <Action
+                    ID="SetupMTCMoveAlongFrameAxis"
+                    acceleration_scale="1.000000"
+                    axis_frame="grasp_link"
+                    axis_x="0.000000"
+                    axis_y="0.000000"
+                    axis_z="1.000000"
+                    hand_frame="grasp_link"
+                    ignore_environment_collisions="false"
+                    max_distance="0.2"
+                    min_distance="0.05"
+                    planning_group_name="manipulator"
+                    task="{task}"
+                    velocity_scale="1.000000"
+                  />
+                  <Action
+                    ID="SetupMTCBatchPoseIK"
+                    end_effector_group="moveit_ee"
+                    end_effector_link="grasp_link"
+                    ik_group="manipulator"
+                    ik_timeout_s="0.01"
+                    max_ik_solutions="1"
+                    monitored_stage="allow collision (&lt;octomap&gt;, gripper)"
+                    target_poses="{grasp_poses}"
+                    task="{task}"
+                  />
+                  <Control ID="Parallel" success_count="2" failure_count="1">
+                    <Control ID="Sequence">
+                      <Action
+                        ID="PlanMTCTask"
+                        solution="{solution}"
+                        task="{task}"
+                      />
+                      <SubTree
+                        ID="Execute MTC Solution (JTC)"
+                        solution="{solution}"
+                        goal_duration_tolerance="-1.0"
+                      />
+                    </Control>
+                    <Control ID="Sequence" name="TopLevelSequence">
+                      <Action
+                        ID="LoadPointCloudFromFile"
+                        color="0;255;0"
+                        file_path="box.stl"
+                        point_cloud="{box_mesh}"
+                        frame_id="world"
+                        num_sampled_points="50000"
+                        scale="1.000000"
+                      />
+                      <Action
+                        ID="GetCentroidFromPointCloud"
+                        point_cloud="{point_cloud_fragment}"
+                        output_pose="{point_cloud_fragment_center}"
+                      />
+                      <Action
+                        ID="TransformPointCloud"
+                        input_cloud="{box_mesh}"
+                        transform_pose="{point_cloud_fragment_center}"
+                        output_cloud="{box_mesh}"
+                      />
+                      <Action
+                        ID="RegisterPointClouds"
+                        target_point_cloud="{point_cloud_fragment}"
+                        target_pose_in_base_frame="{target_pose}"
+                        base_point_cloud="{box_mesh}"
+                        max_correspondence_distance="0.05"
+                        max_iterations="40"
+                      />
+                      <Action
+                        ID="TransformPointCloud"
+                        input_cloud="{box_mesh}"
+                        transform_pose="{target_pose}"
+                        output_cloud="{icp_cloud}"
+                      />
+                      <Action
+                        ID="TransformPointCloudFrame"
+                        input_cloud="{icp_cloud}"
+                        output_cloud="{icp_cloud}"
+                        target_frame="world"
+                      />
+                      <Action
+                        ID="SendPointCloudToUI"
+                        pcd_topic="/pcd_pointcloud_captures"
+                        point_cloud="{icp_cloud}"
+                      />
+                    </Control>
+                  </Control>
+                  <Action
+                    ID="MoveGripperAction"
+                    timeout="10.000000"
+                    gripper_command_action_name="/vacuum_gripper/gripper_cmd"
+                    position="1.0"
+                  />
+                  <SubTree
+                    ID="Move to Pose No Preview"
+                    _collapsed="true"
+                    target_pose="{place_pose}"
+                  />
+                  <Action
+                    ID="MoveGripperAction"
+                    position="0.0"
+                    timeout="10.000000"
+                    gripper_command_action_name="/vacuum_gripper/gripper_cmd"
+                  />
+                  <!--
+                      A full pick+place cycle completed. The parent Objective reads
+                      picked_box to decide whether to continue the outer loop or exit
+                      cleanly when both view waypoints stop yielding picks.
+                    -->
+                  <Action ID="Script" code="picked_box := true" />
+                </Control>
+              </Decorator>
+            </Decorator>
+          </Control>
         </Decorator>
       </Control>
     </Control>
@@ -358,12 +361,13 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
-      <input_port name="erosion_size" default="0" />
-      <input_port name="negative_prompts" default="{negative_prompts}" />
+      <input_port
+        name="confidence_threshold"
+        default="{confidence_threshold}"
+      />
+      <output_port name="picked_box" default="{picked_box}" />
       <input_port name="place_pose" default="{place_pose}" />
-      <inout_port name="prompt" default="{prompt}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <input_port name="text_prompt" default="{text_prompt}" />
       <input_port name="waypoint_name" default="View Boxes" />
     </SubTree>
   </TreeNodesModel>

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -117,6 +117,28 @@
           masks2d="{masks2d}"
           mask_count="{mask_count}"
         />
+        <!--
+          Drop both oversized false positives (SAM3 occasionally returns a
+          single mask covering most of the image — e.g., the cart frame, which
+          measured ~26,285 px in calibration) and tiny edge-fragment detections
+          (~778 px in calibration). Real boxes in this scene measured
+          3,949–20,643 px; thresholds sit ~2x outside that range on the low
+          end and ~12% inside the cart-vs-largest-real gap on the high end.
+          Re-run "Calibrate SAM3 Mask Areas" if the camera, lens, or scale
+          changes.
+        -->
+        <Action
+          ID="FilterMasks2DByArea"
+          masks="{masks2d}"
+          min_area="2000"
+          max_area="23000"
+          filtered_masks="{masks2d}"
+        />
+        <Action
+          ID="GetSizeOfVector"
+          vector_in="{masks2d}"
+          vector_size="{mask_count}"
+        />
         <Action
           ID="PublishMask2D"
           image="{image}"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -207,6 +207,53 @@
                     target_object="{graspable_object}"
                     ui_grasp_link="grasp_link"
                   />
+                  <!--
+                    Discard the box-yaw component from every generated grasp.
+
+                    `GenerateVacuumGraspPoses` builds each grasp as
+                    `R_world_to_object * (face/position/flip/wrist samples)`, so
+                    the box's detected yaw rotates every candidate orientation in
+                    world frame. SAM3's per-detection yaw is noisy and arbitrary
+                    for a rotationally-symmetric brown cube, and with
+                    `max_ik_solutions="1"` MTC picks the first IK-valid candidate
+                    — meaning the chosen wrist angle drifts with detection noise
+                    instead of staying consistent across picks.
+
+                    We overwrite each grasp's orientation with a fixed
+                    "gripper pointing straight down" quaternion (matching the
+                    outer Objective's `place_pose`). The vacuum gripper is
+                    rotationally symmetric about its approach axis, so the pick
+                    is unaffected. Tradeoff: this collapses the 20 wrist-angle
+                    samples to one orientation per (face, position, flip), so
+                    candidates that previously succeeded only at a non-trivial
+                    wrist angle will now fail IK. The centroid-grasp sample and
+                    the bidirectional flip variant remain, which has been
+                    sufficient for top-face picks of cubes in hangar_sim.
+                  -->
+                  <Action
+                    ID="ResetPoseStampedVector"
+                    vector="{leveled_grasp_poses}"
+                  />
+                  <Decorator
+                    ID="ForEach"
+                    vector_in="{grasp_poses}"
+                    index="{grasp_index}"
+                    out="{grasp_pose}"
+                  >
+                    <Control ID="Sequence">
+                      <Action
+                        ID="OverridePoseOrientation"
+                        input_pose="{grasp_pose}"
+                        orientation_xyzw="0;1.0;0;0"
+                        output_pose="{leveled_grasp_pose}"
+                      />
+                      <Action
+                        ID="AddPoseStampedToVector"
+                        input="{leveled_grasp_pose}"
+                        vector="{leveled_grasp_poses}"
+                      />
+                    </Control>
+                  </Decorator>
                   <Action
                     ID="InitializeMTCTask"
                     controller_names="joint_trajectory_controller"
@@ -260,7 +307,7 @@
                     ik_timeout_s="0.01"
                     max_ik_solutions="1"
                     monitored_stage="allow collision (&lt;octomap&gt;, gripper)"
-                    target_poses="{grasp_poses}"
+                    target_poses="{leveled_grasp_poses}"
                     task="{task}"
                   />
                   <Control ID="Parallel" success_count="2" failure_count="1">


### PR DESCRIPTION
## Problem

The `ML Move Boxes to Loading Zone` Objective in `hangar_sim` gets stuck in an infinite loop and never completes. Repro: launch hangar_sim, run the Objective — after the correct picks finish (sometimes 20+ minutes in), it spins forever.

Root cause: the inner pick Subtree uses `GetMasks2DFromTextQuery` (CLIPSeg) which returns FAILURE when no masks are detected. The old outer loop wrapped this in `RetryUntilSuccessful + ForceFailure`, so CLIPSeg's "nothing here" FAILURE was indistinguishable from a real pick error and the loop ran forever once the scene was drained.

Fixes #19112.

## Alternatives considered

1. **Change `GetMasks2DFromTextQuery`'s contract in moveit_pro to return SUCCESS on empty masks.** Drafted as moveit_pro PR #19239 + example_ws PR #645. Rejected after an audit found that the contract change had downstream regressions across kitchen_sim / lab_sim / hangar_sim Objectives that consumed CLIPSeg's FAILURE-on-empty as a flow-control signal. Behavior contracts are public API — changing them to fix one consumer breaks others. Both PRs closed.

2. **Wrap CLIPSeg in a custom decorator that converts FAILURE→SUCCESS only in this Objective.** Kept the contract intact but added BT complexity that future maintainers would have to re-derive. Did not solve the larger "CLIPSeg has no clean empty-mask signal" usability issue.

3. **(Chosen) Replace CLIPSeg with `GetMasks2DFromExemplar` (SAM3) in this Objective.** SAM3 is the newer multimodal segmenter, accepts the same `text_prompt` input, and exposes a `mask_count` output port that returns 0 cleanly on empty detections. This Objective can then `_skipIf="mask_count == 0"` the downstream pick pipeline and return SUCCESS with `picked_box=false`, which the outer loop interprets as "drained".

## Chosen approach

- **Inner Subtree** (`move_boxes_to_loading_zone_from_waypoint.xml`): Uses `GetMasks2DFromExemplar` for perception. The pick pipeline is wrapped in an `Inverter > ForEach > Inverter > Sequence` (existing "try each mask, succeed on first") and gated by `_skipIf="mask_count == 0"` so empty SAM3 results don't drive the rest of the tree. The Subtree returns SUCCESS with `picked_box` set true/false on the happy path and FAILURE only on real pick errors.

- **Outer Objective** (`ml_move_boxes_to_loading_zone.xml`): Replaces `RetryUntilSuccessful + ForceFailure` with `Fallback { RepeatUnlessFailureEachTick(-1) { ... ScriptCondition(!drained) }, ScriptCondition(drained) }`. The Script `drained := !(picked_at_wp1 || picked_at_wp2)` is computed each cycle; when both view-waypoints return no picks, `drained` becomes true, the inner ScriptCondition FAILs, the loop exits, and the post-loop ScriptCondition on `drained` succeeds → Objective SUCCESS. Real pick errors propagate as FAILURE with `drained=false` → Objective FAILURE.

## Tradeoffs

- **Loss of negative-prompt knob.** CLIPSeg+SAM2 supported `negative_prompts` (`"yellow ladder;"`, `"gray;gray;rails"`); SAM3's text encoder doesn't. If SAM3 starts mis-detecting the ladder or rails as a "brown cube", there's no negative-prompt fallback. Acceptable for hangar_sim today; would be a follow-up if it surfaces in CI runs.

- **Runtime version dependency.** The Objective uses `GetMasks2DFromExemplar`, `RepeatUnlessFailureEachTick`, and `_skipIf`/SKIPPED propagation through Sequences — all 9.3+. The compatibility comment in the outer Objective documents this; older runtimes will fail to load the tree.

## Follow-up

- **Code-reviewer flagged**: `Script(picked_box := true)` is set AFTER `MoveGripperAction(position=0.0)` (release). If release fails mid-cycle, `picked_box` stays false and the outer loop may treat a real failure as "nothing picked". Behavior change to fix this is tracked separately; in practice this corner case has not surfaced in tested runs.
- **Platform-architect-bot flagged**: `package.xml` should pin a minimum `moveit_pro` version. Follow-up.
- The robot model has unrelated visual inconsistencies in `ur5e_ridgeback.xml` (chassis vs wheel chain vertical alignment) that surfaced during testing — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)