### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable MD041 -->
+<!-- Write your PR description above this line. The Claude agent checks below stay at the bottom. -->
+
+---
+
+## Claude agent checks
+
+*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; agents that don't apply are ticked with `SKIPPED` right after the checkbox plus a brief reason.*
+
+- [ ] `code-reviewer` (required)
+- [ ] `test-runner` (required)
+- [ ] `platform-architect-bot` (required for backend / C++ / ROS / REST / build-CI changes)
+- [ ] `frontend-noah-bot` (required when `src/web/frontend/**` changes)
+- [ ] `security-auditor` (required for security-sensitive paths)
+- [ ] `test-writer` (optional)
+- [ ] `unit-test-reviewer` (optional)


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md`, copied from the `moveit_pro` repo. The `See [.claude/rules/agent-delegation.md]` sentence was dropped since this repo has no `.claude/rules/` directory; the rest is verbatim.