### PR TITLE
Fix: Filter SAM3 mask false positives by area in hangar_sim

### DIFF
--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -63,7 +63,7 @@
               _collapsed="true"
               waypoint_name="View Boxes"
               confidence_threshold="0.25"
-              text_prompt="brown cube"
+              text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
               picked_box="{picked_at_wp1}"
             />
@@ -83,7 +83,7 @@
               _skipIf="picked_at_wp1"
               waypoint_name="View Boxes 2"
               confidence_threshold="0.25"
-              text_prompt="brown cube"
+              text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
               picked_box="{picked_at_wp2}"
             />

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -117,6 +117,28 @@
           masks2d="{masks2d}"
           mask_count="{mask_count}"
         />
+        <!--
+          Drop both oversized false positives (SAM3 occasionally returns a
+          single mask covering most of the image — e.g., the cart frame, which
+          measured ~26,285 px in calibration) and tiny edge-fragment detections
+          (~778 px in calibration). Real boxes in this scene measured
+          3,949–20,643 px; thresholds sit ~2x outside that range on the low
+          end and ~12% inside the cart-vs-largest-real gap on the high end.
+          Re-run "Calibrate SAM3 Mask Areas" if the camera, lens, or scale
+          changes.
+        -->
+        <Action
+          ID="FilterMasks2DByArea"
+          masks="{masks2d}"
+          min_area="2000"
+          max_area="23000"
+          filtered_masks="{masks2d}"
+        />
+        <Action
+          ID="GetSizeOfVector"
+          vector_in="{masks2d}"
+          vector_size="{mask_count}"
+        />
         <Action
           ID="PublishMask2D"
           image="{image}"


### PR DESCRIPTION
## Problem

The `ML Move Boxes to Loading Zone` Objective in `hangar_sim`, after switching to SAM3 segmentation on this feature branch, occasionally targets the yellow cart frame instead of a real box. SAM3 returns a single mask covering most of the cart with `area ≈ 26,285 px` (bbox `454 × 133`), which the pick pipeline then tries to grasp — wasting motion and sometimes faulting the run. It also occasionally returns small edge-fragment masks (~800 px) that aren't real detections.

## Root cause

`GetMasks2DFromExemplar` (SAM3) only filters by confidence — nothing in the existing pipeline rejected detections by geometric plausibility. The text prompt also wasn't a great fit for the sim assets, so the model's lower-confidence matches drifted to large rectangular structures (cart bracing) and tiny mis-segmented edges.

## Fix

Two small, related changes:

1. **Prompt change** (`ml_move_boxes_to_loading_zone.xml`)
   `"brown cube"` → `"a single small orange cube box"` for both `View Boxes` waypoints. Tested live in the sim; significantly reduces both the cart false positive rate and the sliver detections.

2. **Area filter** (`move_boxes_to_loading_zone_from_waypoint.xml`)
   Insert `FilterMasks2DByArea` immediately after SAM3 with `min_area=2000`, `max_area=23000`. The Behavior writes the filtered set back to `{masks2d}` in-place, so the existing `PublishMask2D` and `GetMasks3DFromMasks2D` consumers pick up the cleaned-up vector with no other changes.

   Calibration data driving those numbers:
   - Sliver false positive: ~778 px (filtered out)
   - Smallest real box: ~3,949 px
   - Largest real box: ~20,643 px
   - Cart false positive: ~26,285 px (filtered out)
   - Thresholds sit ~2× outside the small end and ~12% inside the cart-vs-largest-real gap on the high end.

   `GetSizeOfVector` then refreshes `{mask_count}` so the existing `_skipIf="mask_count == 0"` gate uses the filtered count — without that, dropping every mask via the filter would leave `mask_count` at its pre-filter value, the pipeline would enter the pick loop with an empty vector, and the surrounding `Inverter` would propagate FAILURE up to the outer `RepeatUnlessFailureEachTick`, halting the run.

## Alternatives considered

- **`FilterMasks2DByBoundingBox` instead of by area.** The cart bbox is `454 × 133` — aspect ratio ~3.4:1, a clean structural signature vs. ~square real boxes. Considered chaining a bbox filter for belt-and-suspenders, but the area separation alone (3,949 vs 20,643 vs 26,285) is wide enough to be reliable for this scene. Left as a future option if a different angle of the cart slips through.
- **Re-ordering picks by closest-first.** Considered using `GetClosestObjectToPose` + `RemoveFromVector` to walk boxes closest-to-TCP first, but the existing waypoint partitioning makes the gain marginal and the refactor would touch the pick path. Punted as a separate enhancement.

## Branch base

PR is targeted at `fix/19112-ml-move-boxes-sam3` (this feature branch) rather than `v9.3`, so it stacks on top of the SAM3 swap rather than landing in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)