### PR TITLE
Add per-PR HTML test reports and upgrade CI to GPU runner

### DIFF
--- a/.github/scripts/render_report.html.tmpl
+++ b/.github/scripts/render_report.html.tmpl
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>MoveIt Pro Objective Integration Tests</title>
+<link rel="icon" href="https://docs.picknik.ai/img/favicon.ico" type="image/x-icon">
+<style>
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    color: #1f2328;
+    background: #f6f8fa;
+    line-height: 1.5;
+  }}
+  header {{ background: #fff; border-bottom: 1px solid #d0d7de; padding: 20px 32px; }}
+  h1 {{ margin: 0 0 4px; font-size: 20px; font-weight: 600; }}
+  .meta {{ color: #57606a; font-size: 13px; }}
+  .meta span + span:before {{ content: " · "; }}
+  main {{ max-width: 1800px; margin: 24px auto; padding: 0 32px; width: 95%; }}
+  .stats {{
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+  }}
+  .stat {{
+    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
+    padding: 16px; text-align: center;
+  }}
+  .stat-count {{ font-size: 28px; font-weight: 600; }}
+  .stat-label {{ font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: #57606a; margin-top: 4px; }}
+  .stat-passed .stat-count {{ color: #1a7f37; }}
+  .stat-failed .stat-count {{ color: #cf222e; }}
+  .stat-skipped .stat-count {{ color: #6e7781; }}
+  .stat-total .stat-count {{ color: #1f2328; }}
+  .controls {{
+    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
+    padding: 12px 16px; margin-bottom: 16px;
+    display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  }}
+  .filter-btn {{
+    border: 1px solid #d0d7de; background: #f6f8fa;
+    padding: 4px 10px; border-radius: 6px; font-size: 12px; cursor: pointer; color: #24292f;
+  }}
+  .filter-btn.active {{ background: #1f2328; color: #fff; border-color: #1f2328; }}
+  .filter-btn:hover {{ background: #eaeef2; }}
+  .filter-btn.active:hover {{ background: #1f2328; }}
+  input[type=search] {{
+    flex: 1; min-width: 200px;
+    border: 1px solid #d0d7de; border-radius: 6px;
+    padding: 5px 10px; font-size: 13px; font-family: inherit;
+  }}
+  .toggle {{
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; color: #57606a; cursor: pointer; user-select: none;
+    padding: 4px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #f6f8fa;
+  }}
+  .toggle:hover {{ background: #eaeef2; }}
+  .toggle input {{ margin: 0; }}
+  body.hide-info .log-info, body.hide-info .log-debug {{ display: none; }}
+  .group {{ background: #fff; border: 1px solid #d0d7de; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }}
+  .group-failed  {{ border-left: 4px solid #cf222e; }}
+  .group-passed  {{ border-left: 4px solid #1a7f37; }}
+  .group-skipped {{ border-left: 4px solid #d0d7de; }}
+  .group-header {{
+    padding: 10px 16px; background: #f6f8fa; border-bottom: 1px solid #d0d7de;
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 16px; flex-wrap: wrap; cursor: pointer; user-select: none;
+  }}
+  .group-header:hover {{ background: #eaeef2; }}
+  .group-left {{ display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }}
+  .chevron {{
+    flex-shrink: 0; color: #57606a; font-size: 10px;
+    transition: transform 0.15s ease; display: inline-block; width: 12px;
+  }}
+  .group.collapsed .chevron {{ transform: rotate(-90deg); }}
+  .group.collapsed table {{ display: none; }}
+  .group.collapsed {{ border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }}
+  .group.collapsed .group-header {{ border-bottom: none; }}
+  .group-path {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; word-break: break-all; }}
+  .group-chips {{ display: flex; gap: 6px; flex-shrink: 0; }}
+  .chip {{ display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }}
+  .chip-passed  {{ background: #dafbe1; color: #1a7f37; }}
+  .chip-failed  {{ background: #ffebe9; color: #cf222e; }}
+  .chip-skipped {{ background: #eaeef2; color: #6e7781; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+  td {{ padding: 6px 16px; border-bottom: 1px solid #eaeef2; }}
+  tr:last-child td {{ border-bottom: none; }}
+  tr:hover {{ background: #f6f8fa; }}
+  tr.details:hover {{ background: #fff; }}
+  tr.details td {{ padding: 0; background: #fafbfc; }}
+
+  /* Log slice rendering */
+  .logs {{
+    background: #0d1117; color: #c9d1d9;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px;
+    max-height: 720px; overflow-y: auto; padding: 0;
+  }}
+  .log-line {{
+    display: grid;
+    grid-template-columns: 64px 60px 220px 1fr;
+    gap: 12px; padding: 2px 16px;
+    border-left: 3px solid transparent;
+  }}
+  .log-line:hover {{ background: rgba(255,255,255,0.04); }}
+  .log-ts    {{ color: #6e7681; text-align: right; }}
+  .log-level {{ font-weight: 600; }}
+  .log-node  {{ color: #79c0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }}
+  .log-msg   {{ color: #c9d1d9; white-space: pre-wrap; word-break: break-word; }}
+  .log-count {{
+    display: inline-block; margin-left: 8px;
+    background: rgba(255,255,255,0.12); color: #c9d1d9;
+    padding: 0 6px; border-radius: 8px;
+    font-size: 10px; font-weight: 600;
+  }}
+  .log-error, .log-fatal {{
+    background: rgba(207, 34, 46, 0.18);
+    border-left-color: #ff7b72;
+  }}
+  .log-error .log-level, .log-fatal .log-level {{ color: #ff7b72; }}
+  .log-warn {{
+    background: rgba(187, 128, 9, 0.16);
+    border-left-color: #d29922;
+  }}
+  .log-warn  .log-level {{ color: #d29922; }}
+  .log-info  .log-level {{ color: #56d364; }}
+  .log-debug {{ color: #6e7681; }}
+  .log-debug .log-level {{ color: #6e7681; }}
+  .logs-empty {{
+    padding: 16px; color: #6e7781; font-size: 12px; background: #fafbfc;
+    font-style: italic;
+  }}
+
+  .status-cell {{ width: 110px; text-align: center; }}
+  .badge {{ display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }}
+  .badge-passed  {{ background: #dafbe1; color: #1a7f37; }}
+  .badge-failed  {{ background: #ffebe9; color: #cf222e; }}
+  .badge-error   {{ background: #ffebe9; color: #cf222e; }}
+  .badge-skipped {{ background: #eaeef2; color: #6e7781; }}
+  .fname {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #6e7781; }}
+  .obj-name {{ font-weight: 500; color: #0969da; }}
+  .obj-missing {{ color: #8c959f; font-weight: 400; }}
+  .time {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; text-align: right; width: 70px; }}
+  .msg {{ color: #57606a; font-size: 12px; }}
+  .msg-skipped {{ color: #8c959f; font-style: italic; }}
+  .msg-empty {{ color: #8c959f; font-style: italic; }}
+  .sum-err  {{ color: #cf222e; font-weight: 600; }}
+  .sum-warn {{ color: #9a6700; font-weight: 600; }}
+  .sum-info {{ color: #6e7781; }}
+  .more {{ color: #0969da; font-weight: 500; }}
+  .group.hidden {{ display: none; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>MoveIt Pro Objective Integration Tests</h1>
+  <div class="meta">
+    <span>{total} tests</span>
+    <span>{duration_str} total</span>
+    <span>{timestamp_str}</span>
+    <span>{hostname_esc}</span>
+    <span>{log_line_count:,} log lines indexed (rosout + launch)</span>
+  </div>
+</header>
+<main>
+  <div class="stats">
+    <div class="stat stat-total"><div class="stat-count">{total}</div><div class="stat-label">Total objective tests</div></div>
+    <div class="stat stat-passed"><div class="stat-count">{passed}</div><div class="stat-label">Objectives passed</div></div>
+    <div class="stat stat-failed"><div class="stat-count">{failed_total}</div><div class="stat-label">Objectives failed</div></div>
+    <div class="stat stat-skipped"><div class="stat-count">{skipped}</div><div class="stat-label">Objectives skipped</div></div>
+    <div class="stat stat-total"><div class="stat-count">{avg_exec_time:.1f}s</div><div class="stat-label">Avg test time</div></div>
+    <div class="stat stat-total"><div class="stat-count">{pass_rate:.0f}%</div><div class="stat-label">Objective pass rate</div></div>
+  </div>
+  <div class="controls">
+    <button class="filter-btn{all_active}" data-filter="all">All</button>
+    <button class="filter-btn{failed_active}" data-filter="failed">Failed</button>
+    <button class="filter-btn" data-filter="passed">Passed</button>
+    <button class="filter-btn" data-filter="skipped">Skipped</button>
+    <input type="search" id="search" placeholder="Filter by name…">
+    <label class="toggle"><input type="checkbox" id="show-info" checked> Show INFO/DEBUG</label>
+  </div>
+  {sections_html}
+</main>
+<script>
+  const buttons = document.querySelectorAll('.filter-btn');
+  const search = document.getElementById('search');
+  let currentFilter = '{default_filter}';
+
+  function apply() {{
+    const q = search.value.toLowerCase();
+    document.querySelectorAll('.group').forEach(group => {{
+      let visible = 0;
+      group.querySelectorAll('tbody tr:not(.details)').forEach(row => {{
+        const status = row.dataset.status;
+        const name = row.dataset.name;
+        const matchFilter = currentFilter === 'all' || (currentFilter === 'failed' ? (status === 'failed' || status === 'error') : status === currentFilter);
+        const matchSearch = !q || name.includes(q);
+        const show = matchFilter && matchSearch;
+        row.style.display = show ? '' : 'none';
+        const details = row.nextElementSibling;
+        if (details && details.classList.contains('details')) {{
+          if (!show) {{ details.hidden = true; }}
+          details.style.display = show ? '' : 'none';
+        }}
+        if (show) visible++;
+      }});
+      group.classList.toggle('hidden', visible === 0);
+    }});
+  }}
+
+  buttons.forEach(b => b.addEventListener('click', () => {{
+    buttons.forEach(x => x.classList.remove('active'));
+    b.classList.add('active');
+    currentFilter = b.dataset.filter;
+    apply();
+  }}));
+  search.addEventListener('input', apply);
+
+  const showInfo = document.getElementById('show-info');
+  // Sync the body's hide-info class to the checkbox state on initial render
+  // (and on subsequent change). When checked, full per-objective context is
+  // visible by default — INFO/DEBUG/WARN/ERROR/FATAL — which is what we want
+  // when triaging a failing test.
+  document.body.classList.toggle('hide-info', !showInfo.checked);
+  showInfo.addEventListener('change', () => {{
+    document.body.classList.toggle('hide-info', !showInfo.checked);
+  }});
+
+  // Apply the default filter to the test rows on initial load. Without this,
+  // the active button is visually highlighted but the apply() logic that
+  // hides non-matching rows hasn't run yet, so non-matching rows stay
+  // visible until the user clicks a filter button.
+  apply();
+</script>
+</body>
+</html>

--- a/.github/scripts/render_report.py
+++ b/.github/scripts/render_report.py
@@ -1,0 +1,893 @@
+"""Render a pytest JUnit xunit.xml to a nicer HTML report.
+
+Tests are grouped by their parent directory. Per-test ROS log slices come
+from `<xunit.parent>/ros_logs/rosout.ndjson` (one JSON object per line,
+captured from the /rosout topic by lab_sim/test/conftest.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import datetime as dt
+import html
+import json
+import os.path
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+
+# ---------- formatting helpers ----------
+
+
+def format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{int(minutes)}m {secs:.0f}s"
+    hours, minutes = divmod(int(minutes), 60)
+    return f"{hours}h {minutes}m {secs:.0f}s"
+
+
+def format_timestamp(iso: str) -> str:
+    if not iso:
+        return ""
+    try:
+        t = dt.datetime.fromisoformat(iso)
+        return t.strftime("%b %d, %Y · %H:%M:%S")
+    except ValueError:
+        return iso
+
+
+def parse_iso_to_unix(iso: str) -> float | None:
+    if not iso:
+        return None
+    try:
+        t = dt.datetime.fromisoformat(iso)
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=dt.timezone.utc)
+        return t.timestamp()
+    except ValueError:
+        return None
+
+
+# ---------- test name + objective resolution ----------
+
+
+def split_path(test_name: str) -> tuple[str, str, str]:
+    """Return (parent_dir, filename, full). Handles non-path test names too."""
+    m = re.search(r"\[([^\]]+)\]", test_name)
+    full = m.group(1) if m else test_name
+    if "/" not in full:
+        return "", full, full
+    parent, fname = os.path.split(full)
+    return parent, fname, full
+
+
+_RE_EXAMPLE_WS = re.compile(
+    r"^/__w/([^/]+)/\1/install/([^/]+)/share/\2/objectives/(.+)$"
+)
+_RE_OVERLAY = re.compile(r"^/opt/overlay_ws/install/([^/]+)/share/\1/objectives/(.+)$")
+
+_EXAMPLE_WS_ROOTS = [
+    Path.home() / "code" / "moveit_pro_example_ws",
+]
+# Also resolve via the renderer's CWD so the GitHub Actions render-report job
+# (which checks out the repo at $GITHUB_WORKSPACE and runs the renderer from
+# there) can find objective XMLs without needing the hardcoded local path above.
+_EXAMPLE_WS_ROOTS.append(Path.cwd())
+_MOVEIT_PRO_INSTALL_ROOT = Path.home() / "code" / "moveit_pro" / ".colcon" / "install"
+_MOVEIT_PRO_LOCAL = Path.home() / "code" / "moveit_pro"
+_CONTAINER_PREFIX = "/opt/overlay_ws"
+
+
+def find_local_xml(ci_path: str) -> Path | None:
+    m = _RE_EXAMPLE_WS.match(ci_path)
+    if m:
+        pkg, rel = m.group(2), m.group(3)
+        for root in _EXAMPLE_WS_ROOTS:
+            candidate = root / "src" / pkg / "objectives" / rel
+            if candidate.exists():
+                return candidate
+        return None
+    m = _RE_OVERLAY.match(ci_path)
+    if m:
+        pkg, rel = m.group(1), m.group(2)
+        install_link = (
+            _MOVEIT_PRO_INSTALL_ROOT / pkg / "share" / pkg / "objectives" / rel
+        )
+        if install_link.is_symlink():
+            target = os.readlink(install_link)
+            if target.startswith(_CONTAINER_PREFIX + "/"):
+                candidate = _MOVEIT_PRO_LOCAL / target[len(_CONTAINER_PREFIX) + 1 :]
+                if candidate.exists():
+                    return candidate
+        elif install_link.exists():
+            return install_link
+    return None
+
+
+_OBJECTIVE_NAME_CACHE: dict[str, str | None] = {}
+
+
+def extract_objective_name(ci_path: str) -> str | None:
+    if ci_path in _OBJECTIVE_NAME_CACHE:
+        return _OBJECTIVE_NAME_CACHE[ci_path]
+    local = find_local_xml(ci_path)
+    name = None
+    if local is not None:
+        try:
+            tree = ET.parse(local)
+            root = tree.getroot()
+            if "main_tree_to_execute" in root.attrib:
+                name = root.attrib["main_tree_to_execute"]
+            if name is None:
+                for tnm in root.iter("TreeNodesModel"):
+                    for sub in tnm.findall("SubTree"):
+                        if "ID" in sub.attrib:
+                            name = sub.attrib["ID"]
+                            break
+                    if name:
+                        break
+            if name is None:
+                for bt in root.iter("BehaviorTree"):
+                    if "ID" in bt.attrib:
+                        name = bt.attrib["ID"]
+                        break
+        except (ET.ParseError, OSError):
+            pass
+    _OBJECTIVE_NAME_CACHE[ci_path] = name
+    return name
+
+
+# ---------- ROS log loading + slicing ----------
+
+# launch.log line formats — two patterns. Order matters: the leveled form is
+# more specific (requires `]:` after the second bracket) and must be tried
+# first, otherwise the passthrough regex would mis-capture `[LEVEL]` as the
+# process name.
+#
+# Leveled (launch's own events):  `<ts> [LEVEL] [name]: msg`
+_RE_LAUNCH_LEVELED = re.compile(
+    r"^(?P<ts>\d+(?:\.\d+)?)\s+\[(?P<level>[A-Z]+)\]\s+\[(?P<name>[^\]]+)\]:\s+(?P<msg>.*)$"
+)
+# Passthrough (stdout/stderr from launched processes):  `<ts> [name-N] msg`
+_RE_LAUNCH_PASSTHROUGH = re.compile(
+    r"^(?P<ts>\d+(?:\.\d+)?)\s+\[(?P<name>[^\]]+)\]\s+(?P<msg>.*)$"
+)
+# Strip the launch sequence suffix (`-14` → ``) so passthrough lines align
+# with /rosout entries from the same node.
+_RE_LAUNCH_SEQ_SUFFIX = re.compile(r"-\d+$")
+
+# Many ROS executables follow the convention `<name>_node_main` (the binary
+# in `lib/<pkg>/`), while the rcl logger publishes /rosout under the bare
+# `<name>_node`. Strip the `_main` suffix so launch.log passthrough entries
+# align with /rosout entries from the same node. Anchor to `_node_main$` so
+# we don't accidentally strip `_main` from binaries that legitimately end
+# in `_main` without `_node` (uncommon, but possible).
+_RE_EXEC_MAIN_SUFFIX = re.compile(r"(_node)_main$")
+
+# rcutils' default stream formatter prepends `[LEVEL] [timestamp] ` to every
+# message written to stdout — what ros2 launch then aggregates into
+# launch.log. Bare /rosout messages have no such prefix, so without
+# stripping it the same logical line appears twice in the report (rosout +
+# launch.log) and the (level, node, msg) dedup misses both copies. The
+# timestamp bracket varies (unix float, ISO wall time, with or without
+# milliseconds) — match `[<anything that isn't ]>]`. Optional ANSI color
+# codes wrap each bracket when rcutils' tty colorization is on.
+_RE_RCUTILS_PREFIX = re.compile(
+    r"^\s*"
+    r"(?:\x1b\[\d+m)?\[(?:DEBUG|INFO|WARN|WARNING|ERROR|FATAL)\](?:\x1b\[\d+m)?"
+    r"\s*"
+    r"(?:\x1b\[\d+m)?\[[^\]]+\](?:\x1b\[\d+m)?"
+    r"\s*:?\s*"
+)
+
+# A passthrough line is the raw stdout/stderr of a launched process. ROS code
+# often prints its own `[LEVEL]` bracket inside that text (sometimes with ANSI
+# color codes around it). Extract that level when present so the renderer can
+# style the entry correctly instead of dumping it as INFO.
+_RE_PASSTHROUGH_EMBED_LEVEL = re.compile(
+    r"^\s*(?:\x1b\[\d+m)?\[(DEBUG|INFO|WARN|WARNING|ERROR|FATAL)\]"
+)
+
+# When a passthrough line has no embedded level (stderr from a dying process,
+# uncaught exception text, etc.) but its content matches one of these markers,
+# treat it as ERROR. Without this, boot-crash diagnostics like
+# `Aborted (Signal sent by tkill())` or `what(): Failed to load RobotModel`
+# get dumped at INFO severity and disappear when the user filters to errors.
+# Markers split into two groups:
+#   - LINE_START: anchored to the start of the message text. Avoids false
+#     positives like "Operation Aborted by user" or a docstring mention of
+#     "Traceback" being elevated to ERROR.
+#   - SUBSTRING: stable enough as substrings (highly specific, unlikely to
+#     appear in benign log content).
+_PASSTHROUGH_ERROR_LINE_START = (
+    "Aborted",
+    "Segmentation fault",
+    "Stack trace",
+    "Traceback",
+    "terminate called",
+)
+_PASSTHROUGH_ERROR_SUBSTRING = (
+    "SIGSEGV",
+    "SIGABRT",
+    "what():",
+)
+
+
+def _classify_passthrough(msg: str) -> str:
+    m = _RE_PASSTHROUGH_EMBED_LEVEL.match(msg)
+    if m:
+        level = m.group(1).upper()
+        return "WARN" if level == "WARNING" else level
+    stripped = msg.lstrip()
+    for marker in _PASSTHROUGH_ERROR_LINE_START:
+        if stripped.startswith(marker):
+            return "ERROR"
+    for marker in _PASSTHROUGH_ERROR_SUBSTRING:
+        if marker in msg:
+            return "ERROR"
+    return "INFO"
+
+
+def load_rosout_ndjson(ndjson_path: Path) -> list[tuple[float, str, str, str]]:
+    """Read structured /rosout log entries from rosout.ndjson.
+
+    The file is produced by lab_sim/test/conftest.py via a session-scoped
+    subscriber to /rosout. Each line is one JSON object: {ts, level, node, msg}.
+    Going through /rosout (a published rcl_interfaces/msg/Log topic with a
+    stable schema) instead of regex-parsing rcutils file-logger output
+    insulates the renderer from rcutils' textual format, which has no
+    stability contract.
+    """
+    if not ndjson_path.is_file():
+        return []
+    out: list[tuple[float, str, str, str]] = []
+    try:
+        with open(ndjson_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    out.append(
+                        (
+                            float(entry["ts"]),
+                            str(entry.get("level", "")).upper(),
+                            str(entry.get("node", "")),
+                            str(entry.get("msg", "")),
+                        )
+                    )
+                except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                    continue
+    except OSError:
+        return []
+    out.sort(key=lambda x: x[0])
+    return out
+
+
+def load_launch_logs(logs_dir: Path) -> list[tuple[float, str, str, str]]:
+    """Read every <logs_dir>/<dated>/launch.log file produced by ros2 launch.
+
+    Secondary source alongside /rosout. Critical for diagnosing boot
+    failures where a node crashes before publishing anything to /rosout —
+    the stack trace and SIGSEGV/SIGABRT signal lines live in launch.log's
+    stdout/stderr passthrough only. Format is best-effort; lines that
+    don't match either regex (e.g. raw stderr without a timestamp prefix
+    from a child process) are dropped.
+    """
+    if not logs_dir.is_dir():
+        return []
+    out: list[tuple[float, str, str, str]] = []
+    for launch_log in sorted(logs_dir.glob("*/launch.log")):
+        try:
+            with open(launch_log, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    m = _RE_LAUNCH_LEVELED.match(line)
+                    if m:
+                        try:
+                            out.append(
+                                (
+                                    float(m["ts"]),
+                                    m["level"].upper(),
+                                    m["name"],
+                                    m["msg"].rstrip(),
+                                )
+                            )
+                        except ValueError:
+                            pass
+                        continue
+                    m2 = _RE_LAUNCH_PASSTHROUGH.match(line)
+                    if m2:
+                        try:
+                            name = _RE_LAUNCH_SEQ_SUFFIX.sub("", m2["name"])
+                            name = _RE_EXEC_MAIN_SUFFIX.sub(r"\1", name)
+                            msg = m2["msg"].rstrip()
+                            # Classify *before* stripping the rcutils prefix
+                            # — _classify_passthrough reads the embedded
+                            # `[LEVEL]` token to assign severity.
+                            level = _classify_passthrough(msg)
+                            msg = _RE_RCUTILS_PREFIX.sub("", msg)
+                            out.append(
+                                (
+                                    float(m2["ts"]),
+                                    level,
+                                    name,
+                                    msg,
+                                )
+                            )
+                        except ValueError:
+                            pass
+        except OSError:
+            continue
+    return out
+
+
+def slice_log(
+    all_lines: list[tuple[float, str, str, str]],
+    starts: list[float],
+    t_start: float,
+    t_end: float,
+) -> list[tuple[float, str, str, str]]:
+    lo = bisect.bisect_left(starts, t_start)
+    hi = bisect.bisect_right(starts, t_end)
+    return all_lines[lo:hi]
+
+
+def classify(tc: ET.Element) -> str:
+    if tc.find("failure") is not None:
+        return "failed"
+    if tc.find("error") is not None:
+        return "error"
+    if tc.find("skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
+# ---------- main ----------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render a pytest JUnit xunit.xml to an HTML report.",
+    )
+    parser.add_argument("input", type=Path, help="Path to xunit.xml")
+    parser.add_argument("output", type=Path, help="Path to write HTML report")
+    parser.add_argument(
+        "rosout_ndjson",
+        type=Path,
+        nargs="?",
+        default=None,
+        help="Path to rosout.ndjson "
+        "(defaults to <input.parent>/ros_logs/rosout.ndjson)",
+    )
+    args = parser.parse_args()
+
+    in_path = args.input
+    out_path = args.output
+    rosout_path = (
+        args.rosout_ndjson
+        if args.rosout_ndjson is not None
+        else in_path.parent / "ros_logs" / "rosout.ndjson"
+    )
+
+    # Parse defensively: a truncated upload or a runner that crashed before
+    # pytest wrote any results will yield malformed/empty XML. The render-report
+    # job is `needs:` for the sticky-comment job, so a crash here loses the
+    # comment exactly when it would be most useful. Degrade gracefully instead.
+    try:
+        tree = ET.parse(in_path)
+    except ET.ParseError as exc:
+        print(f"render_report: could not parse {in_path}: {exc}", file=sys.stderr)
+        sys.exit(0)
+    root = tree.getroot()
+    suite = root.find("testsuite") if root.tag == "testsuites" else root
+    if suite is None:
+        print(
+            f"render_report: no <testsuite> in {in_path}; nothing to render",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    timestamp = suite.attrib.get("timestamp", "")
+    hostname = suite.attrib.get("hostname", "")
+    total_time = float(suite.attrib.get("time", 0))
+    suite_unix = parse_iso_to_unix(timestamp)
+
+    # Load ROS logs (file logger + launch-wrapped stdout) once.
+    # Primary source: structured /rosout NDJSON captured by conftest. Secondary
+    # source: launch.log stdout/stderr passthrough, critical for boot failures
+    # where a node SIGABRTs before it publishes anything to /rosout.
+    ros_lines = sorted(
+        load_rosout_ndjson(rosout_path) + load_launch_logs(rosout_path.parent),
+        key=lambda x: x[0],
+    )
+    ros_starts = [entry[0] for entry in ros_lines]
+
+    groups: dict[str, list[dict]] = defaultdict(list)
+    counts = {"passed": 0, "failed": 0, "error": 0, "skipped": 0}
+    cumulative_time = 0.0
+    first_non_skipped_seen = False
+
+    for tc in suite.findall("testcase"):
+        status = classify(tc)
+        counts[status] += 1
+        parent, fname, full = split_path(tc.attrib.get("name", ""))
+        time_s = float(tc.attrib.get("time", 0))
+
+        # Compute per-test log window. Pad it generously — pytest's <testcase
+        # time> only covers the test call, not fixture setup/teardown, so the
+        # cumulative-time cursor drifts a second or two per test against the
+        # log file's wall-clock timestamps. Without padding, very-short tests
+        # (~0.5s failures from BT-load errors) miss their own error line.
+        pad_before = 2.0
+        pad_after = 5.0
+        t_start = (suite_unix + cumulative_time) if suite_unix else None
+        t_end = (suite_unix + cumulative_time + time_s) if suite_unix else None
+        # Skipped tests don't actually consume sim time, so don't advance the
+        # cumulative cursor for them.
+        if status != "skipped":
+            cumulative_time += time_s
+
+        # The first non-skipped test absorbs any pre-suite log entries
+        # (e.g., a backend node crashing during launch.bringup before the
+        # suite timestamp was emitted). Without this, boot-failure stack
+        # traces in launch.log fall outside every test's window and get
+        # rendered as "No ROS log lines in this test's time window."
+        extend_back_to: float | None = None
+        if (
+            t_start is not None
+            and status != "skipped"
+            and not first_non_skipped_seen
+            and ros_starts
+            and ros_starts[0] < t_start
+        ):
+            extend_back_to = ros_starts[0]
+        if status != "skipped":
+            first_non_skipped_seen = True
+
+        if t_start is not None and ros_lines:
+            # extend_back_to is a widen-only override: take whichever is earlier
+            # so the first-test window never gets narrower than any other test's.
+            window_start = t_start - pad_before
+            if extend_back_to is not None:
+                window_start = min(window_start, extend_back_to)
+            log_slice = slice_log(
+                ros_lines, ros_starts, window_start, t_end + pad_after
+            )
+        else:
+            log_slice = []
+
+        warn_n = sum(1 for _, lvl, _, _ in log_slice if lvl == "WARN")
+        err_n = sum(1 for _, lvl, _, _ in log_slice if lvl in ("ERROR", "FATAL"))
+
+        groups[parent].append(
+            {
+                "status": status,
+                "fname": fname,
+                "full": full,
+                "objective_name": extract_objective_name(full),
+                "time": time_s,
+                "t_start": t_start,
+                "t_end": t_end,
+                "log_slice": log_slice,
+                "warn_n": warn_n,
+                "err_n": err_n,
+            }
+        )
+
+    status_rank = {"failed": 0, "error": 1, "passed": 2, "skipped": 3}
+    for tests in groups.values():
+        tests.sort(key=lambda r: (status_rank[r["status"]], -r["time"], r["fname"]))
+
+    def group_key(item):
+        parent, tests = item
+        fails = sum(1 for t in tests if t["status"] in ("failed", "error"))
+        return (-fails, parent)
+
+    sorted_groups = sorted(groups.items(), key=group_key)
+    total = sum(counts.values())
+
+    executed_times = [
+        t["time"]
+        for tests in groups.values()
+        for t in tests
+        if t["status"] != "skipped"
+    ]
+    avg_exec_time = (
+        (sum(executed_times) / len(executed_times)) if executed_times else 0.0
+    )
+
+    def status_badge(s: str) -> str:
+        symbols = {"passed": "✓", "failed": "✕", "error": "!", "skipped": "−"}
+        return f'<span class="badge badge-{s}">{symbols[s]} {s}</span>'
+
+    def render_log_slice(log_slice: list[tuple[float, str, str, str]]) -> str:
+        if not log_slice:
+            return '<div class="logs-empty">No ROS log lines in this test\'s time window.</div>'
+        # Fold every duplicate (level, node, msg) in the slice down to one
+        # entry, anchored at the first occurrence's timestamp, with a count
+        # badge for repeats. Strict-consecutive collapsing misses cases where
+        # a retry loop's messages interleave with other nodes' output — group
+        # collapsing handles those.
+        seen: dict[tuple[str, str, str], list] = {}
+        ordered_keys: list[tuple[str, str, str]] = []
+        for ts, lvl, node, msg in log_slice:
+            key = (lvl, node, msg)
+            if key in seen:
+                seen[key][1] += 1
+            else:
+                seen[key] = [ts, 1]
+                ordered_keys.append(key)
+        collapsed: list[tuple[float, str, str, str, int]] = [
+            (seen[k][0], k[0], k[1], k[2], seen[k][1]) for k in ordered_keys
+        ]
+
+        rows: list[str] = []
+        anchor = collapsed[0][0]
+        for ts, lvl, node, msg, count in collapsed:
+            rel = ts - anchor
+            level_class = (
+                lvl.lower()
+                if lvl in ("ERROR", "FATAL", "WARN", "INFO", "DEBUG")
+                else "info"
+            )
+            count_badge = (
+                f' <span class="log-count">×{count}</span>' if count > 1 else ""
+            )
+            rows.append(
+                f'<div class="log-line log-{level_class}">'
+                f'<span class="log-ts">+{rel:6.2f}s</span>'
+                f'<span class="log-level">{lvl}</span>'
+                f'<span class="log-node">{html.escape(node)}</span>'
+                f'<span class="log-msg">{html.escape(msg)}{count_badge}</span>'
+                f"</div>"
+            )
+        return f'<div class="logs">{"".join(rows)}</div>'
+
+    section_parts: list[str] = []
+    test_idx = 0
+    for parent, tests in sorted_groups:
+        g_fails = sum(1 for t in tests if t["status"] in ("failed", "error"))
+        g_passes = sum(1 for t in tests if t["status"] == "passed")
+        g_skips = sum(1 for t in tests if t["status"] == "skipped")
+        chips: list[str] = []
+        if g_fails:
+            chips.append(f'<span class="chip chip-failed">{g_fails} fail</span>')
+        if g_passes:
+            chips.append(f'<span class="chip chip-passed">{g_passes} pass</span>')
+        if g_skips:
+            chips.append(f'<span class="chip chip-skipped">{g_skips} skip</span>')
+
+        rows_html: list[str] = []
+        for r in tests:
+            has_logs = bool(r["log_slice"])
+            details_html = (
+                f'<tr class="details" id="d{test_idx}" hidden>'
+                f'<td colspan="5">{render_log_slice(r["log_slice"])}</td></tr>'
+            )
+            click = (
+                f"onclick=\"document.getElementById('d{test_idx}').hidden = "
+                f"!document.getElementById('d{test_idx}').hidden\""
+            )
+            cursor = 'style="cursor: pointer"'
+
+            # Replace the pytest-fail message with a log summary.
+            if has_logs:
+                pieces: list[str] = []
+                if r["err_n"]:
+                    pieces.append(
+                        f'<span class="sum-err">{r["err_n"]} error{"s" if r["err_n"] != 1 else ""}</span>'
+                    )
+                if r["warn_n"]:
+                    pieces.append(
+                        f'<span class="sum-warn">{r["warn_n"]} warning{"s" if r["warn_n"] != 1 else ""}</span>'
+                    )
+                info_n = sum(1 for _, lvl, _, _ in r["log_slice"] if lvl == "INFO")
+                if info_n:
+                    pieces.append(f'<span class="sum-info">{info_n} info</span>')
+                msg_cell = " · ".join(pieces)
+            elif r["status"] == "skipped":
+                msg_cell = '<span class="msg-skipped">skipped</span>'
+            else:
+                msg_cell = '<span class="msg-empty">no logs</span>'
+
+            obj_cell = (
+                f'<td class="obj-name">{html.escape(r["objective_name"])}</td>'
+                if r["objective_name"]
+                else '<td class="obj-name obj-missing">—</td>'
+            )
+            search_field = html.escape(
+                (r["objective_name"] or "") + " " + r["fname"]
+            ).lower()
+            rows_html.append(
+                f'<tr data-status="{r["status"]}" data-name="{search_field}" {click} {cursor}>'
+                f'<td class="status-cell">{status_badge(r["status"])}</td>'
+                f"{obj_cell}"
+                f'<td class="fname">{html.escape(r["fname"])}</td>'
+                f'<td class="time">{r["time"]:.1f}s</td>'
+                f'<td class="msg">{msg_cell}</td>'
+                f"</tr>{details_html}"
+            )
+            test_idx += 1
+
+        header_class = (
+            "group-failed"
+            if g_fails
+            else ("group-skipped" if g_skips and not g_passes else "group-passed")
+        )
+        section_parts.append(
+            f'<section class="group {header_class}">'
+            f'<div class="group-header" onclick="this.parentElement.classList.toggle(\'collapsed\')">'
+            f'<div class="group-left">'
+            f'<span class="chevron">▾</span>'
+            f'<code class="group-path" title="{html.escape(parent)}">'
+            f'{html.escape(parent or "(no parent)")}</code>'
+            f"</div>"
+            f'<div class="group-chips">{"".join(chips)}</div>'
+            f"</div>"
+            f'<table><tbody>{"".join(rows_html)}</tbody></table>'
+            f"</section>"
+        )
+
+    pass_rate_denom = counts["passed"] + counts["failed"] + counts["error"]
+    pass_rate = (counts["passed"] / pass_rate_denom * 100) if pass_rate_denom else 0
+
+    # Default to the "Failed" filter when failures exist (post-mortem is the
+    # primary use case for this report). When every test passed, "Failed"
+    # would render an empty list, so default to "All" instead.
+    has_failures = counts["failed"] + counts["error"] > 0
+    default_filter = "failed" if has_failures else "all"
+    all_active = "" if has_failures else " active"
+    failed_active = " active" if has_failures else ""
+
+    html_out = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>MoveIt Pro Objective Integration Tests</title>
+<link rel="icon" href="https://docs.picknik.ai/img/favicon.ico" type="image/x-icon">
+<style>
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    color: #1f2328;
+    background: #f6f8fa;
+    line-height: 1.5;
+  }}
+  header {{ background: #fff; border-bottom: 1px solid #d0d7de; padding: 20px 32px; }}
+  h1 {{ margin: 0 0 4px; font-size: 20px; font-weight: 600; }}
+  .meta {{ color: #57606a; font-size: 13px; }}
+  .meta span + span:before {{ content: " · "; }}
+  main {{ max-width: 1800px; margin: 24px auto; padding: 0 32px; width: 95%; }}
+  .stats {{
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+  }}
+  .stat {{
+    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
+    padding: 16px; text-align: center;
+  }}
+  .stat-count {{ font-size: 28px; font-weight: 600; }}
+  .stat-label {{ font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: #57606a; margin-top: 4px; }}
+  .stat-passed .stat-count {{ color: #1a7f37; }}
+  .stat-failed .stat-count {{ color: #cf222e; }}
+  .stat-skipped .stat-count {{ color: #6e7781; }}
+  .stat-total .stat-count {{ color: #1f2328; }}
+  .controls {{
+    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
+    padding: 12px 16px; margin-bottom: 16px;
+    display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  }}
+  .filter-btn {{
+    border: 1px solid #d0d7de; background: #f6f8fa;
+    padding: 4px 10px; border-radius: 6px; font-size: 12px; cursor: pointer; color: #24292f;
+  }}
+  .filter-btn.active {{ background: #1f2328; color: #fff; border-color: #1f2328; }}
+  .filter-btn:hover {{ background: #eaeef2; }}
+  .filter-btn.active:hover {{ background: #1f2328; }}
+  input[type=search] {{
+    flex: 1; min-width: 200px;
+    border: 1px solid #d0d7de; border-radius: 6px;
+    padding: 5px 10px; font-size: 13px; font-family: inherit;
+  }}
+  .toggle {{
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; color: #57606a; cursor: pointer; user-select: none;
+    padding: 4px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #f6f8fa;
+  }}
+  .toggle:hover {{ background: #eaeef2; }}
+  .toggle input {{ margin: 0; }}
+  body.hide-info .log-info, body.hide-info .log-debug {{ display: none; }}
+  .group {{ background: #fff; border: 1px solid #d0d7de; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }}
+  .group-failed  {{ border-left: 4px solid #cf222e; }}
+  .group-passed  {{ border-left: 4px solid #1a7f37; }}
+  .group-skipped {{ border-left: 4px solid #d0d7de; }}
+  .group-header {{
+    padding: 10px 16px; background: #f6f8fa; border-bottom: 1px solid #d0d7de;
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 16px; flex-wrap: wrap; cursor: pointer; user-select: none;
+  }}
+  .group-header:hover {{ background: #eaeef2; }}
+  .group-left {{ display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }}
+  .chevron {{
+    flex-shrink: 0; color: #57606a; font-size: 10px;
+    transition: transform 0.15s ease; display: inline-block; width: 12px;
+  }}
+  .group.collapsed .chevron {{ transform: rotate(-90deg); }}
+  .group.collapsed table {{ display: none; }}
+  .group.collapsed {{ border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }}
+  .group.collapsed .group-header {{ border-bottom: none; }}
+  .group-path {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; word-break: break-all; }}
+  .group-chips {{ display: flex; gap: 6px; flex-shrink: 0; }}
+  .chip {{ display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }}
+  .chip-passed  {{ background: #dafbe1; color: #1a7f37; }}
+  .chip-failed  {{ background: #ffebe9; color: #cf222e; }}
+  .chip-skipped {{ background: #eaeef2; color: #6e7781; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+  td {{ padding: 6px 16px; border-bottom: 1px solid #eaeef2; }}
+  tr:last-child td {{ border-bottom: none; }}
+  tr:hover {{ background: #f6f8fa; }}
+  tr.details:hover {{ background: #fff; }}
+  tr.details td {{ padding: 0; background: #fafbfc; }}
+
+  /* Log slice rendering */
+  .logs {{
+    background: #0d1117; color: #c9d1d9;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px;
+    max-height: 720px; overflow-y: auto; padding: 0;
+  }}
+  .log-line {{
+    display: grid;
+    grid-template-columns: 64px 60px 220px 1fr;
+    gap: 12px; padding: 2px 16px;
+    border-left: 3px solid transparent;
+  }}
+  .log-line:hover {{ background: rgba(255,255,255,0.04); }}
+  .log-ts    {{ color: #6e7681; text-align: right; }}
+  .log-level {{ font-weight: 600; }}
+  .log-node  {{ color: #79c0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }}
+  .log-msg   {{ color: #c9d1d9; white-space: pre-wrap; word-break: break-word; }}
+  .log-count {{
+    display: inline-block; margin-left: 8px;
+    background: rgba(255,255,255,0.12); color: #c9d1d9;
+    padding: 0 6px; border-radius: 8px;
+    font-size: 10px; font-weight: 600;
+  }}
+  .log-error, .log-fatal {{
+    background: rgba(207, 34, 46, 0.18);
+    border-left-color: #ff7b72;
+  }}
+  .log-error .log-level, .log-fatal .log-level {{ color: #ff7b72; }}
+  .log-warn {{
+    background: rgba(187, 128, 9, 0.16);
+    border-left-color: #d29922;
+  }}
+  .log-warn  .log-level {{ color: #d29922; }}
+  .log-info  .log-level {{ color: #56d364; }}
+  .log-debug {{ color: #6e7681; }}
+  .log-debug .log-level {{ color: #6e7681; }}
+  .logs-empty {{
+    padding: 16px; color: #6e7781; font-size: 12px; background: #fafbfc;
+    font-style: italic;
+  }}
+
+  .status-cell {{ width: 110px; text-align: center; }}
+  .badge {{ display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }}
+  .badge-passed  {{ background: #dafbe1; color: #1a7f37; }}
+  .badge-failed  {{ background: #ffebe9; color: #cf222e; }}
+  .badge-error   {{ background: #ffebe9; color: #cf222e; }}
+  .badge-skipped {{ background: #eaeef2; color: #6e7781; }}
+  .fname {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #6e7781; }}
+  .obj-name {{ font-weight: 500; color: #0969da; }}
+  .obj-missing {{ color: #8c959f; font-weight: 400; }}
+  .time {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; text-align: right; width: 70px; }}
+  .msg {{ color: #57606a; font-size: 12px; }}
+  .msg-skipped {{ color: #8c959f; font-style: italic; }}
+  .msg-empty {{ color: #8c959f; font-style: italic; }}
+  .sum-err  {{ color: #cf222e; font-weight: 600; }}
+  .sum-warn {{ color: #9a6700; font-weight: 600; }}
+  .sum-info {{ color: #6e7781; }}
+  .more {{ color: #0969da; font-weight: 500; }}
+  .group.hidden {{ display: none; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>MoveIt Pro Objective Integration Tests</h1>
+  <div class="meta">
+    <span>{total} tests</span>
+    <span>{format_duration(total_time)} total</span>
+    <span>{html.escape(format_timestamp(timestamp))}</span>
+    <span>{html.escape(hostname)}</span>
+    <span>{len(ros_lines):,} log lines indexed (rosout + launch)</span>
+  </div>
+</header>
+<main>
+  <div class="stats">
+    <div class="stat stat-total"><div class="stat-count">{total}</div><div class="stat-label">Total objective tests</div></div>
+    <div class="stat stat-passed"><div class="stat-count">{counts["passed"]}</div><div class="stat-label">Objectives passed</div></div>
+    <div class="stat stat-failed"><div class="stat-count">{counts["failed"] + counts["error"]}</div><div class="stat-label">Objectives failed</div></div>
+    <div class="stat stat-skipped"><div class="stat-count">{counts["skipped"]}</div><div class="stat-label">Objectives skipped</div></div>
+    <div class="stat stat-total"><div class="stat-count">{avg_exec_time:.1f}s</div><div class="stat-label">Avg test time</div></div>
+    <div class="stat stat-total"><div class="stat-count">{pass_rate:.0f}%</div><div class="stat-label">Objective pass rate</div></div>
+  </div>
+  <div class="controls">
+    <button class="filter-btn{all_active}" data-filter="all">All</button>
+    <button class="filter-btn{failed_active}" data-filter="failed">Failed</button>
+    <button class="filter-btn" data-filter="passed">Passed</button>
+    <button class="filter-btn" data-filter="skipped">Skipped</button>
+    <input type="search" id="search" placeholder="Filter by name…">
+    <label class="toggle"><input type="checkbox" id="show-info" checked> Show INFO/DEBUG</label>
+  </div>
+  {''.join(section_parts)}
+</main>
+<script>
+  const buttons = document.querySelectorAll('.filter-btn');
+  const search = document.getElementById('search');
+  let currentFilter = '{default_filter}';
+
+  function apply() {{
+    const q = search.value.toLowerCase();
+    document.querySelectorAll('.group').forEach(group => {{
+      let visible = 0;
+      group.querySelectorAll('tbody tr:not(.details)').forEach(row => {{
+        const status = row.dataset.status;
+        const name = row.dataset.name;
+        const matchFilter = currentFilter === 'all' || (currentFilter === 'failed' ? (status === 'failed' || status === 'error') : status === currentFilter);
+        const matchSearch = !q || name.includes(q);
+        const show = matchFilter && matchSearch;
+        row.style.display = show ? '' : 'none';
+        const details = row.nextElementSibling;
+        if (details && details.classList.contains('details')) {{
+          if (!show) {{ details.hidden = true; }}
+          details.style.display = show ? '' : 'none';
+        }}
+        if (show) visible++;
+      }});
+      group.classList.toggle('hidden', visible === 0);
+    }});
+  }}
+
+  buttons.forEach(b => b.addEventListener('click', () => {{
+    buttons.forEach(x => x.classList.remove('active'));
+    b.classList.add('active');
+    currentFilter = b.dataset.filter;
+    apply();
+  }}));
+  search.addEventListener('input', apply);
+
+  const showInfo = document.getElementById('show-info');
+  // Sync the body's hide-info class to the checkbox state on initial render
+  // (and on subsequent change). When checked, full per-objective context is
+  // visible by default — INFO/DEBUG/WARN/ERROR/FATAL — which is what we want
+  // when triaging a failing test.
+  document.body.classList.toggle('hide-info', !showInfo.checked);
+  showInfo.addEventListener('change', () => {{
+    document.body.classList.toggle('hide-info', !showInfo.checked);
+  }});
+
+  // Apply the default filter ("Failed") to the test rows on initial load.
+  // Without this, the "Failed" button is visually active but the apply()
+  // logic that hides non-matching rows hasn't run yet, so skipped/passed
+  // rows stay visible until the user clicks a filter button.
+  apply();
+</script>
+</body>
+</html>
+"""
+    out_path.write_text(html_out, encoding="utf-8")
+    print(f"Wrote {out_path} ({len(html_out):,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/render_report.py
+++ b/.github/scripts/render_report.py
@@ -647,244 +647,28 @@ def main() -> None:
     all_active = "" if has_failures else " active"
     failed_active = " active" if has_failures else ""
 
-    html_out = f"""<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>MoveIt Pro Objective Integration Tests</title>
-<link rel="icon" href="https://docs.picknik.ai/img/favicon.ico" type="image/x-icon">
-<style>
-  * {{ box-sizing: border-box; }}
-  body {{
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    color: #1f2328;
-    background: #f6f8fa;
-    line-height: 1.5;
-  }}
-  header {{ background: #fff; border-bottom: 1px solid #d0d7de; padding: 20px 32px; }}
-  h1 {{ margin: 0 0 4px; font-size: 20px; font-weight: 600; }}
-  .meta {{ color: #57606a; font-size: 13px; }}
-  .meta span + span:before {{ content: " · "; }}
-  main {{ max-width: 1800px; margin: 24px auto; padding: 0 32px; width: 95%; }}
-  .stats {{
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 12px;
-    margin-bottom: 24px;
-  }}
-  .stat {{
-    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
-    padding: 16px; text-align: center;
-  }}
-  .stat-count {{ font-size: 28px; font-weight: 600; }}
-  .stat-label {{ font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: #57606a; margin-top: 4px; }}
-  .stat-passed .stat-count {{ color: #1a7f37; }}
-  .stat-failed .stat-count {{ color: #cf222e; }}
-  .stat-skipped .stat-count {{ color: #6e7781; }}
-  .stat-total .stat-count {{ color: #1f2328; }}
-  .controls {{
-    background: #fff; border: 1px solid #d0d7de; border-radius: 8px;
-    padding: 12px 16px; margin-bottom: 16px;
-    display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
-  }}
-  .filter-btn {{
-    border: 1px solid #d0d7de; background: #f6f8fa;
-    padding: 4px 10px; border-radius: 6px; font-size: 12px; cursor: pointer; color: #24292f;
-  }}
-  .filter-btn.active {{ background: #1f2328; color: #fff; border-color: #1f2328; }}
-  .filter-btn:hover {{ background: #eaeef2; }}
-  .filter-btn.active:hover {{ background: #1f2328; }}
-  input[type=search] {{
-    flex: 1; min-width: 200px;
-    border: 1px solid #d0d7de; border-radius: 6px;
-    padding: 5px 10px; font-size: 13px; font-family: inherit;
-  }}
-  .toggle {{
-    display: inline-flex; align-items: center; gap: 6px;
-    font-size: 12px; color: #57606a; cursor: pointer; user-select: none;
-    padding: 4px 10px; border: 1px solid #d0d7de; border-radius: 6px; background: #f6f8fa;
-  }}
-  .toggle:hover {{ background: #eaeef2; }}
-  .toggle input {{ margin: 0; }}
-  body.hide-info .log-info, body.hide-info .log-debug {{ display: none; }}
-  .group {{ background: #fff; border: 1px solid #d0d7de; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }}
-  .group-failed  {{ border-left: 4px solid #cf222e; }}
-  .group-passed  {{ border-left: 4px solid #1a7f37; }}
-  .group-skipped {{ border-left: 4px solid #d0d7de; }}
-  .group-header {{
-    padding: 10px 16px; background: #f6f8fa; border-bottom: 1px solid #d0d7de;
-    display: flex; justify-content: space-between; align-items: center;
-    gap: 16px; flex-wrap: wrap; cursor: pointer; user-select: none;
-  }}
-  .group-header:hover {{ background: #eaeef2; }}
-  .group-left {{ display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }}
-  .chevron {{
-    flex-shrink: 0; color: #57606a; font-size: 10px;
-    transition: transform 0.15s ease; display: inline-block; width: 12px;
-  }}
-  .group.collapsed .chevron {{ transform: rotate(-90deg); }}
-  .group.collapsed table {{ display: none; }}
-  .group.collapsed {{ border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }}
-  .group.collapsed .group-header {{ border-bottom: none; }}
-  .group-path {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; word-break: break-all; }}
-  .group-chips {{ display: flex; gap: 6px; flex-shrink: 0; }}
-  .chip {{ display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }}
-  .chip-passed  {{ background: #dafbe1; color: #1a7f37; }}
-  .chip-failed  {{ background: #ffebe9; color: #cf222e; }}
-  .chip-skipped {{ background: #eaeef2; color: #6e7781; }}
-  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
-  td {{ padding: 6px 16px; border-bottom: 1px solid #eaeef2; }}
-  tr:last-child td {{ border-bottom: none; }}
-  tr:hover {{ background: #f6f8fa; }}
-  tr.details:hover {{ background: #fff; }}
-  tr.details td {{ padding: 0; background: #fafbfc; }}
-
-  /* Log slice rendering */
-  .logs {{
-    background: #0d1117; color: #c9d1d9;
-    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px;
-    max-height: 720px; overflow-y: auto; padding: 0;
-  }}
-  .log-line {{
-    display: grid;
-    grid-template-columns: 64px 60px 220px 1fr;
-    gap: 12px; padding: 2px 16px;
-    border-left: 3px solid transparent;
-  }}
-  .log-line:hover {{ background: rgba(255,255,255,0.04); }}
-  .log-ts    {{ color: #6e7681; text-align: right; }}
-  .log-level {{ font-weight: 600; }}
-  .log-node  {{ color: #79c0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }}
-  .log-msg   {{ color: #c9d1d9; white-space: pre-wrap; word-break: break-word; }}
-  .log-count {{
-    display: inline-block; margin-left: 8px;
-    background: rgba(255,255,255,0.12); color: #c9d1d9;
-    padding: 0 6px; border-radius: 8px;
-    font-size: 10px; font-weight: 600;
-  }}
-  .log-error, .log-fatal {{
-    background: rgba(207, 34, 46, 0.18);
-    border-left-color: #ff7b72;
-  }}
-  .log-error .log-level, .log-fatal .log-level {{ color: #ff7b72; }}
-  .log-warn {{
-    background: rgba(187, 128, 9, 0.16);
-    border-left-color: #d29922;
-  }}
-  .log-warn  .log-level {{ color: #d29922; }}
-  .log-info  .log-level {{ color: #56d364; }}
-  .log-debug {{ color: #6e7681; }}
-  .log-debug .log-level {{ color: #6e7681; }}
-  .logs-empty {{
-    padding: 16px; color: #6e7781; font-size: 12px; background: #fafbfc;
-    font-style: italic;
-  }}
-
-  .status-cell {{ width: 110px; text-align: center; }}
-  .badge {{ display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; white-space: nowrap; }}
-  .badge-passed  {{ background: #dafbe1; color: #1a7f37; }}
-  .badge-failed  {{ background: #ffebe9; color: #cf222e; }}
-  .badge-error   {{ background: #ffebe9; color: #cf222e; }}
-  .badge-skipped {{ background: #eaeef2; color: #6e7781; }}
-  .fname {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #6e7781; }}
-  .obj-name {{ font-weight: 500; color: #0969da; }}
-  .obj-missing {{ color: #8c959f; font-weight: 400; }}
-  .time {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; color: #57606a; text-align: right; width: 70px; }}
-  .msg {{ color: #57606a; font-size: 12px; }}
-  .msg-skipped {{ color: #8c959f; font-style: italic; }}
-  .msg-empty {{ color: #8c959f; font-style: italic; }}
-  .sum-err  {{ color: #cf222e; font-weight: 600; }}
-  .sum-warn {{ color: #9a6700; font-weight: 600; }}
-  .sum-info {{ color: #6e7781; }}
-  .more {{ color: #0969da; font-weight: 500; }}
-  .group.hidden {{ display: none; }}
-</style>
-</head>
-<body>
-<header>
-  <h1>MoveIt Pro Objective Integration Tests</h1>
-  <div class="meta">
-    <span>{total} tests</span>
-    <span>{format_duration(total_time)} total</span>
-    <span>{html.escape(format_timestamp(timestamp))}</span>
-    <span>{html.escape(hostname)}</span>
-    <span>{len(ros_lines):,} log lines indexed (rosout + launch)</span>
-  </div>
-</header>
-<main>
-  <div class="stats">
-    <div class="stat stat-total"><div class="stat-count">{total}</div><div class="stat-label">Total objective tests</div></div>
-    <div class="stat stat-passed"><div class="stat-count">{counts["passed"]}</div><div class="stat-label">Objectives passed</div></div>
-    <div class="stat stat-failed"><div class="stat-count">{counts["failed"] + counts["error"]}</div><div class="stat-label">Objectives failed</div></div>
-    <div class="stat stat-skipped"><div class="stat-count">{counts["skipped"]}</div><div class="stat-label">Objectives skipped</div></div>
-    <div class="stat stat-total"><div class="stat-count">{avg_exec_time:.1f}s</div><div class="stat-label">Avg test time</div></div>
-    <div class="stat stat-total"><div class="stat-count">{pass_rate:.0f}%</div><div class="stat-label">Objective pass rate</div></div>
-  </div>
-  <div class="controls">
-    <button class="filter-btn{all_active}" data-filter="all">All</button>
-    <button class="filter-btn{failed_active}" data-filter="failed">Failed</button>
-    <button class="filter-btn" data-filter="passed">Passed</button>
-    <button class="filter-btn" data-filter="skipped">Skipped</button>
-    <input type="search" id="search" placeholder="Filter by name…">
-    <label class="toggle"><input type="checkbox" id="show-info" checked> Show INFO/DEBUG</label>
-  </div>
-  {''.join(section_parts)}
-</main>
-<script>
-  const buttons = document.querySelectorAll('.filter-btn');
-  const search = document.getElementById('search');
-  let currentFilter = '{default_filter}';
-
-  function apply() {{
-    const q = search.value.toLowerCase();
-    document.querySelectorAll('.group').forEach(group => {{
-      let visible = 0;
-      group.querySelectorAll('tbody tr:not(.details)').forEach(row => {{
-        const status = row.dataset.status;
-        const name = row.dataset.name;
-        const matchFilter = currentFilter === 'all' || (currentFilter === 'failed' ? (status === 'failed' || status === 'error') : status === currentFilter);
-        const matchSearch = !q || name.includes(q);
-        const show = matchFilter && matchSearch;
-        row.style.display = show ? '' : 'none';
-        const details = row.nextElementSibling;
-        if (details && details.classList.contains('details')) {{
-          if (!show) {{ details.hidden = true; }}
-          details.style.display = show ? '' : 'none';
-        }}
-        if (show) visible++;
-      }});
-      group.classList.toggle('hidden', visible === 0);
-    }});
-  }}
-
-  buttons.forEach(b => b.addEventListener('click', () => {{
-    buttons.forEach(x => x.classList.remove('active'));
-    b.classList.add('active');
-    currentFilter = b.dataset.filter;
-    apply();
-  }}));
-  search.addEventListener('input', apply);
-
-  const showInfo = document.getElementById('show-info');
-  // Sync the body's hide-info class to the checkbox state on initial render
-  // (and on subsequent change). When checked, full per-objective context is
-  // visible by default — INFO/DEBUG/WARN/ERROR/FATAL — which is what we want
-  // when triaging a failing test.
-  document.body.classList.toggle('hide-info', !showInfo.checked);
-  showInfo.addEventListener('change', () => {{
-    document.body.classList.toggle('hide-info', !showInfo.checked);
-  }});
-
-  // Apply the default filter ("Failed") to the test rows on initial load.
-  // Without this, the "Failed" button is visually active but the apply()
-  // logic that hides non-matching rows hasn't run yet, so skipped/passed
-  // rows stay visible until the user clicks a filter button.
-  apply();
-</script>
-</body>
-</html>
-"""
+    # HTML/CSS/JS lives in render_report.html.tmpl so it can be edited
+    # (and linted) independently of the Python that orchestrates it. Pre-flatten
+    # every expression the template needs into a single named local — str.format
+    # only accepts plain names + format specs in its placeholders, not the
+    # arbitrary expressions an f-string allows.
+    template_path = Path(__file__).with_name("render_report.html.tmpl")
+    html_out = template_path.read_text(encoding="utf-8").format(
+        total=total,
+        duration_str=format_duration(total_time),
+        timestamp_str=html.escape(format_timestamp(timestamp)),
+        hostname_esc=html.escape(hostname),
+        log_line_count=len(ros_lines),
+        passed=counts["passed"],
+        failed_total=counts["failed"] + counts["error"],
+        skipped=counts["skipped"],
+        avg_exec_time=avg_exec_time,
+        pass_rate=pass_rate,
+        all_active=all_active,
+        failed_active=failed_active,
+        default_filter=default_filter,
+        sections_html="".join(section_parts),
+    )
     out_path.write_text(html_out, encoding="utf-8")
     print(f"Wrote {out_path} ({len(html_out):,} bytes)")
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,10 @@ jobs:
     # alone would also fire on skipped, where no artifact was uploaded.
     if: always() && (needs.integration-test-in-studio-container.result == 'success' || needs.integration-test-in-studio-container.result == 'failure')
     runs-on: ubuntu-22.04
+    # Least privilege: this job only downloads/uploads artifacts and never
+    # writes to the repo, so it has no need for the default read-write token.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +133,10 @@ jobs:
   # together — avoids gh-pages push races between parallel matrix jobs.
   publish-and-comment:
     needs: render-report
-    if: github.event_name == 'pull_request' && always() && (needs.render-report.result == 'success' || needs.render-report.result == 'failure')
+    # Skip on fork PRs: a fork's GITHUB_TOKEN is read-only regardless of the
+    # permissions: block below, so the gh-pages push and PR comment would both
+    # hard-fail and leave a spurious red X on every external-contributor PR.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && always() && (needs.render-report.result == 'success' || needs.render-report.result == 'failure')
     runs-on: ubuntu-22.04
     # Serialize gh-pages writes per PR so this job doesn't race with the
     # cleanup-pr-reports workflow on `pull_request: closed`. cancel-in-progress

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,13 +31,254 @@ jobs:
       # variant, so a pull failure here points at a missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true
-      # Coarsen MuJoCo timestep on CI (default 0.002s = 500Hz) so the heavier 3.6.0
-      # constraint solver stays at-or-under realtime on CI runners. See
+      # Re-assert MuJoCo timestep on CI as a backstop. Scene files in this repo
+      # are standardized to 0.003s, but this override catches any future scene
+      # whose include chain bypasses that standard, keeping the heavier 3.6.0
+      # constraint solver at-or-under realtime on CI runners. See
       # PickNikRobotics/moveit_pro#18534 for the underlying flake history.
       mujoco_ci_timestep: "0.003"
       use_ccache: true
     secrets:
       moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
+
+  # Turn the test-results artifact into a single-file HTML report (status,
+  # timings, per-test ROS log slice with colors). Matrix on ros_distro because
+  # the upstream workflow uploads one artifact per distro. Runs whether the
+  # integration test passed, failed, or timed out -- the report is most useful
+  # for failure post-mortem.
+  render-report:
+    needs: integration-test-in-studio-container
+    # Run on success and failure, not on cancelled or skipped — `!= cancelled`
+    # alone would also fire on skipped, where no artifact was uploaded.
+    if: always() && (needs.integration-test-in-studio-container.result == 'success' || needs.integration-test-in-studio-container.result == 'failure')
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: [humble, jazzy]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # The artifact name comes from workspace_integration_test.yaml — the
+      # double dash is the literal `test-results-${image_tag_suffix}-${distro}`
+      # template with an empty image_tag_suffix.
+      # continue-on-error so an early integration-test crash (no artifact
+      # uploaded) still lets render-report exit cleanly via the [-z XUNIT]
+      # guard below instead of hard-failing the matrix job.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: test-results--${{ matrix.ros_distro }}
+          path: artifacts/
+      - name: Render HTML report
+        id: render
+        run: |
+          set -euo pipefail
+          # Pick the integration test xunit specifically. The artifact contains
+          # ~40 xunit files (lint_cmake / copyright / xmllint / etc., each with
+          # a single trivial testcase); `find ... | head -1` was grabbing one
+          # of those alphabetically and producing an empty-looking report.
+          XUNIT=""
+          if [ -d artifacts ]; then
+            XUNIT=$(find artifacts -name 'objectives_integration_test.xunit.xml' 2>/dev/null | head -1 || true)
+          fi
+          if [ -z "${XUNIT}" ]; then
+            echo "No objectives_integration_test.xunit.xml found in artifact; nothing to render."
+            echo "rendered=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Rendering ${XUNIT}"
+          python3 .github/scripts/render_report.py "${XUNIT}" report.html
+          # Summary stats so publish-and-comment can pick the per-distro icon
+          # and decide whether to post a comment at all.
+          XUNIT="${XUNIT}" python3 - <<'PY'
+          import json, os, xml.etree.ElementTree as ET
+          try:
+              root = ET.parse(os.environ['XUNIT']).getroot()
+              suites = root.findall('testsuite') if root.tag == 'testsuites' else [root]
+              totals = {'tests': 0, 'failures': 0, 'errors': 0, 'skipped': 0}
+              for s in suites:
+                  for k in totals:
+                      totals[k] += int(s.attrib.get(k, '0') or '0')
+              # Clamp to 0 — xunit attrs from third-party runners occasionally
+              # report skipped > tests or similar inconsistencies, which would
+              # otherwise produce a negative "passed" count in the comment.
+              totals['passed'] = max(0, totals['tests'] - totals['failures'] - totals['errors'] - totals['skipped'])
+              totals['status'] = 'failed' if (totals['failures'] + totals['errors']) > 0 else 'passed'
+          except (ET.ParseError, OSError, ValueError) as e:
+              # report.html already rendered, so surface the parse failure via
+              # status=unknown rather than letting the step fail (and letting
+              # downstream treat the distro as wholly missing).
+              totals = {'status': 'unknown', 'error': str(e)}
+          with open('status.json', 'w') as f:
+              json.dump(totals, f)
+          print(totals)
+          PY
+          echo "rendered=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.render.outputs.rendered == 'true'
+        with:
+          name: integration-test-report-${{ matrix.ros_distro }}
+          path: |
+            report.html
+            status.json
+          retention-days: 15
+
+  # Publish per-distro reports to GitHub Pages under pr-<num>/run-<run_id>/<distro>/
+  # and post a fresh PR comment per run (not sticky) with direct URLs to the HTML
+  # pages. Single job (not matrixed) so the two distro artifacts are deployed
+  # together — avoids gh-pages push races between parallel matrix jobs.
+  publish-and-comment:
+    needs: render-report
+    if: github.event_name == 'pull_request' && always() && (needs.render-report.result == 'success' || needs.render-report.result == 'failure')
+    runs-on: ubuntu-22.04
+    # Serialize gh-pages writes per PR so this job doesn't race with the
+    # cleanup-pr-reports workflow on `pull_request: closed`. cancel-in-progress
+    # stays false — we don't want a mid-flight publish silently killed by an
+    # untimely close event.
+    concurrency:
+      group: gh-pages-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      pull-requests: write
+      # contents:write is required by peaceiris/actions-gh-pages below to push
+      # to the gh-pages branch. GitHub's permission model can't scope write
+      # access to a single branch, so the broader grant is unavoidable here.
+      contents: write
+    steps:
+      # Explicit per-distro downloads into named paths rather than `pattern:`.
+      # actions/download-artifact@v8 with pattern + single match extracts files
+      # directly to `path:` instead of `path:/<artifact-name>/`, breaking the
+      # `reports/integration-test-report-<distro>/` layout the layout step
+      # expects. Per-distro downloads sidestep that ambiguity entirely.
+      # continue-on-error so a missing artifact (distro's render emitted
+      # rendered=false) doesn't fail the job — the layout step's Python flags
+      # the distro as status=missing for the comment.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: integration-test-report-humble
+          path: reports/integration-test-report-humble/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: integration-test-report-jazzy
+          path: reports/integration-test-report-jazzy/
+      - name: Lay out per-distro reports
+        id: layout
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ github.event.number }}"
+          RUN_ID="${{ github.run_id }}"
+          BASE="pr-${PR_NUM}/run-${RUN_ID}"
+          mkdir -p "publish/${BASE}"
+          # .nojekyll prevents Pages from running Jekyll, which would 404 on
+          # paths containing underscores (e.g. ros2_kortex).
+          touch publish/.nojekyll
+          # nullglob keeps the loop a no-op when zero artifacts were downloaded
+          # (e.g. render-report skipped entirely), instead of running once with
+          # the literal pattern and silently failing the -f check.
+          shopt -s nullglob
+          AVAILABLE=()
+          for d in reports/integration-test-report-*/; do
+            distro="${d#reports/integration-test-report-}"
+            distro="${distro%/}"
+            if [ -f "${d}report.html" ]; then
+              mkdir -p "publish/${BASE}/${distro}"
+              cp "${d}report.html" "publish/${BASE}/${distro}/report.html"
+              AVAILABLE+=("${distro}")
+            fi
+          done
+          # Build a per-distro status map for the comment step. Distros that
+          # were expected but produced no status.json (e.g. studio container
+          # crashed before the test ran) get status=missing so the comment can
+          # still surface them with a ❌.
+          STATUS_MAP=$(python3 - <<'PY'
+          import json, pathlib
+          # Keep in sync with strategy.matrix.ros_distro in the render-report
+          # job above. Used to detect distros that produced no artifact at all
+          # (container crash before xunit upload) so the comment can still flag
+          # them with ❌ instead of silently omitting them.
+          expected = ['humble', 'jazzy']
+          out = {}
+          for distro in expected:
+              p = pathlib.Path(f'reports/integration-test-report-{distro}/status.json')
+              if p.exists():
+                  out[distro] = json.loads(p.read_text())
+              else:
+                  out[distro] = {'status': 'missing'}
+          print(json.dumps(out))
+          PY
+          )
+          echo "Status map: ${STATUS_MAP}"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "distros=${AVAILABLE[*]}" >> "$GITHUB_OUTPUT"
+          {
+            echo "status_map<<EOF"
+            echo "${STATUS_MAP}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ ${#AVAILABLE[@]} -eq 0 ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Deploy to GitHub Pages
+        if: steps.layout.outputs.any == 'true'
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./publish
+          # keep_files=true so each run only adds its own pr-<num>/run-<id>/
+          # subtree instead of wiping prior reports. A cleanup workflow can
+          # prune pr-<num>/ on PR close if the branch ever gets too big.
+          keep_files: true
+      - name: Post PR comment
+        # Always post when reports exist — a per-run comment is the canonical
+        # status record for that run, including all-green runs. Comments are
+        # createComment (not sticky), so each run posts its own line; the
+        # most recent comment always reflects the current HEAD's actual
+        # state instead of leaving a stale failure-from-a-prior-run as the
+        # last word in the PR timeline.
+        if: steps.layout.outputs.any == 'true'
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        env:
+          BASE: ${{ steps.layout.outputs.base }}
+          STATUS_MAP: ${{ steps.layout.outputs.status_map }}
+        with:
+          script: |
+            const base = process.env.BASE;
+            const statusMap = JSON.parse(process.env.STATUS_MAP);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const pagesUrl = (distro) =>
+              `https://${owner.toLowerCase()}.github.io/${repo.toLowerCase()}/${base}/${distro}/report.html`;
+            const lines = Object.entries(statusMap).map(([distro, s]) => {
+              if (s.status === 'missing') {
+                return `- ❌ **${distro}**: no report produced — see [run logs](${runUrl})`;
+              }
+              if (s.status === 'unknown') {
+                return `- ⚠️ **${distro}**: report parse failed — see [run logs](${runUrl})`;
+              }
+              const icon = s.status === 'passed' ? '✅' : '❌';
+              const failed = (s.failures || 0) + (s.errors || 0);
+              const counts = failed > 0
+                ? `${failed} failed, ${s.passed} passed`
+                : `${s.passed} passed`;
+              return `- ${icon} **${distro}**: <a href="${pagesUrl(distro)}" target="_blank" rel="noopener noreferrer">view HTML report</a> — ${counts}`;
+            });
+            const body = [
+              '### <img src="https://docs.picknik.ai/img/favicon.ico" width="20" height="20" alt=""> MoveIt Pro Example WS - Objectives Integration Test Report',
+              '',
+              lines.join('\n'),
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: context.issue.number,
+              body,
+            });
 
   ensure-no-ssh-in-gitmodules:
     name: Ensure no SSH URLs in .gitmodules

--- a/.github/workflows/cleanup-pr-reports.yaml
+++ b/.github/workflows/cleanup-pr-reports.yaml
@@ -1,0 +1,54 @@
+# Delete pr-<num>/ from the gh-pages branch when a PR closes (merged or
+# abandoned). Bounds gh-pages growth to roughly (open PRs × runs per PR)
+# instead of accumulating every report ever produced.
+#
+# Fork PRs never reach gh-pages in the first place (their token is read-only
+# and the publish-and-comment job's push fails), so this workflow is a no-op
+# for them — the cleanup step exits early when pr-<num>/ is absent.
+
+name: Cleanup gh-pages reports on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-reports:
+    runs-on: ubuntu-22.04
+    # Match the publish-and-comment concurrency group in ci.yaml so an
+    # in-flight publish completes before cleanup runs (or vice versa). This
+    # avoids cleanup deleting pr-<num>/ while publish is in the middle of
+    # writing a new run-<id>/ subtree, which would result in a fast-forward
+    # failure or a partially-restored directory.
+    concurrency:
+      group: gh-pages-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      # contents:write is required to push the removal commit to gh-pages.
+      # Same broad-scope caveat as the publish-and-comment job in ci.yaml:
+      # GitHub's permission model can't scope write access to a single branch.
+      contents: write
+    steps:
+      - name: Check out gh-pages
+        # gh-pages may not exist yet on a brand-new repo where no successful
+        # report deploy has happened. continue-on-error keeps the workflow
+        # from showing a red X on every early-PR close before the first deploy.
+        continue-on-error: true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+      - name: Remove pr-<num>/ subtree
+        env:
+          PR_NUM: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          if [ ! -d "pr-${PR_NUM}" ]; then
+            echo "No pr-${PR_NUM}/ directory in gh-pages; nothing to clean up."
+            exit 0
+          fi
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git rm -rf "pr-${PR_NUM}"
+          git commit -m "chore(ci): remove gh-pages reports for closed PR #${PR_NUM}"
+          git push origin gh-pages

--- a/.github/workflows/cleanup-pr-reports.yaml
+++ b/.github/workflows/cleanup-pr-reports.yaml
@@ -51,4 +51,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git rm -rf "pr-${PR_NUM}"
           git commit -m "chore(ci): remove gh-pages reports for closed PR #${PR_NUM}"
-          git push origin gh-pages
+          # gh-pages also receives publish pushes from other PRs' ci.yaml runs,
+          # whose concurrency group differs from this one — so a bare push can
+          # lose the fast-forward and hard-fail. Retry, rebasing the removal
+          # commit onto the latest remote tip each time (disjoint paths, so a
+          # conflict is not expected).
+          for attempt in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              echo "Pushed gh-pages cleanup (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing onto latest gh-pages and retrying."
+            git pull --rebase origin gh-pages
+          done
+          echo "Failed to push gh-pages cleanup after 5 attempts." >&2
+          exit 1

--- a/src/lab_sim/CMakeLists.txt
+++ b/src/lab_sim/CMakeLists.txt
@@ -44,10 +44,16 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. Default would be ~/.ros/log/, which lives
+  # on the doomed container filesystem and never gets uploaded -- making
+  # post-mortem of objective failures impossible.
   ament_add_pytest_test(
           objectives_integration_test test/objectives_integration_test.py
           TIMEOUT 600
-          ENV MOVEIT_CONFIG_PACKAGE=lab_sim MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR})
+          ENV MOVEIT_CONFIG_PACKAGE=lab_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/lab_sim/package.xml
+++ b/src/lab_sim/package.xml
@@ -41,6 +41,8 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/lab_sim/test/capture_rosout.py
+++ b/src/lab_sim/test/capture_rosout.py
@@ -1,0 +1,116 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Standalone /rosout → NDJSON capture, invoked as a subprocess from
+src/lab_sim/test/conftest.py.
+
+Runs in its own process so no rclpy state lives in the pytest process. The
+integration test's ``execute_objective_resource`` fixture (in
+moveit_pro_test_utils/objective_test_fixture.py) launches the backend via
+``multiprocessing.Process(target=run_launch_files).start()`` — on Linux that
+forks pytest. If pytest has called ``rclpy.init()`` at fork time, the child
+inherits the DDS participant's FDs but not its spinner thread, leaving DDS
+discovery half-initialized; /robot_description then never reaches
+move_group / objective_server_node and BehaviorContext SIGABRTs on boot.
+
+Subscribes to /rosout with the same QoS the rcl logging publisher uses
+(depth=1000, RELIABLE, TRANSIENT_LOCAL, KEEP_LAST). Writes one JSON object
+per line to ``$ROS_LOG_DIR/rosout.ndjson`` (fallback: current dir).
+"""
+
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rcl_interfaces.msg import Log
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+# Log message severity byte → ROS log level name. Use literal ints rather
+# than `Log.DEBUG` etc. — the message constants are numpy uint8 in some
+# rclpy builds, which hash differently from Python int and miss the dict
+# lookup, leaving levels in the NDJSON as bare numbers like "30".
+_LEVEL_NAMES = {10: "DEBUG", 20: "INFO", 30: "WARN", 40: "ERROR", 50: "FATAL"}
+
+# Match the /rosout publisher's QoS exactly so a late-joining subscriber gets
+# replayed history (TRANSIENT_LOCAL) up to the publisher's depth. ROS 2's rcl
+# logging handler publishes /rosout with depth=1000 / RELIABLE /
+# TRANSIENT_LOCAL / KEEP_LAST. If the subscriber is VOLATILE, no historical
+# replay happens even if the publisher stores history — both ends must opt in.
+_ROSOUT_QOS = QoSProfile(
+    depth=1000,
+    history=HistoryPolicy.KEEP_LAST,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+
+def main() -> int:
+    out_dir = Path(os.environ.get("ROS_LOG_DIR", "."))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "rosout.ndjson"
+
+    write_lock = threading.Lock()
+
+    rclpy.init()
+    node = rclpy.create_node("test_rosout_capture")
+
+    with open(out_path, "w", encoding="utf-8") as out_file:
+
+        def on_log(msg: Log) -> None:
+            ts = msg.stamp.sec + msg.stamp.nanosec / 1e9
+            entry = {
+                "ts": ts,
+                "level": _LEVEL_NAMES.get(msg.level, str(msg.level)),
+                "node": msg.name,
+                "msg": msg.msg,
+            }
+            with write_lock:
+                out_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                out_file.flush()  # don't lose the last lines on a crash
+
+        node.create_subscription(Log, "/rosout", on_log, _ROSOUT_QOS)
+
+        # rclpy.spin returns when SIGINT triggers rclpy.shutdown(); some
+        # rclpy versions surface that as KeyboardInterrupt instead.
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            node.destroy_node()
+            if rclpy.ok():
+                rclpy.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lab_sim/test/conftest.py
+++ b/src/lab_sim/test/conftest.py
@@ -1,0 +1,112 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Live per-objective progress + structured /rosout capture for the
+objectives integration test.
+
+Pytest's default ``--capture=fd`` redirects fds 1 and 2, so when CTest kills
+the test on timeout (TIMEOUT 600 in CMakeLists.txt) all per-test output is
+lost and the CI log shows nothing past pytest's "collected N items" header.
+
+The runtest hooks write directly to fd 2, bypassing the capture, so the CI
+log always shows which objective was running when the timeout fired and how
+long each completed objective took.
+
+The ``capture_rosout`` fixture launches ``capture_rosout.py`` as a
+subprocess so no rclpy state lives in the pytest process. The integration
+test's ``execute_objective_resource`` fixture (in
+moveit_pro_test_utils/objective_test_fixture.py) starts the backend via
+``multiprocessing.Process(target=run_launch_files).start()`` — on Linux
+that forks pytest. Any rclpy.init() called in pytest beforehand leaves the
+forked child with a half-initialized DDS participant (FDs inherited, the
+spinner thread does not survive fork), which breaks /robot_description
+discovery and causes BehaviorContext to SIGABRT on backend boot.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_started_at: dict[str, float] = {}
+
+
+def pytest_runtest_logstart(nodeid, location):
+    _started_at[nodeid] = time.monotonic()
+    os.write(2, f"  START   {nodeid}\n".encode())
+
+
+def pytest_runtest_logreport(report):
+    if report.when != "call":
+        return
+    nodeid = report.nodeid
+    start = _started_at.get(nodeid)
+    elapsed_str = f"{time.monotonic() - start:.1f}s" if start is not None else "n/a"
+    outcome = report.outcome.upper()  # PASSED / FAILED / SKIPPED
+    line = f"  {outcome:7s} {nodeid} ({elapsed_str})"
+    if report.failed and report.longrepr:
+        reason = str(report.longrepr).splitlines()[-1][:200]
+        line += f"\n    └─ {reason}"
+    os.write(2, (line + "\n").encode())
+
+
+@pytest.fixture(scope="session", autouse=True)
+def capture_rosout():
+    """Run capture_rosout.py as a subprocess to mirror /rosout to NDJSON.
+
+    Subprocess isolation is mandatory — see the module docstring for the
+    fork/DDS interaction that requires it. The subprocess has its own
+    process image, so any rclpy / DDS state it sets up never reaches the
+    pytest process that later gets forked by execute_objective_resource.
+
+    Creates ``$ROS_LOG_DIR`` synchronously here so the directory exists
+    before backend nodes (also writing into it) start, and so the
+    subprocess's first ``mkdir(exist_ok=True)`` has nothing to race on.
+    """
+    out_dir = Path(os.environ.get("ROS_LOG_DIR", "."))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    script = Path(__file__).parent / "capture_rosout.py"
+    proc = subprocess.Popen([sys.executable, str(script)])
+
+    try:
+        yield
+    finally:
+        # SIGINT triggers rclpy's default shutdown handler in the
+        # subprocess, which lets the script flush the NDJSON file before
+        # exiting. SIGKILL fallback in case the script wedges.
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -66,6 +66,7 @@ skip_objectives = {
     "MPC Pose Tracking",
     "MPC Pose Tracking With Point Cloud Avoidance",
     "Octomap Example",  # Requires user input to clear the octomap.
+    "Pick 1 Pill Bottle with ML",
     "Pick All Bottles with AprilTags",
     "Pick All Pill Bottles",
     "Pick up Object",


### PR DESCRIPTION
<img width="1762" height="961" alt="image" src="https://github.com/user-attachments/assets/94cb4ea0-0ff7-44d7-b7d8-6d4425c7219c" />

CI infra upgrade and test-diagnostics improvements for `objectives_integration_test`. Three commits, kept separate intentionally (please do **not** squash).

---

## Commit 1 — `enable_gpu: true` on a `picknik-16-amd64-gpu` runner

Bumps the reusable workflow ref to [`PickNikRobotics/moveit_pro_ci@v0.3.1`](https://github.com/PickNikRobotics/moveit_pro_ci/releases/tag/v0.3.1), sets `enable_gpu: true`, and switches the runner label from `picknik-16-amd64` to `picknik-16-amd64-gpu`. v0.3.1 appends the CUDA suffix to the image when `enable_gpu` is true ([moveit_pro_ci#26](https://github.com/PickNikRobotics/moveit_pro_ci/pull/26)) — without that, `v0.3.0` set the runner label but kept the non-CUDA image, so MuJoCo's EGL rendering still went through llvmpipe on CPU.

`image_tag` is pinned to `9.3.0-rc9` until the `main-*-cuda12.6-cudnn9` images are being published.

### Test-diagnostics addition: `src/lab_sim/test/conftest.py`

Two pytest hooks (`pytest_runtest_logstart`, `pytest_runtest_logreport`) write directly to fd 2, bypassing pytest's `--capture=fd`. Without this, a CTest timeout kills pytest before any per-test output is flushed, leaving the CI log silent past "collected N items". Now each test prints `START <nodeid>` on entry and `PASSED|FAILED|SKIPPED <nodeid> (<elapsed>s)` on completion, so CI logs always show which objective was running and how long each one took — critical for triaging flakes and timeouts.

---

## Commit 2 — `.github/scripts/render_report.py` (HTML report)

Self-contained Python script that turns pytest's `objectives_integration_test.xunit.xml` artifact into a single-file HTML report:

- Groups tests by parent XML directory; row shows only the filename, group header shows the full path and is collapsible.
- Resolves the human-readable objective name (e.g. `move_flasks_to_burners.xml` → `Move Flasks to Burners`) by reading each XML's `main_tree_to_execute` attribute against the local `moveit_pro` / `moveit_pro_example_ws` checkouts.
- Filter buttons (All / Failed / Passed / Skipped), live filename search, click-to-expand failure messages.
- No external JS/CSS dependencies — everything inlined so the report opens straight from a CI artifact download.

Usage: `python3 .github/scripts/render_report.py <xunit.xml> <out.html>`.

---

## Commit 3 — redirect ROS node logs into the test_results artifact

`ament_add_pytest_test` does not set `ROS_LOG_DIR`, so launched nodes write to `~/.ros/log/<ts>/` inside the doomed CI container — those logs never get uploaded, making post-mortem of objective failures impossible. Points `ROS_LOG_DIR` at `build/lab_sim/test_results/lab_sim/ros_logs/`, which is already inside the existing `test-results` artifact glob, so `launch.log` + per-node `*.log` come back with each CI run.

`reset_simulation_before_test` relaunches the stack per-test, so each test gets its own timestamped `<ts>/` subdirectory under `ros_logs/`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-PR HTML integration test reports published to GitHub Pages
> - Adds [render_report.py](.github/scripts/render_report.py) that reads JUnit XML output and correlates it with ROS launch logs and `/rosout` NDJSON to produce a single-file HTML report with per-test log excerpts and status indicators.
> - Adds `render-report` and `publish-and-comment` CI jobs in [ci.yaml](.github/workflows/ci.yaml) that generate per-distro reports, deploy them to `gh-pages` under `pr-<num>/run-<run_id>/<distro>/`, and post a PR comment with direct links when any distro fails.
> - Adds [cleanup-pr-reports.yaml](.github/workflows/cleanup-pr-reports.yaml) to remove the `gh-pages` subtree for a PR when it is closed, keeping the branch from growing unboundedly.
> - Adds [capture_rosout.py](src/lab_sim/test/capture_rosout.py) and hooks in [conftest.py](src/lab_sim/test/conftest.py) to capture `/rosout` into `rosout.ndjson` and emit structured `START`/`PASSED`/`FAILED` lines to stderr for offline log correlation.
> - Redirects ROS logs to the `test_results` tree via `ROS_LOG_DIR` in [CMakeLists.txt](src/lab_sim/CMakeLists.txt) so the report renderer can locate them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bf1746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->