### PR TITLE
Fix: Backport PublishVelocityForceCommand unstamped twist/wrench XML to v9.3

### DIFF
--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -210,15 +210,31 @@
             hand_frame_name="grasp_link"
             force_threshold="100"
           />
-          <Action
-            ID="PublishVelocityForceCommand"
-            force_controlled_axes="0;0;0;0;0;0"
-            wrench_gain="0.01"
-            velocity_controlled_axes="0;0;1;0;0;0"
-            publish_rate="50"
-            twist_stamped="{desired_twist}"
-            wrench_stamped="{desired_wrench}"
-          />
+          <Control ID="Sequence" name="Sequence">
+            <Action
+              ID="UnpackTwistStampedMessage"
+              name="UnpackTwistStampedMessage"
+              twist="{twist}"
+              header="{header}"
+              twist_stamped="{desired_twist}"
+            />
+            <Action
+              ID="UnpackWrenchStampedMessage"
+              name="UnpackWrenchStampedMessage"
+              wrench="{wrench}"
+              header="{header}"
+              wrench_stamped="{desired_wrench}"
+            />
+            <Action
+              ID="PublishVelocityForceCommand"
+              force_controlled_axes="0;0;0;0;0;0"
+              wrench_gain="0.01"
+              velocity_controlled_axes="0;0;1;0;0;0"
+              publish_rate="50"
+              twist="{twist}"
+              wrench="{wrench}"
+            />
+          </Control>
         </Control>
         <SubTree
           ID="Force Relaxation"

--- a/src/lab_sim/objectives/force_relaxation.xml
+++ b/src/lab_sim/objectives/force_relaxation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Force Relaxation">
-  <!--//////////-->
   <BehaviorTree
     ID="Force Relaxation"
     _description="Relaxes the force sensed at the force/torque sensor by moving the robot tip in the direction of the sensed force."
@@ -11,10 +10,28 @@
         ID="CreateTwistStamped"
         reference_frame="{tip_link}"
         twist_stamped="{zero_twist}"
+        angular_velocity_xyz="0.000000;0.000000;0.000000"
+        linear_velocity_xyz="0.000000;0.000000;0.000000"
+      />
+      <Action
+        ID="UnpackTwistStampedMessage"
+        name="UnpackTwistStampedMessage"
+        twist="{twist}"
+        header="{header}"
+        twist_stamped="{zero_twist}"
       />
       <Action
         ID="CreateWrenchStamped"
         reference_frame="{tip_link}"
+        wrench_stamped="{zero_wrench}"
+        torque_xyz="0.000000;0.000000;0.000000"
+        force_xyz="0.000000;0.000000;0.000000"
+      />
+      <Action
+        ID="UnpackWrenchStampedMessage"
+        name="UnpackWrenchStampedMessage"
+        wrench="{wrench}"
+        header="{header}"
         wrench_stamped="{zero_wrench}"
       />
       <Decorator ID="ForceSuccess">
@@ -24,10 +41,10 @@
             wrench_gain="{wrench_gain}"
             force_controlled_axes="1;1;1;0;0;0"
             publish_rate="50"
-            twist_stamped="{zero_twist}"
-            wrench_stamped="{zero_wrench}"
             velocity_controlled_axes="0;0;0;0;0;0"
             velocity_force_controller_command_topic="/velocity_force_controller/command"
+            wrench="{wrench}"
+            twist="{twist}"
           />
         </Decorator>
       </Decorator>
@@ -39,9 +56,9 @@
             force_controlled_axes="0;0;0;0;0;0"
             publish_rate="50"
             velocity_controlled_axes="1;1;1;0;0;0"
-            wrench_stamped="{zero_wrench}"
-            twist_stamped="{zero_twist}"
             velocity_force_controller_command_topic="/velocity_force_controller/command"
+            wrench="{wrench}"
+            twist="{twist}"
           />
         </Decorator>
       </Decorator>
@@ -50,8 +67,8 @@
   <TreeNodesModel>
     <SubTree ID="Force Relaxation">
       <MetadataFields>
-        <Metadata subcategory="Motion - Controls" />
         <Metadata runnable="false" />
+        <Metadata subcategory="Motion - Controls" />
       </MetadataFields>
       <input_port name="relaxation_time_ms" default="500" />
       <input_port name="tip_link" default="grasp_link" />

--- a/src/lab_sim/objectives/move_with_velocity_and_force.xml
+++ b/src/lab_sim/objectives/move_with_velocity_and_force.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Push Button">
-  <!--//////////-->
   <BehaviorTree
     ID="Push Button"
     _description="An example for how to use the VFC to move with a velocity / force reference until it collides"
@@ -13,14 +12,33 @@
         _collapsed="true"
         waypoint_name="VFC Start"
         joint_group_name="manipulator"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        execution_pipeline="jtac"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.01"
+        seed="0"
+        velocity_scale_factor="1.0"
       />
       <Action
         ID="SwitchController"
         activate_controllers="velocity_force_controller"
+        controller_switch_action_name="/controller_manager/switch_controller"
+        timeout="-1.000000"
+        activate_asap="true"
+        strictness="1"
+        controller_list_action_name="/controller_manager/list_controllers"
+        automatic_deactivation="true"
+        automatic_activation="true"
+        deactivate_controllers=""
       />
       <Action
         ID="CallTriggerService"
         service_name="/velocity_force_controller/zero_fts"
+        response_timeout="3.000000"
+        wait_for_server_available_timeout="3.000000"
       />
       <Action
         ID="CreateWrenchStamped"
@@ -40,11 +58,14 @@
         ID="CreatePoseStamped"
         reference_frame="grasp_link"
         pose_stamped="{initial_pose}"
+        orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
+        position_xyz="0.000000;0.000000;0.000000"
       />
       <Action
         ID="TransformPoseFrame"
         output_pose="{initial_pose}"
         input_pose="{initial_pose}"
+        target_frame_id="world"
       />
       <Control ID="Parallel" failure_count="1" success_count="1">
         <Action
@@ -53,34 +74,65 @@
           wrench_frame_name="tool0"
           hand_frame_name="grasp_link"
           force_threshold="20"
+          wrench_topic_name="/force_torque_sensor_broadcaster/wrench"
         />
-        <Action
-          ID="PublishVelocityForceCommand"
-          force_controlled_axes="0;0;0;0;0;0"
-          wrench_gain="0.01"
-          velocity_controlled_axes="0;0;1;0;0;0"
-          publish_rate="50"
-        />
+        <Control ID="Sequence" name="Sequence">
+          <Action
+            ID="UnpackTwistStampedMessage"
+            name="UnpackTwistStampedMessage"
+            twist="{twist}"
+            header="{header}"
+            twist_stamped="{desired_twist}"
+          />
+          <Action
+            ID="UnpackWrenchStampedMessage"
+            name="UnpackWrenchStampedMessage"
+            wrench="{wrench}"
+            header="{header}"
+            wrench_stamped="{desired_wrench}"
+          />
+          <Action
+            ID="PublishVelocityForceCommand"
+            force_controlled_axes="0;0;0;0;0;0"
+            wrench_gain="0.01"
+            velocity_controlled_axes="0;0;1;0;0;0"
+            publish_rate="50"
+            wrench="{wrench}"
+            twist="{twist}"
+            velocity_force_controller_command_topic="/velocity_force_controller/command"
+          />
+        </Control>
       </Control>
-      <!--Relax the arm for 500ms to just stay in contact without applying force.-->
       <SubTree
         ID="Force Relaxation"
+        name="Force Relaxation"
         _collapsed="true"
-        wrench_gain="0.01"
         relaxation_time_ms="500"
         tip_link="grasp_link"
+        wrench_gain="0.01"
       />
+      <!--Relax the arm for 500ms to just stay in contact without applying force.-->
       <SubTree
         ID="Move to Waypoint"
         _collapsed="true"
         joint_group_name="manipulator"
         waypoint_name="Look at Table"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        execution_pipeline="jtac"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.01"
+        seed="0"
+        velocity_scale_factor="1.0"
       />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Push Button">
       <MetadataFields>
+        <Metadata runnable="true" />
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
     </SubTree>

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -316,16 +316,32 @@
                     force_threshold="30"
                     wrench_topic_name="/force_torque_sensor_broadcaster/wrench"
                   />
-                  <Action
-                    ID="PublishVelocityForceCommand"
-                    force_controlled_axes="0;0;0;0;0;0"
-                    wrench_gain="0.01"
-                    velocity_controlled_axes="0;0;1;0;0;0"
-                    publish_rate="50"
-                    twist_stamped="{desired_twist}"
-                    wrench_stamped="{desired_wrench}"
-                    velocity_force_controller_command_topic="/velocity_force_controller/command"
-                  />
+                  <Control ID="Sequence" name="Sequence">
+                    <Action
+                      ID="UnpackTwistStampedMessage"
+                      name="UnpackTwistStampedMessage"
+                      twist="{twist}"
+                      header="{header}"
+                      twist_stamped="{desired_twist}"
+                    />
+                    <Action
+                      ID="UnpackWrenchStampedMessage"
+                      name="UnpackWrenchStampedMessage"
+                      wrench="{wrench}"
+                      header="{header}"
+                      wrench_stamped="{desired_wrench}"
+                    />
+                    <Action
+                      ID="PublishVelocityForceCommand"
+                      force_controlled_axes="0;0;0;0;0;0"
+                      wrench_gain="0.01"
+                      velocity_controlled_axes="0;0;1;0;0;0"
+                      publish_rate="50"
+                      twist="{twist}"
+                      wrench="{wrench}"
+                      velocity_force_controller_command_topic="/velocity_force_controller/command"
+                    />
+                  </Control>
                 </Control>
                 <SubTree
                   ID="Force Relaxation"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
@@ -268,22 +268,36 @@
         reference_frame="world"
       />
       <Action
+        ID="UnpackTwistStampedMessage"
+        name="UnpackTwistStampedMessage"
+        twist="{twist}"
+        header="{header}"
+        twist_stamped="{desired_twist}"
+      />
+      <Action
         ID="CreateWrenchStamped"
         torque_xyz="0.0;0.0;0.0"
         force_xyz="0.0;0.0;0.0"
         wrench_stamped="{desired_wrench}"
         reference_frame="world"
       />
+      <Action
+        ID="UnpackWrenchStampedMessage"
+        name="UnpackWrenchStampedMessage"
+        wrench="{wrench}"
+        header="{header}"
+        wrench_stamped="{desired_wrench}"
+      />
       <Control ID="Parallel" success_count="1" failure_count="1">
         <Action
           ID="PublishVelocityForceCommand"
           force_controlled_axes="1;1;1;1;1;1"
           publish_rate="10"
-          twist_stamped="{desired_twist}"
+          twist="{twist}"
           velocity_controlled_axes="0;0;0;0;0;0"
           velocity_force_controller_command_topic="/velocity_force_controller/command"
           wrench_gain="0.0"
-          wrench_stamped="{desired_wrench}"
+          wrench="{wrench}"
         />
         <SubTree ID="Close Gripper" _collapsed="true" />
       </Control>

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/velocity_force_controller_zero.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/velocity_force_controller_zero.xml
@@ -14,6 +14,13 @@
         reference_frame="world"
       />
       <Action
+        ID="UnpackTwistStampedMessage"
+        name="UnpackTwistStampedMessage"
+        twist="{twist}"
+        header="{header}"
+        twist_stamped="{desired_twist}"
+      />
+      <Action
         ID="SwitchController"
         activate_controllers="velocity_force_controller"
         controller_switch_action_name="/controller_manager/switch_controller"
@@ -39,14 +46,21 @@
         wait_for_server_available_timeout="3.000000"
         service_name="/velocity_force_controller/zero_fts"
       />
+      <Action
+        ID="UnpackWrenchStampedMessage"
+        name="UnpackWrenchStampedMessage"
+        wrench="{wrench}"
+        header="{header}"
+        wrench_stamped="{desired_wrench}"
+      />
       <Decorator ID="KeepRunningUntilFailure">
         <Action
           ID="PublishVelocityForceCommand"
           wrench_gain="0.1"
           velocity_controlled_axes="0;0;0;0;0;0"
           force_controlled_axes="1;1;1;0;0;0"
-          wrench_stamped="{desired_wrench}"
-          twist_stamped="{desired_twist}"
+          twist="{twist}"
+          wrench="{wrench}"
           publish_rate="10"
           velocity_force_controller_command_topic="/velocity_force_controller/command"
         />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/grapple_moving_satellite_via_fiducial_tracking.xml
@@ -3,7 +3,6 @@
   BTCPP_format="4"
   main_tree_to_execute="Grapple Moving Satellite via Fiducial Tracking"
 >
-  <!--//////////-->
   <BehaviorTree
     ID="Grapple Moving Satellite via Fiducial Tracking"
     _description="Track and grapple satellite using state estimation of target April tags. Initiate satellite motion or reset position with Key 1 in the MuJoCo viewer."
@@ -15,6 +14,16 @@
         ID="Move to Waypoint"
         _collapsed="true"
         waypoint_name="View Tag"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        execution_pipeline="jtac"
+        joint_group_name="manipulator"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.01"
+        seed="0"
+        velocity_scale_factor="1.0"
       />
       <Action
         ID="SwitchController"
@@ -25,21 +34,23 @@
         controller_switch_action_name="/controller_manager/switch_controller"
         strictness="1"
         timeout="-1.000000"
+        automatic_activation="true"
+        deactivate_controllers=""
       />
       <Action
         ID="CreatePoseStamped"
+        name="target pose offset"
         pose_stamped="{target_pose_offset}"
         orientation_xyzw="-0.7071068;0.7071068;0;0"
         position_xyz="0.0;0.0;0.2"
         reference_frame="world"
-        name="target pose offset"
       />
       <Action
         ID="CreateWrenchStamped"
+        name="Always 0, not using Force"
         torque_xyz="0.0;0.0;0.0"
         force_xyz="0.0;0.0;0.0"
         wrench_stamped="{desired_wrench}"
-        name="Always 0, not using Force"
         reference_frame="world"
       />
       <Action
@@ -49,6 +60,24 @@
         linear_velocity_xyz="0;0;0"
         twist_stamped="{desired_twist}"
         reference_frame="world"
+      />
+      <!--Seed the unstamped {twist}/{wrench} blackboard keys before the Parallel so
+          PublishVelocityForceCommand sees values on its first tick. The compute loop below
+          re-unpacks {twist} each cycle as ComputeVelocityToAlignWithTarget refreshes
+          {desired_twist}; {desired_wrench} is static so the seed unpack is sufficient.-->
+      <Action
+        ID="UnpackTwistStampedMessage"
+        name="UnpackTwistStampedMessage"
+        twist="{twist}"
+        header="{header}"
+        twist_stamped="{desired_twist}"
+      />
+      <Action
+        ID="UnpackWrenchStampedMessage"
+        name="UnpackWrenchStampedMessage"
+        wrench="{wrench}"
+        header="{header}"
+        wrench_stamped="{desired_wrench}"
       />
       <Action
         ID="ResetMujocoKeyframe"
@@ -80,6 +109,7 @@
                 marker_name="odom_pose"
                 marker_lifetime="0.000000"
                 marker_size="0.100000"
+                marker_text=""
               />
               <Action
                 ID="ComputeVelocityToAlignWithTarget"
@@ -91,6 +121,13 @@
                 target_pose_offset="{target_pose_offset}"
                 output_pose_error="{error_pose}"
               />
+              <Action
+                ID="UnpackTwistStampedMessage"
+                name="UnpackTwistStampedMessage"
+                twist="{twist}"
+                header="{header}"
+                twist_stamped="{desired_twist}"
+              />
             </Control>
           </Decorator>
         </Control>
@@ -101,9 +138,9 @@
             velocity_controlled_axes="1;1;1;1;1;1"
             force_controlled_axes="0;0;0;0;0;0"
             publish_rate="10"
-            twist_stamped="{desired_twist}"
+            twist="{twist}"
             velocity_force_controller_command_topic="/pose_jog/manipulator"
-            wrench_stamped="{desired_wrench}"
+            wrench="{wrench}"
           />
         </Decorator>
         <Decorator ID="KeepRunningUntilFailure">
@@ -114,13 +151,14 @@
             planning_group_names="manipulator"
             stop_safety_factor="1.200000"
             include_octomap="false"
+            skip_collision_checks="false"
           />
         </Decorator>
         <Control ID="Sequence" name="TopLevelSequence">
           <Action
             ID="WaitForDuration"
-            delay_duration="0.2"
             name="Wait for {error_pose} to be created."
+            delay_duration="0.2"
           />
           <Decorator ID="RetryUntilSuccessful" num_attempts="-1">
             <Control ID="Sequence">
@@ -145,6 +183,7 @@
           <Action
             ID="BreakpointSubscriber"
             breakpoint_topic="/moveit_pro_breakpoint"
+            message=""
           />
           <Action
             ID="CreatePoseStamped"


### PR DESCRIPTION
## Problem

CI integration tests for `lab_sim` against released `9.3.0-rc9` / `9.3.0-rc10` images fail in ~0.6s with:

```
A port with name [twist] is found in the XML (PublishVelocityForceCommand, line 228)
but not in the providedPorts() of its registered node type.
```

A paired refactor split across releases between this repo and `moveit_pro`. The XML side (`9ff6820f` on `moveit_pro_example_ws/main`, 2026-05-18) switched lab/kinova Objectives to the new unstamped `twist` / `wrench` ports. The matching C++ side landed on `moveit_pro/main` but missed the `9.3.0-rc9` and `rc10` cuts. Neither half is on v9.3.

This PR backports the XML half. It is paired with PickNikRobotics/moveit_pro#19304 which backports the C++ half. Both halves must land together for `v9.3` to be consistent; the C++ PR alone (with v9.3's old XML still wiring `twist_stamped`) keeps working via the backwards-compat path, but landing this PR ahead of the C++ PR would break v9.3 CI the same way main broke when the workspace shipped first.

For PickNikRobotics/moveit_pro#19269.

## Alternatives considered

- **Leave v9.3 on the old stamped wiring and only backport the C++ side.** Workable because the C++ commit keeps `twist_stamped`/`wrench_stamped` accepted (deprecated but supported). Rejected because we want v9.3 and main to stay aligned at the Objective-XML level so backports and bisection don't keep tripping on the same diff.
- **Skip the affected lab_sim tests on v9.3.** Hides the symptom; rejected.
- **Cherry-pick the XML commit onto v9.3 (this PR).** Chosen.

## Chosen approach

Direct cherry-pick of `9ff6820f` onto v9.3. One conflict in `velocity_force_controller_zero.xml`: v9.3 has unrelated `publish_rate="10"` and `velocity_force_controller_command_topic` attributes that aren't on main. Resolved by keeping those v9.3-only attributes and applying the `twist=` / `wrench=` port rename from the cherry-pick.

## Merge ordering

Merge PickNikRobotics/moveit_pro#19304 first (or together) so the next `v9.3` image build has the new C++ ports before this XML lands. If this PR's CI uses an image_tag built after #19304 merges, it should go green.