### PR TITLE
Add fuselage surface sweep Objectives (3-pass working + single-path raster)

### DIFF
--- a/src/hangar_sim/objectives/plan_path_along_surface_3_passes.xml
+++ b/src/hangar_sim/objectives/plan_path_along_surface_3_passes.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Plan Path Along Surface 3 Passes">
+  <BehaviorTree
+    ID="Plan Path Along Surface 3 Passes"
+    _description="Sweep three stacked contour passes along the side of the fuselage. Generates and previews all three surface-contour markers up front, then plans, validates, and executes a Cartesian path for each pass in turn -- each pass starting where the previous one ended (a pseudo-raster). Built on the same GetContourFromPointCloudSlice perception as Plan Path Along Surface."
+    _favorite="true"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Move to Waypoint (JTC)"
+        _collapsed="true"
+        acceleration_scale_factor="1.0"
+        controller_names="joint_trajectory_controller"
+        joint_group_name="manipulator"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.0"
+        seed="0"
+        velocity_scale_factor="1.0"
+        waypoint_name="Look at Plane"
+        controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+      />
+      <!--Capture one point cloud and lift it to the world frame; all three slices reuse it.-->
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{full_cloud}"
+        publisher_timeout_sec="5.000000"
+        message_timeout_sec="5.000000"
+      />
+      <Action
+        ID="TransformPointCloudFrame"
+        input_cloud="{full_cloud}"
+        output_cloud="{full_cloud}"
+        target_frame="world"
+      />
+      <!--========== Generate all three contours and show their markers ==========-->
+      <!--Row 1: top, z = 1.7-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_1}"
+        position_xyz="0;12.5;1.7"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_1}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_1}"
+        crop_box_size="5;4;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_1}"
+        point_cloud="{crop_1}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_1}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.0"
+        input_cloud="{crop_1}"
+        slice_distance_from_plane="0.050000"
+        slice_plane="{centroid_1}"
+        contour_crop_angle_span="3.15"
+        contour_crop_angle_start="1.60"
+      />
+      <!--Reverse contours 1 and 3 (contour 2 is left as-is) so the three passes
+           chain end-to-start in alternating directions: pass 1 y11->y14,
+           pass 2 y14->y11, pass 3 y11->y14. No return-home between passes.-->
+      <Action
+        ID="ReversePoseStampedVector"
+        input_vector="{contour_1}"
+        output_vector="{contour_1}"
+      />
+      <!--Row 2: middle, z = 1.55-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_2}"
+        position_xyz="0;12.5;1.55"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_2}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_2}"
+        crop_box_size="5;4;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_2}"
+        point_cloud="{crop_2}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_2}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.0"
+        input_cloud="{crop_2}"
+        slice_distance_from_plane="0.050000"
+        slice_plane="{centroid_2}"
+        contour_crop_angle_span="3.15"
+        contour_crop_angle_start="1.60"
+      />
+      <!--Row 3: bottom, z = 1.4-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_3}"
+        position_xyz="0;12.5;1.4"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_3}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_3}"
+        crop_box_size="5;4;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_3}"
+        point_cloud="{crop_3}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_3}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.0"
+        input_cloud="{crop_3}"
+        slice_distance_from_plane="0.050000"
+        slice_plane="{centroid_3}"
+        contour_crop_angle_span="3.15"
+        contour_crop_angle_start="1.60"
+      />
+      <Action
+        ID="ReversePoseStampedVector"
+        input_vector="{contour_3}"
+        output_vector="{contour_3}"
+      />
+      <!--Show all three path markers at once before any motion.-->
+      <Action
+        ID="VisualizePath"
+        marker_lifetime="0.000000"
+        marker_name="pass_1"
+        path="{contour_1}"
+        pose_marker_size="0.050000"
+        show_poses="true"
+      />
+      <Action
+        ID="VisualizePath"
+        marker_lifetime="0.000000"
+        marker_name="pass_2"
+        path="{contour_2}"
+        pose_marker_size="0.050000"
+        show_poses="true"
+      />
+      <Action
+        ID="VisualizePath"
+        marker_lifetime="0.000000"
+        marker_name="pass_3"
+        path="{contour_3}"
+        pose_marker_size="0.050000"
+        show_poses="true"
+      />
+      <!--========== Pass 1: top contour (from the Look at Plane pose) ==========-->
+      <Action
+        ID="PlanCartesianPath"
+        acceleration_scale_factor="1.000000"
+        blending_radius="0.0050000"
+        ik_cartesian_space_density="0.010000"
+        ik_joint_space_density="0.100000"
+        joint_trajectory_msg="{traj_1}"
+        path="{contour_1}"
+        planning_group_name="manipulator"
+        position_only="false"
+        trajectory_sampling_rate="100"
+        velocity_scale_factor="1.000000"
+        tip_offset="0;0;0.2;0;0;0"
+        debug_solution="{debug_solution}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="ValidateTrajectory"
+        planning_scene_msg="{planning_scene}"
+        planning_group_name="manipulator"
+        joint_trajectory_msg="{traj_1}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        execution_pipeline="jtc"
+        controller_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+        joint_trajectory_msg="{traj_1}"
+      />
+      <!--========== Pass 2: middle contour (continues from end of pass 1) ==========-->
+      <Action
+        ID="PlanCartesianPath"
+        acceleration_scale_factor="1.000000"
+        blending_radius="0.0050000"
+        ik_cartesian_space_density="0.010000"
+        ik_joint_space_density="0.100000"
+        joint_trajectory_msg="{traj_2}"
+        path="{contour_2}"
+        planning_group_name="manipulator"
+        position_only="false"
+        trajectory_sampling_rate="100"
+        velocity_scale_factor="1.000000"
+        tip_offset="0;0;0.2;0;0;0"
+        debug_solution="{debug_solution}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="ValidateTrajectory"
+        planning_scene_msg="{planning_scene}"
+        planning_group_name="manipulator"
+        joint_trajectory_msg="{traj_2}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        execution_pipeline="jtc"
+        controller_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+        joint_trajectory_msg="{traj_2}"
+      />
+      <!--========== Pass 3: bottom contour (continues from end of pass 2) ==========-->
+      <!--tip_offset z is 0.3 here vs 0.2 on passes 1-2: the fuselage's coarse
+           collision mesh (collision_Plane_009) bulges past the visual skin low on
+           the body, so the bottom pass needs a little more standoff to validate
+           collision-free. See the PR follow-up note on the collision mesh.-->
+      <Action
+        ID="PlanCartesianPath"
+        acceleration_scale_factor="1.000000"
+        blending_radius="0.0050000"
+        ik_cartesian_space_density="0.010000"
+        ik_joint_space_density="0.100000"
+        joint_trajectory_msg="{traj_3}"
+        path="{contour_3}"
+        planning_group_name="manipulator"
+        position_only="false"
+        trajectory_sampling_rate="100"
+        velocity_scale_factor="1.000000"
+        tip_offset="0;0;0.3;0;0;0"
+        debug_solution="{debug_solution}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="ValidateTrajectory"
+        planning_scene_msg="{planning_scene}"
+        planning_group_name="manipulator"
+        joint_trajectory_msg="{traj_3}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        execution_pipeline="jtc"
+        controller_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+        joint_trajectory_msg="{traj_3}"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Plan Path Along Surface 3 Passes">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Training Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/hangar_sim/objectives/raster_path_along_fuselage.xml
+++ b/src/hangar_sim/objectives/raster_path_along_fuselage.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Raster Path Along Fuselage">
+  <!--
+    KNOWN LIMITATION — NEEDS PLANNER TUNING.
+
+    This Objective stitches three stacked fuselage contours into ONE boustrophedon
+    path and tries to plan it with a single PlanCartesianPath. On hangar_sim that
+    single plan does not return in a reasonable time (>8 min for ~116 waypoints,
+    versus ~2 s for a single 53-waypoint contour). The blow-up comes from the
+    whole-body "manipulator" group's base redundancy combined with the orientation
+    discontinuities at the seams between stacked contours.
+
+    For a working multi-pass sweep today, use the `Plan Path Along Surface 3 Passes`
+    Objective, which plans and executes each contour separately (fast, reliable),
+    chaining each pass from the previous contour's endpoint (no return to
+    "Look at Plane" between passes).
+
+    To make this single-path version tractable, options to explore: plan with an
+    arm-only group instead of the whole-body group, coarsen the path
+    (max_pose_spacing / ik_cartesian_space_density), increase blending_radius so the
+    planner does not have to hit every pose exactly, or split the execute per row.
+  -->
+  <BehaviorTree
+    ID="Raster Path Along Fuselage"
+    _description="Build a single 2D raster coverage path over the airplane fuselage. Captures one wrist-camera point cloud, then slices it at three stacked heights (the same crop/centroid/contour approach as Plan Path Along Surface), reverses the middle contour, and stitches all three into one boustrophedon Cartesian path. NOTE: the single stitched PlanCartesianPath is currently intractable on hangar_sim - see the Plan Path Along Surface 3 Passes Objective for a working multi-pass sweep, and the header comment for tuning options."
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Move to Waypoint (JTC)"
+        _collapsed="true"
+        acceleration_scale_factor="1.0"
+        controller_names="joint_trajectory_controller"
+        joint_group_name="manipulator"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.0"
+        seed="0"
+        velocity_scale_factor="1.0"
+        waypoint_name="Look at Plane"
+      />
+      <!--Capture one point cloud, lift to world frame. All three slices reuse it.-->
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{full_cloud}"
+        publisher_timeout_sec="5.000000"
+        message_timeout_sec="5.000000"
+      />
+      <Action
+        ID="TransformPointCloudFrame"
+        input_cloud="{full_cloud}"
+        output_cloud="{full_cloud}"
+        target_frame="world"
+      />
+      <Action ID="ResetPoseStampedVector" vector="{raster_path}" />
+      <!--===== Row 1: top, z = 1.7, left-to-right =====-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_1}"
+        position_xyz="0;12;1.7"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_1}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_1}"
+        crop_box_size="5;15;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_1}"
+        point_cloud="{crop_1}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_1}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.000000"
+        input_cloud="{crop_1}"
+        slice_distance_from_plane="0.100000"
+        slice_plane="{centroid_1}"
+        contour_crop_angle_span="3.2"
+        contour_crop_angle_start="1.58"
+      />
+      <Decorator ID="ForEach" index="{i1}" out="{p1}" vector_in="{contour_1}">
+        <Action
+          ID="AddPoseStampedToVector"
+          input="{p1}"
+          vector="{raster_path}"
+        />
+      </Decorator>
+      <!--===== Row 2: middle, z = 1.55, reversed for a lawn-mower turn =====-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_2}"
+        position_xyz="0;12;1.55"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_2}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_2}"
+        crop_box_size="5;15;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_2}"
+        point_cloud="{crop_2}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_2}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.000000"
+        input_cloud="{crop_2}"
+        slice_distance_from_plane="0.100000"
+        slice_plane="{centroid_2}"
+        contour_crop_angle_span="3.2"
+        contour_crop_angle_start="1.58"
+      />
+      <Action
+        ID="ReversePoseStampedVector"
+        input_vector="{contour_2}"
+        output_vector="{contour_2}"
+      />
+      <Decorator ID="ForEach" index="{i2}" out="{p2}" vector_in="{contour_2}">
+        <Action
+          ID="AddPoseStampedToVector"
+          input="{p2}"
+          vector="{raster_path}"
+        />
+      </Decorator>
+      <!--===== Row 3: bottom, z = 1.4, left-to-right =====-->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="world"
+        pose_stamped="{roi_3}"
+        position_xyz="0;12;1.4"
+      />
+      <Action
+        ID="CropPointsInBox"
+        crop_box_centroid_pose="{roi_3}"
+        point_cloud="{full_cloud}"
+        point_cloud_cropped="{crop_3}"
+        crop_box_size="5;15;0.2"
+      />
+      <Action
+        ID="GetCentroidFromPointCloud"
+        output_pose="{centroid_3}"
+        point_cloud="{crop_3}"
+      />
+      <Action
+        ID="GetContourFromPointCloudSlice"
+        contour_path="{contour_3}"
+        max_pose_spacing="0.200000"
+        hull_alpha="-1.000000"
+        input_cloud="{crop_3}"
+        slice_distance_from_plane="0.100000"
+        slice_plane="{centroid_3}"
+        contour_crop_angle_span="3.2"
+        contour_crop_angle_start="1.58"
+      />
+      <Decorator ID="ForEach" index="{i3}" out="{p3}" vector_in="{contour_3}">
+        <Action
+          ID="AddPoseStampedToVector"
+          input="{p3}"
+          vector="{raster_path}"
+        />
+      </Decorator>
+      <!--Visualize and execute the stitched raster as a single Cartesian motion.-->
+      <Action
+        ID="VisualizePath"
+        marker_lifetime="0.000000"
+        marker_name="raster"
+        path="{raster_path}"
+        pose_marker_size="0.050000"
+        show_poses="true"
+      />
+      <Action
+        ID="PlanCartesianPath"
+        acceleration_scale_factor="1.000000"
+        blending_radius="0.0050000"
+        ik_cartesian_space_density="0.010000"
+        ik_joint_space_density="0.100000"
+        joint_trajectory_msg="{joint_trajectory_msg}"
+        path="{raster_path}"
+        planning_group_name="manipulator"
+        position_only="true"
+        trajectory_sampling_rate="100"
+        velocity_scale_factor="1.000000"
+        tip_offset="0;0;0.1;0;0;0"
+        debug_solution="{debug_solution}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        execution_pipeline="jtc"
+        controller_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Raster Path Along Fuselage">
+      <MetadataFields>
+        <!-- Not runnable: the single-path plan can hang (see KNOWN LIMITATION header).
+             Use `Plan Path Along Surface 3 Passes` for a working sweep. -->
+        <Metadata runnable="false" />
+        <Metadata subcategory="Training Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
## Motivation

Tutorial 4 is dropping the flat-rectangle `GenerateCoveragePath` examples (see PickNikRobotics/moveit_pro#19330). This PR adds the replacement: real point-cloud-driven coverage of the airplane fuselage, built up from the working `Plan Path Along Surface` Objective.

## Brief description

Two Objectives in `src/hangar_sim/objectives/`:

- **`plan_path_along_surface_3_passes.xml` — the working multi-pass sweep.** Reuses the proven `Plan Path Along Surface` flow (crop a thin slab → centroid → `GetContourFromPointCloudSlice` → `PlanCartesianPath` → `ValidateTrajectory` → `ExecuteTrajectory`) at three stacked heights (z = 1.7, 1.55, 1.4, top-down to stay reachable). All three contour markers are shown up front, then each pass is planned, validated, and executed in turn — each pass chaining from the previous contour's endpoint (a pseudo-raster; no return to `Look at Plane` between passes). `tip_offset` holds the tool at a fixed standoff from the surface: 0.2 m on passes 1–2, and 0.3 m on pass 3 where the coarse fuselage collision mesh needs a little more clearance (see follow-up comment below). **Verified: ran SUCCEEDED end-to-end on hangar_sim with all three `ValidateTrajectory` checks enabled.**
- **`raster_path_along_fuselage.xml` — single stitched-path raster (reference, not runnable).** Stitches the three contours into one boustrophedon path and plans it with a single `PlanCartesianPath`. Kept as a documented reference and marked `runnable="false"` because the single plan can hang on hangar_sim (see header comment for tuning options).

## How it was tested

Run live on a hangar_sim dev backend (`agent_robot.app`), driven via `ros2 action send_goal /do_objective`:

- `Plan Path Along Surface` (baseline): SUCCEEDED from a clean robot state.
- `Plan Path Along Surface 3 Passes`: SUCCEEDED end-to-end — all three contours planned and executed, each pass chaining from the previous endpoint, with every `ValidateTrajectory` passing.
- `Raster Path Along Fuselage` (single stitched path): perception + stitching produce the path, but the single `PlanCartesianPath` does not return in reasonable time (>8 min, vs ~2 s for one contour). Root cause: the whole-body `manipulator` group's base redundancy plus orientation discontinuities at the contour seams. Header comment lists tuning options (arm-only group, coarser path, larger blending radius, per-row execute).

Required Git LFS assets had to be pulled for hangar_sim to launch (the wrist cloud and ros2_control IMU interfaces depend on the MuJoCo meshes).

## Alternatives considered

- **Single monolithic `PlanCartesianPath` over all three stacked contours** — does not return in reasonable time in this sim (see above). Kept as a documented, non-runnable reference rather than the primary path.
- **Freespace `Move to Pose` resets between passes** — an earlier version moved toward an approach pose between passes. Once the tool orientation and standoff were corrected, the plain per-pass Cartesian chain plans the short inter-pass move fine, so the resets were removed.
- **`FindSlicePlanesAlongEdge`/`AddOverageToPath` raster (original approach)** — generated paths fine but the wide whole-body Cartesian plan hit wrist-joint limits / did not converge; the centroid-slab contour approach is far more reliable on hangar_sim.

## Release notes

New Behavior/Library: New `Plan Path Along Surface 3 Passes` Objective in `hangar_sim` that sweeps three stacked contour passes along the airplane fuselage.