### PR TITLE
Add Pick 1 Pill Bottle with SAM3 Objective for Tutorial 3

### DIFF
--- a/src/lab_sim/objectives/pick_1_pill_bottle_with_sam3.xml
+++ b/src/lab_sim/objectives/pick_1_pill_bottle_with_sam3.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Pick 1 Pill Bottle with SAM3">
+  <BehaviorTree
+    ID="Pick 1 Pill Bottle with SAM3"
+    _description="Single-bottle version of Pick All Pill Bottles. Uses SAM3 text-prompt segmentation seeded into an ICP fit, then picks one bottle and drops it in the tray via a Cartesian up-over-down drop."
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="TopLevelSequence" _collapsed="false">
+      <SubTree ID="Open Gripper" _collapsed="true" />
+      <SubTree
+        ID="Move to Waypoint"
+        name="Look at pill bottles"
+        _collapsed="true"
+        joint_group_name="manipulator"
+        waypoint_name="Look at Bottles Left"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        execution_pipeline="jtac"
+        keep_orientation="false"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.01"
+        seed="0"
+        velocity_scale_factor="1.0"
+      />
+      <!--The admittance controller reports trajectory success before the arm
+           has fully settled, so without this wait the wrist camera captures
+           a mid-motion frame.-->
+      <Action
+        ID="WaitForDuration"
+        name="Let arm settle at look pose"
+        delay_duration="1.0"
+      />
+      <SubTree ID="Add Table to Planning Scene" _collapsed="true" />
+      <!--Perception: SAM3 segments a bottle, derives an ICP seed from the
+           mask centroid, and fits the bottle CAD model to the masked cloud
+           via ICP. Output is a world-frame grasp pose at the bottle cap.-->
+      <SubTree
+        ID="Get Bottle Grasp via ICP Subtree"
+        name="Get grasp pose for a pill bottle"
+        _collapsed="true"
+        camera_image_topic="/wrist_camera/color"
+        camera_info_topic="/wrist_camera/camera_info"
+        camera_points_topic="/wrist_camera/points"
+        output_grasp="{output_grasp}"
+        object_prompt="a small white or grey rectangular pill bottle with a purple blue top cap"
+        exemplar_image="{exemplar_image}"
+        target_bboxes="{target_bboxes}"
+        exemplar_bboxes="{exemplar_bboxes}"
+      />
+      <Action
+        ID="VisualizePose"
+        name="Show grasp pose"
+        marker_lifetime="0.000000"
+        marker_name="grasp_pose"
+        marker_size="0.100000"
+        pose="{output_grasp}"
+        marker_text="grasp_pose"
+      />
+      <SubTree
+        ID="Fan Pose About Tool-Z Subtree"
+        name="Build yaw-variant grasp poses"
+        _collapsed="true"
+        input_pose="{output_grasp}"
+        output_pose_vector="{grasp_pose_vector}"
+      />
+      <SubTree
+        ID="Pick from Pose Vector"
+        name="Pick up pill bottle"
+        _collapsed="true"
+        approach_distance="0.1"
+        retract_xyz="0;0;-0.1"
+        grasp_poses="{grasp_pose_vector}"
+      />
+      <!--Drop: cartesian up-over-down to the tray, orientation-locked so the
+           gripper stays vertical and the bottle does not tip mid-flight.
+           position_only="false" on the lift, position_only="true" on the
+           descent so the soft nullspace task can absorb small orientation
+           drift during the longer Cartesian move.-->
+      <Control
+        ID="Sequence"
+        name="Drop: cartesian up-over-down to tray"
+        _collapsed="true"
+      >
+        <Action
+          ID="CreatePoseStamped"
+          name="Gripper origin in gripper frame"
+          position_xyz="0;0;0"
+          orientation_xyzw="0;0;0;1"
+          reference_frame="grasp_link"
+          pose_stamped="{gripper_local_pose}"
+        />
+        <Action
+          ID="TransformPoseFrame"
+          name="Resolve gripper pose in world"
+          input_pose="{gripper_local_pose}"
+          target_frame_id="world"
+          output_pose="{post_pick_world_pose}"
+        />
+        <Action
+          ID="TransformPose"
+          name="Up: lift 10 cm in local frame"
+          input_pose="{post_pick_world_pose}"
+          output_pose="{up_pose}"
+          translation_xyz="0;0;-0.1"
+          quaternion_xyzw="0;0;0;1"
+          marker_lifetime="0.000000"
+          marker_size="0.000000"
+          marker_text=""
+          visualize_pose="false"
+        />
+        <Action
+          ID="CreatePoseStamped"
+          name="Over: hover above tray"
+          position_xyz="0.95;0.5568;0.85"
+          orientation_xyzw="-0.0436;0.9990;0;0"
+          reference_frame="world"
+          pose_stamped="{over_pose}"
+        />
+        <Action
+          ID="CreatePoseStamped"
+          name="Down: drop pose above tray surface"
+          position_xyz="0.95;0.5568;0.605"
+          orientation_xyzw="-0.0436;0.9990;0;0"
+          reference_frame="world"
+          pose_stamped="{down_pose}"
+        />
+        <SubTree
+          ID="CreateVector"
+          name="Init drop path"
+          _collapsed="true"
+          vector="{drop_path}"
+        />
+        <SubTree
+          ID="AddToVector"
+          name="Add up via-point"
+          _collapsed="true"
+          element="{up_pose}"
+          input_vector="{drop_path}"
+          output_vector="{drop_path}"
+        />
+        <SubTree
+          ID="AddToVector"
+          name="Add over hover"
+          _collapsed="true"
+          element="{over_pose}"
+          input_vector="{drop_path}"
+          output_vector="{drop_path}"
+        />
+        <SubTree
+          ID="AddToVector"
+          name="Add down drop"
+          _collapsed="true"
+          element="{down_pose}"
+          input_vector="{drop_path}"
+          output_vector="{drop_path}"
+        />
+        <Action
+          ID="PlanCartesianPath"
+          name="Plan up-over-down"
+          path="{drop_path}"
+          position_only="true"
+          joint_trajectory_msg="{drop_traj}"
+          debug_solution="{drop_debug}"
+          planning_group_name="manipulator"
+          tip_links="grasp_link"
+          tip_offset="0;0;0;0;0;0"
+          acceleration_scale_factor="1.000000"
+          velocity_scale_factor="1.000000"
+          blending_radius="0.020000"
+          ik_cartesian_space_density="0.010000"
+          ik_joint_space_density="0.100000"
+          trajectory_sampling_rate="100"
+          max_optimizer_iterations="1"
+        />
+        <Action
+          ID="ExecuteTrajectory"
+          name="Execute up-over-down"
+          joint_trajectory_msg="{drop_traj}"
+          goal_duration_tolerance="-1.000000"
+          controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+          execution_pipeline="jtac"
+        />
+        <SubTree ID="Open Gripper" _collapsed="true" />
+      </Control>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Pick 1 Pill Bottle with SAM3">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
## Motivation

Tutorial 3 (Perception & Machine Learning) in the docs is being refactored to walk prebuilt Objectives instead of building them click-by-click in the editor (PickNikRobotics/moveit_pro#19226). The ICP section has a 1:1 match in the existing `Fit Bottle Model Subtree`, but there was no single-bottle SAM3 picker — only `Pick All Pill Bottles` (full placement loop) and `pick_1_pill_bottle_with_ml.xml` (CLIPSeg, not SAM3). This PR adds the missing canonical reference.

## Brief description

New Objective `Pick 1 Pill Bottle with SAM3` in `lab_sim`. It mirrors `Pick All Pill Bottles` minus the placement-loop and YAML-driven place poses: SAM3 segments one bottle (`Get Bottle Grasp via ICP Subtree`), `Fan Pose About Tool-Z Subtree` builds yaw variants, `Pick from Pose Vector` picks it, then a Cartesian up–over–down drop into the tray with `position_only=true` on the descent.

## How it was tested

- Reads the same SAM3 + ICP stack `Pick All Pill Bottles` already uses (`Get Bottle Grasp via ICP Subtree`, which wraps `Segment Bottle Subtree` and `Fit Bottle Model Subtree`); no new perception code introduced.
- `pre-commit run --files src/lab_sim/objectives/pick_1_pill_bottle_with_sam3.xml` — passes, including `Validate Objective favorites`.
- `MetadataFields` block present per the user_ws CI requirement (`runnable=true`, subcategory `Application - ML (GPU Recommended)`).
- Manual runtime validation in `lab_sim` is recommended before merge (GPU-only Objective).

## Alternatives considered

- **Re-scope tutorial to use `Pick All Pill Bottles` directly.** Rejected: the placement-loop and YAML-loaded poses are pedagogical noise when introducing the SAM3 + ICP combination for the first time. The full Objective is still the headline at the end of the tutorial; this is the simpler stepping stone.
- **Adapt `pick_1_pill_bottle_with_ml.xml` (CLIPSeg).** Rejected: it would mean either renaming the tutorial section ("Pick One Bottle with ML") or rewriting the existing CLIPSeg pick to use SAM3, which silently changes behavior of an existing Objective that may be referenced elsewhere.

## Release notes

None.