### PR TITLE
Fix: restore static map→odom TF conditioned on slam:=false

### DIFF
--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -316,11 +316,21 @@ def generate_launch_description():
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "map"],
     )
 
+    # Static map→odom bootstrap: anchors 'odom' in the TF tree before MuJoCo finishes loading so
+    # bt_navigator can initialize without an "unconnected trees" TF error. Not used in slam mode
+    # because slam_toolbox owns and publishes map→odom dynamically.
+    static_tf_map_to_odom = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_tf_map_to_odom",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "map", "odom"],
+        condition=IfCondition(PythonExpression(["not ", slam])),
+    )
+
     # Static TF connecting MoveIt's planning root ('world') to the simulation root ('mj_world').
     # The UI (pose-utils.ts) hardcodes 'world' as the reference frame for all user-clicked poses,
-    # so this link is required for nav2 goals to be transformable to 'map', and lets MoveIt
-    # locate the base link via 'world → mj_world → base_platform → ridgeback_base_link'
-    # instead of relying on virtual joint states (which are not published in sim).
+    # so this link is required for nav2 goals to be transformable to 'map'.
     static_tf_mj_world_to_world = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -421,6 +431,7 @@ def generate_launch_description():
 
     ld.add_action(static_tf_world_to_map)
     ld.add_action(static_tf_mj_world_to_world)
+    ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
     ld.add_action(laser_filter_front_node)
     ld.add_action(laser_filter_rear_node)


### PR DESCRIPTION
Human (that's me) :
I noticed some odom and map TF errors on hangar_sim start. I needed to have this TF that used to be there conditional on slam being false. I saw that before I added it back the 'navigate to clicked point' failed, and now the 'navigate to clicked point' is working again. 

## Problem

`static_tf_map_to_odom` was removed unconditionally in PR #596 to avoid conflicting with slam_toolbox's dynamic `map → odom` publish. When `slam:=false` (the default), `odom` has no parent in the TF tree so all navigation objectives fail immediately with `Could not find a connection between 'map' and 'odom' because they are not part of the same tree`.

## Fix

Restore `static_tf_map_to_odom` conditioned on `slam:=false`. When `slam:=true`, the static TF is suppressed and slam_toolbox owns `map → odom` dynamically as before.

## Alternatives considered

- Publish `mj_world → odom` from MuJoCo — rejected because it hardcodes an identity and interferes with fuse and localization.
- Leave as-is and require slam to always be running — too much overhead for simple navigation testing.

Fixes PickNikRobotics/moveit_pro#19337

## Release notes

None