### PR TITLE
test: skip ML Segment Point Cloud in CI

### DIFF
--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -62,6 +62,7 @@ skip_objectives = {
     "ML Find Bottles on Table from Image Exemplar",  # Skipped because it looks for a file on a home path
     "ML Segment Image",
     "ML Segment Image Loop",
+    "ML Segment Point Cloud",  # Camera topic /wrist_camera/color not available in CI
     "ML Segment Point Cloud from Clicked Point",
     "MPC Pose Tracking",
     "MPC Pose Tracking With Point Cloud Avoidance",
@@ -90,10 +91,13 @@ def wait_for_gripper_action_server(timeout: int = 180):
     action_client = ActionClient(
         node, GripperCommand, "/robotiq_gripper_controller/gripper_cmd"
     )
-    if not action_client.wait_for_server(timeout_sec=timeout):
-        raise TimeoutError(
-            "Timeout waiting for robotiq_gripper_controller gripper action server to start"
-        )
+    try:
+        if not action_client.wait_for_server(timeout_sec=timeout):
+            raise TimeoutError(
+                "Timeout waiting for robotiq_gripper_controller gripper action server to start"
+            )
+    finally:
+        node.destroy_node()
     return True
 
 


### PR DESCRIPTION
From the Human (me):
 I'm seeing lots of failures during CI on the integration-test-in-studio-container in example_ws, but this one popped up and seemed more convincing of a fix than others. I am not sure if others have seen this and it makes sense to skip this objective or not (if it truly is trying to access a camera) ?  THANNNKKKKSSSSSS :)

## Summary

- `"ML Segment Point Cloud"` was missing from `skip_objectives` in `lab_sim/test/objectives_integration_test.py`
- All sibling ML Segment objectives (`"ML Segment Image"`, `"ML Segment Image Loop"`, `"ML Segment Point Cloud from Clicked Point"`) are already skipped, but this one was overlooked

## Is this real?

Observed in CI run logs — the objective consistently fails because the wrist camera topic is not available:

```
[objective_server_node_main-14] [INFO] Objective `ML Segment Point Cloud` starting at time: 1779824415.07318687 seconds.
[objective_server_node_main-14] [ERROR] GetImage Error: Failed to get next message on topic '/wrist_camera/color': Timed out after 5 seconds.
[objective_server_node_main-14] [ERROR] Execution of Behavior Tree for Objective `ML Segment Point Cloud` did not succeed at time: 1779824420.09333515 seconds
```

Full failure from CI (run `70856775458`):
```
FAILED test_all_objectives[.../objectives/ml_segment_point_cloud.xml]
Failed: Objective 'ML Segment Point Cloud' failed to execute:
  assert ros_service_data.request_response.val == MoveItErrorCodes.SUCCESS
  AssertionError
```

Flagging as a PR rather than merging directly — haven't seen this reported before, so wanted confirmation this is expected behavior in CI before skipping it permanently.

## Test plan
- [ ] Confirm CI passes with `ML Segment Point Cloud` skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)