### PR TITLE
Fix: Backport lab_sim burner pushable fix to inlined picknik_accessories

### DIFF
--- a/src/picknik_accessories/mujoco_assets/lab_desk/desk.xml
+++ b/src/picknik_accessories/mujoco_assets/lab_desk/desk.xml
@@ -132,7 +132,19 @@
     <joint type="free" damping="1" />
   </body>
   <body name="stirrer" pos="0.605 0.761 0.473827" euler="0 0 0">
-    <freejoint />
+    <joint type="free" damping="1" />
+    <!-- Explicit inertial keeps the burner light enough to be pushed by the gripper.
+         Without this, MuJoCo auto-infers ~9.7 kg from the 0.2x0.4x0.074 m collision box
+         at default density 1000 kg/m^3, and static friction (per MAX-rule combine
+         with the desk's default friction=1.0) pins it under any vertical-dominant
+         gripper push. priority="1" on the collision geom below makes the burner's
+         lower friction override the desk's, so the burner can actually slide.
+         The diaginertia is intentionally non-homogeneous: a real stirrer's mass
+         is biased toward the base (motor + heavy stand) under a thin top plate,
+         so xx/yy are symmetric and well below the homogeneous-box values
+         (~0.0207, ~0.00569, ~0.025 for 1.5 kg, 0.2x0.4x0.074 m). Do not
+         regenerate these from the collision box extents. -->
+    <inertial pos="0 0 0.02" mass="1.5" diaginertia="0.008 0.008 0.012" />
     <geom
       material="stirrer"
       mesh="stirrer"
@@ -140,6 +152,7 @@
       contype="0"
       conaffinity="0"
       group="2"
+      mass="0"
     />
     <geom
       class="collision"
@@ -147,6 +160,8 @@
       pos="0 0 0"
       size="0.1 0.2 0.037"
       group="4"
+      friction="0.3 0.005 0.0001"
+      priority="1"
     />
   </body>
   <body name="test_tubes_stand" pos="0.3 0.85 0.472476" euler="0 0 0">


### PR DESCRIPTION
## Summary

Backports the burner-pushable fix from `picknik_accessories` PR [#45](https://github.com/PickNikRobotics/picknik_accessories/pull/45) into the now-inlined copy of those assets on `main`.

The `v9.3` branch already has this fix via PR #661 (submodule bump `aad29fa` → `3b0912d`). Main does not, because PR #656 inlined the pre-fix `aad29fa` snapshot of `picknik_accessories` shortly after `v9.3` was cut, so the `picknik_accessories#45` fix never made it across.

## What changed

Three surgical changes to the `stirrer` body in `src/picknik_accessories/mujoco_assets/lab_desk/desk.xml`:

1. `<freejoint />` → `<joint type="free" damping="1" />`, plus an explicit `<inertial pos="0 0 0.02" mass="1.5" diaginertia="0.008 0.008 0.012" />` so MuJoCo does not auto-infer ~9.7 kg from the collision-box extents.
2. `mass="0"` on the visual geom so it contributes no inertia (the `<inertial>` element is authoritative).
3. `friction="0.3 0.005 0.0001"` + `priority="1"` on the collision geom so the burner's lower friction overrides the desk's default friction under the MAX-rule combine, allowing the gripper to push it.

The long explanatory comment about the diaginertia choices is preserved from the upstream commit.

## Verification

- `picknik_accessories@aad29fa..3b0912d` touches only one file (`mujoco_assets/lab_desk/desk.xml`) across two commits (the fix + its merge), so this is the complete diff — nothing else on `main` is missing.
- Diffed the resulting file against `picknik_accessories@3b0912d:mujoco_assets/lab_desk/desk.xml` — the only remaining differences are cosmetic formatting (multi-line vs single-line attributes), inherited from the pre-commit reformat done in PR #656.
- Local pre-commit passes on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)