### PR TITLE
feat(hangar_sim): enable fuse velocity_decay to prevent drift after nav2 stops

### DIFF
--- a/src/hangar_sim/config/fuse/fuse.yaml
+++ b/src/hangar_sim/config/fuse/fuse.yaml
@@ -21,7 +21,8 @@ state_estimator:
       process_noise_diagonal: [1.0, 1.0, 0.0001, 0.0001, 0.0001, 0.5, 0.5, 0.5, 0.0001, 0.0001, 0.0001, 0.25, 0.00001, 0.00001, 0.00001]
       # Exponential velocity decay rate (1/s). Predicted velocity decays toward zero when the
       # odometry source goes silent (e.g., after a nav2 controller deactivates), preventing
-      # indefinite drift. Set to 0.0 to disable. With k=1.0, velocity halves in ~0.7s.
+      # indefinite drift. Set to 0.0 to disable. k=1.0 chosen so velocity is ~95% decayed
+      # within 3s — long enough to not affect normal driving, short enough to kill post-nav2 drift.
       velocity_decay: 1.0
 
     sensor_models:

--- a/src/hangar_sim/config/fuse/fuse.yaml
+++ b/src/hangar_sim/config/fuse/fuse.yaml
@@ -19,6 +19,10 @@ state_estimator:
       #process_noise_diagonal: [0.25, 0.25, 0.00001, 0.00001, 0.00001, 0.25
       #   -, 0.1, 0.1, 0.00001, 0.00001, 0.0001, 0.1, 0.0001, 0.0001, 0.00001]
       process_noise_diagonal: [1.0, 1.0, 0.0001, 0.0001, 0.0001, 0.5, 0.5, 0.5, 0.0001, 0.0001, 0.0001, 0.25, 0.00001, 0.00001, 0.00001]
+      # Exponential velocity decay rate (1/s). Predicted velocity decays toward zero when the
+      # odometry source goes silent (e.g., after a nav2 controller deactivates), preventing
+      # indefinite drift. Set to 0.0 to disable. With k=1.0, velocity halves in ~0.7s.
+      velocity_decay: 1.0
 
     sensor_models:
       initial_localization_sensor:


### PR DESCRIPTION
## Summary

Enables \`velocity_decay: 1.0\` in \`hangar_sim/config/fuse/fuse.yaml\` to use the new parameter added in PickNikRobotics/fuse#34.

Fixes the fuse estimate drifting diagonally after a nav2 Objective completes and \`platform_velocity_controller_nav2\` deactivates. Tracked in PickNikRobotics/moveit_pro#18070.

**Depends on PickNikRobotics/moveit_pro#19565 being merged first** (Dockerfile bump that pulls in the new fuse binary with \`velocity_decay\` support).

## Claude agent checks
- [x] code-reviewer
- [x] test-runner
- [x] platform-architect-bot