### PR TITLE
Fix: Skip Teleoperate and ML Segment Point Cloud in CI integration tests

### DIFF
--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -50,7 +50,6 @@ cancel_objectives = {
     "Plan and Save Trajectory",
     "Record and Replay Scanning Motion",
     "Stationary Admittance",
-    "Teleoperate",
 }
 
 # Objectives to skip entirely from integration testing
@@ -62,6 +61,7 @@ skip_objectives = {
     "ML Find Bottles on Table from Image Exemplar",  # Skipped because it looks for a file on a home path
     "ML Segment Image",
     "ML Segment Image Loop",
+    "ML Segment Point Cloud",  # Requires GPU for ONNX inference; falls back to CPU and times out waiting for /wrist_camera/points on CI runners without a camera warmup delay.
     "ML Segment Point Cloud from Clicked Point",
     "MPC Pose Tracking",
     "MPC Pose Tracking With Point Cloud Avoidance",
@@ -80,6 +80,10 @@ skip_objectives = {
     "Stitch Multiple Point Clouds Together",
     "Marker Visualization Example",  # Server not available for GetTextFromUser
     "Register CAD Part",  # TODO: remove this for 9.2.0 and fix it correctly
+    # DoTeleoperateAction immediately rejects the goal when no UI tab is subscribed to
+    # /moveit_pro_ui/do_teleoperate/goal. The objective never reaches RUNNING status, so
+    # the cancel flow times out. This is a headless-CI limitation, not a bug in the objective.
+    "Teleoperate",
 }
 
 


### PR DESCRIPTION
## Problem

**Jazzy** has been failing every CI run on the `Teleoperate` objective. **Humble** has intermittent failures on `Teleoperate` and `ML Segment Point Cloud`, plus occasional CTest 600 s timeouts.

### Jazzy — Teleoperate (constant)

`DoTeleoperateAction` on Jazzy immediately rejects the goal when no UI tab is subscribed to `/moveit_pro_ui/do_teleoperate/goal`:

```
[ui_teleop_bridge-17] [WARN] Rejecting /do_teleoperate goal: no UI tab is subscribed to /moveit_pro_ui/do_teleoperate/goal.
[objective_server_node_main-14] [ERROR] DoTeleoperateAction Error: Failed to send goal request to action server: Goal request was rejected by the action server
```

The objective errors out immediately, never reaches `RUNNING` status, and the cancel-objective flow times out with:

```
Failed: Objective 'Teleoperate' did not reach RUNNING status within 30.0s; cannot exercise cancel.
```

### Humble — Teleoperate (intermittent) + ML Segment Point Cloud

The same UI-rejection failure occurs on Humble when the bridge is slow to start (race condition). Additionally, `ML Segment Point Cloud` fails with `error_code 99999` because:

1. ONNX falls back to CPU (no GPU on CI runners): `Falling back to CPU execution provider`
2. CPU inference blocks the thread long enough that `GetPointCloud` times out waiting for `/wrist_camera/points` (10 s topic wait)

Both failures also eat into the 600 s CTest budget. The base test suite takes ~452 s; any single slow or hanging test tips it over the limit.

## Approach

Move `"Teleoperate"` and `"ML Segment Point Cloud"` from their current sets to `skip_objectives`. This matches the existing pattern for objectives that require UI interaction (`"ML Auto Grasp Object from Clicked Point"`, `"Stack Objects with ICP"`) or GPU/hardware resources (`"ML Segment Image"`, `"MPC Pose Tracking"`).

`"Teleoperate"` was added to `cancel_objectives` in PR #[commit 4003c6ff] but the `DoTeleoperateAction` behavior change in the Jazzy image introduced the unconditional rejection when no UI is present — this is a headless-CI limitation, not a bug in the objective itself.

## Release notes

None
