### PR TITLE
Standardize MuJoCo camera resolution to 1280x720 across robot configs

### DIFF
--- a/src/april_tag_sim/description/scene.xml
+++ b/src/april_tag_sim/description/scene.xml
@@ -8,6 +8,14 @@
 
   <option integrator="implicitfast" />
 
+  <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
+       (picknik_mujoco_ros cameras.cpp). Single shared buffer for all cameras,
+       so the scene_camera below plus wrist_camera (1280x720) from the ur5e
+       include must all be 1280x720, or ros2_control_node aborts on load. -->
+  <visual>
+    <global offwidth="1280" offheight="720" />
+  </visual>
+
   <asset>
     <mesh name="cube" file="assets/Cube.stl" />
   </asset>
@@ -39,7 +47,7 @@
       pos="-1.0 -2.0 2.966"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       euler="0.849 0.000 0.0"
     />
     <!-- lab desk -->

--- a/src/dual_arm_sim/description/mujoco/scene.xml
+++ b/src/dual_arm_sim/description/mujoco/scene.xml
@@ -6,7 +6,13 @@
   <size nuser_jnt="0" />
 
   <visual>
-    <global azimuth="120" elevation="-21" fovy="58" />
+    <global
+      azimuth="120"
+      elevation="-21"
+      fovy="58"
+      offwidth="1280"
+      offheight="720"
+    />
     <headlight ambient="0.3 0.3 0.3" diffuse="0.6 0.6 0.6" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
   </visual>
@@ -53,7 +59,7 @@
       pos="0.7 0.0 0.65"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       xyaxes="0 -1 0 1 0 0"
     />
     <geom

--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -53,7 +53,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <!-- Add Fanuc support files -->
@@ -74,7 +74,7 @@
       pos="-1.046 1.252 2.019"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       xyaxes="-0.607 -0.795 0.000 0.555 -0.424 0.715"
     />
     <site
@@ -88,7 +88,7 @@
       pos="-0.25 0.6 0.85"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       xyaxes="0 -1 0 1 0 0"
     />
     <site

--- a/src/grinding_sim/description/scene.xml
+++ b/src/grinding_sim/description/scene.xml
@@ -95,7 +95,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <worldbody>
@@ -136,7 +136,7 @@
       pos="0.0 -2.56685 1.62333"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       quat="0.916616 0.399763 -0.000804 -0.001843"
     />
 

--- a/src/kitchen_sim/description/mujoco/scene.xml
+++ b/src/kitchen_sim/description/mujoco/scene.xml
@@ -16,7 +16,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <asset>
@@ -62,7 +62,7 @@
     <camera
       name="scene_camera"
       fovy="48"
-      resolution="640 480"
+      resolution="1280 720"
       pos="-0.476 -0.378 2.733"
       xyaxes="0.510 -0.860 0.000 0.666 0.395 0.633"
     />
@@ -77,7 +77,7 @@
     <camera
       name="back_camera"
       fovy="48"
-      resolution="640 480"
+      resolution="1280 720"
       pos="-0.661 0.324 1.325"
       xyaxes="0.026 -1.000 0.000 0.062 0.002 0.998"
     />

--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -84,10 +84,13 @@
     />
   </asset>
 
-  <!-- Set offscreen rendering resolution to match camera sensor resolution (640x480) so that
-       MuJoCo renders images at the correct size for the simulated wrist and scene cameras. -->
+  <!-- Offscreen buffer size. picknik_mujoco_ros (cameras.cpp) requires every
+       non-lidar camera's resolution to EXACTLY equal <global offwidth offheight>;
+       there is a single offscreen buffer shared by all cameras, so every camera
+       in this scene (scene_camera below, plus wrist_camera from the ur5e include)
+       must be 1280x720 to match. Mismatch aborts ros2_control_node on load. -->
   <visual>
-    <global offwidth="640" offheight="480" />
+    <global offwidth="1280" offheight="720" />
     <headlight ambient="0.3 0.3 0.3" diffuse="0.5 0.5 0.5" />
   </visual>
 
@@ -124,7 +127,7 @@
       pos="1.8 -0.495 1.0"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       xyaxes="0.586 0.810 0.000 -0.186 0.135 0.973"
       user="0"
     />

--- a/src/lab_sim/description/simple_scene.xml
+++ b/src/lab_sim/description/simple_scene.xml
@@ -4,6 +4,13 @@
   <include file="robotiq_2f85/robotiq2f85_globals.xml" />
   <compiler angle="radian" autolimits="true" />
   <option integrator="implicitfast" />
+  <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
+       (cameras.cpp). This scene pulls in wrist_camera (1280x720) via the ur5e
+       include, so the global must be 1280x720 too. Without it the buffer defaults
+       to 640x480 and extract_cameras aborts ros2_control_node on model load. -->
+  <visual>
+    <global offwidth="1280" offheight="720" />
+  </visual>
   <worldbody>
     <include file="ur5e/ur5e_linear_rail.xml" />
   </worldbody>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof.xml
@@ -320,7 +320,7 @@
                       pos="0.0 -0.056 -0.058"
                       fovy="58"
                       mode="fixed"
-                      resolution="640 480"
+                      resolution="1280 720"
                       quat="0.0 0.0 0.0 1.0"
                     />
                     <site

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof_rafti_fingers.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof_rafti_fingers.xml
@@ -320,7 +320,7 @@
                       pos="0.0 -0.056 -0.058"
                       fovy="58"
                       mode="fixed"
-                      resolution="640 480"
+                      resolution="1280 720"
                       quat="0.0 0.0 0.0 1.0"
                     />
                     <site

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
@@ -13,7 +13,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <asset>
@@ -58,7 +58,7 @@
       pos="-0.5 0.75 1.5"
       fovy="75"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       quat="0.365715 0.232986 -0.484157 -0.759975"
     />
     <site

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
@@ -8,7 +8,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <asset>
@@ -64,7 +64,7 @@
       pos="0.0 0.3 0.55"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       quat="0.365715 0.232986 -0.484157 -0.759975"
     />
     <site

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
@@ -8,7 +8,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <asset>
@@ -64,7 +64,7 @@
       pos="0.0 0.3 0.55"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       quat="0.365715 0.232986 -0.484157 -0.759975"
     />
     <site

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/gen3_7dof_body.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/gen3_7dof_body.xml
@@ -136,7 +136,7 @@
                     pos="0.0 -0.056 -0.058"
                     fovy="58"
                     mode="fixed"
-                    resolution="640 480"
+                    resolution="1280 720"
                     quat="0.0 0.0 0.0 1.0"
                   />
                   <site

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
@@ -12,7 +12,7 @@
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
-    <global azimuth="120" elevation="-20" />
+    <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
   </visual>
 
   <asset>
@@ -90,7 +90,7 @@
       pos="-0.3 0.3 1.0"
       fovy="58"
       mode="fixed"
-      resolution="640 480"
+      resolution="1280 720"
       euler="0 -1.0472 -1.5708"
     />
     <site
@@ -186,7 +186,7 @@
         pos="0.6 1 0"
         fovy="58"
         mode="fixed"
-        resolution="640 480"
+        resolution="1280 720"
         euler="1.5708 -2 0.0"
         user="1"
       />

--- a/src/picknik_accessories/mujoco_assets/ur5e/ur5e.xml
+++ b/src/picknik_accessories/mujoco_assets/ur5e/ur5e.xml
@@ -146,7 +146,7 @@
                   pos="0.0 0.2 0.05"
                   fovy="58"
                   mode="fixed"
-                  resolution="640 480"
+                  resolution="1280 720"
                   euler="1.57 0.0 0.0"
                 />
                 <!-- The camera optical frame should be set to the <camera> position rotated 180 degrees about its x-axis -->


### PR DESCRIPTION
This PR standardizes MuJoCo camera resolutions and offscreen render buffers across the workspace's robot configs.

## Problem

`picknik_mujoco_ros` (`cameras.cpp` `extract_cameras`) requires every non-lidar camera's `resolution` to **exactly equal** the scene's single `<visual><global offwidth offheight>` offscreen buffer — there is one shared buffer for all cameras, so they must all be the same size. Any camera that differs aborts `ros2_control_node` on model load with `terminate called ... MujocoException: Camera resolution mismatch`.

Camera/buffer sizes were inconsistent across configs:

| Config | Previous |
|---|---|
| `lunar_sim`, `hangar_sim` | already 1280×720 |
| `space_satellite_sim_camera_cal` | 1920×1080 (intentional — calibration data) |
| `picknik_accessories/ur5e` `wrist_camera` | 640×480 |
| everything else | 640×480 |

This surfaced as a `lab_sim` integration-test failure: bumping `lab_sim`'s `scene_camera` and global buffer to 1280×720 left the **shared** `ur5e` `wrist_camera` (pulled in via the `ur5e/ur5e.xml` include) at 640×480, so the two cameras in one scene could not both match the single buffer.

## Chosen approach

Make every non-lidar camera in a given scene — and that scene's global buffer — the same resolution.

- Every `<camera resolution="640 480">` in the workspace's MJCF bumped to `1280 720` (15 files, 17 camera tags), **including** the shared `picknik_accessories/ur5e/ur5e.xml` `wrist_camera`. This is the fix for the original CI failure.
- Every top-level scene's `<visual><global>` given matching `offwidth="1280" offheight="720"`: bumped `lab_sim`'s 640×480 global, and added the attributes to the existing `<global azimuth/elevation>` elements in 7 other scenes.
- Added a new `<visual><global offwidth="1280" offheight="720"/></visual>` to `april_tag_sim` (had no `<visual>` block) and to `lab_sim/description/simple_scene.xml` (the MPC model, which includes the now-1280×720 wrist camera but had no global — without it the buffer defaults to 640×480 and `extract_cameras` aborts).
- `space_satellite_sim_camera_cal` left at 1920×1080 (camera and global both, self-consistent — it has its own `gen3_7dof_body.xml` with a 1920×1080 wrist camera, separate from `space_satellite_sim`'s copy).

## Tradeoff

1280×720 is ~3× the pixels of 640×480, so each offscreen buffer and every published `image`/`depth`/`camera_info` grows ~3× per camera. Multi-camera scenes (kitchen, factory, space_satellite: 2 cameras each) push ~3× the bytes/frame through the render path and ROS image topics, raising per-tick render time and topic bandwidth on memory/GPU-constrained targets (e.g. Jetson). Accepted for uniformity and to match downstream vision/ML consumers' expected input size.

## Skipped

`phoebe_sim` (submodule `external_dependencies/phoebe_ws`) is **intentionally not included** — it needs a separate PR in `PickNikRobotics/phoebe_ws`. Its cameras were already 1280×720.
