### PR TITLE
Opt into the S3-backed Git LFS cache (moveit_pro_ci v0.5.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       # contents: read for checkout; id-token: write to assume the LFS cache role via OIDC.
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@67abf09bbe5b310a893850e476b261068c85960f # v0.5.0
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@e0e05a8de9a8d78e5ba58cd68ca254d3a41cc1d8 # v0.5.1
     with:
       image_tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
       colcon_test_args: "--executor sequential"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,11 @@ concurrency:
 
 jobs:
   integration-test-in-studio-container:
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@baf17129fd55f858b7965fb971fa333cf45463cb # v0.3.2
+    permissions:
+      # contents: read for checkout; id-token: write to assume the LFS cache role via OIDC.
+      contents: read
+      id-token: write
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@67abf09bbe5b310a893850e476b261068c85960f # v0.5.0
     with:
       image_tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
       colcon_test_args: "--executor sequential"
@@ -38,8 +42,14 @@ jobs:
       # PickNikRobotics/moveit_pro#18534 for the underlying flake history.
       mujoco_ci_timestep: "0.003"
       use_ccache: true
+      # Fetch Git LFS through the in-region S3 cache instead of a direct pull.
+      # Empty for fork PRs (which get no OIDC token / secrets) so they fall back
+      # to a normal direct LFS pull instead of failing the cache preflight.
+      lfs_cache_s3_bucket: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'picknik-arc-ci-ccache-682033501538' || '' }}
+      lfs_cache_aws_region: us-east-1
     secrets:
       moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
+      lfs_cache_role_arn: ${{ secrets.LFS_CACHE_ROLE_ARN }}
 
   # Turn the test-results artifact into a single-file HTML report (status,
   # timings, per-test ROS log slice with colors). Matrix on ros_distro because


### PR DESCRIPTION
## Motivation

Integration-test runs pull this workspace's large Git LFS set (~1.9 GB) on every job. `moveit_pro_ci` v0.5.0 added an opt-in S3-backed LFS cache to `workspace_integration_test.yaml`; this opts in so LFS is restored from S3 instead of pulled in full each run.

## Brief description

On the `integration-test-in-studio-container` job:
- Bump the reusable-workflow ref `v0.3.2` → `v0.5.0` (`67abf09`).
- Pass `lfs_cache_s3_bucket` + `lfs_cache_aws_region`, and the `lfs_cache_role_arn` secret.
- Grant `permissions: { contents: read, id-token: write }` (OIDC, for the cache role).
- **Fork-PR safe:** the bucket input is gated to same-repo events, so fork PRs (which get no OIDC token or secrets) fall back to a normal direct LFS pull instead of failing the cache preflight.

LFS content (including submodule LFS) and the default-pull behavior for everyone else are unchanged.

## Required before CI can use the cache

Set a repo secret on `moveit_pro_example_ws`:
- `LFS_CACHE_ROLE_ARN` = `arn:aws:iam::682033501538:role/picknik-arc-workspace-lfs-cache`

Without it, same-repo runs fail the cache preflight by design (clear error). (I did not create the secret — happy to, or you can.)

## How it was tested

`actionlint` + YAML + pre-commit. Ran `code-reviewer`, `platform-architect-bot`, `security-auditor`: input/secret names match v0.5.0, the SHA is v0.5.0, and `contents: read` + `id-token: write` is exactly sufficient (no permission regression). The security P1 (fork PRs hard-failing) is fixed by the bucket gating above. This PR's own CI exercises the one remaining unvalidated piece end-to-end: the `container:`-job OIDC → S3 LFS path.

## Note for review

The bucket name embeds the AWS account ID and is a plaintext input in this public repo. AWS treats account IDs as non-secret and this matches standard public GitHub-OIDC→AWS setups, so it's left as an input. If you'd prefer it hidden too, we can make `lfs_cache_s3_bucket` a secret in `moveit_pro_ci` (a small follow-up + re-release) — it would also make fork-PR fallback automatic (no secret → no cache).
