### PR TITLE
Decimate d415 camera mesh under the 10 MB URDF load gate

### DIFF
--- a/src/picknik_accessories/descriptions/sensors/d415.stl
+++ b/src/picknik_accessories/descriptions/sensors/d415.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eebb3fa4674b9f13eaed3d6de6612654f74d5cbee43f34fc979c143844eac3bf
+size 4250084

--- a/src/picknik_accessories/descriptions/sensors/realsense_d415.urdf.xacro
+++ b/src/picknik_accessories/descriptions/sensors/realsense_d415.urdf.xacro
@@ -55,7 +55,7 @@ aluminum peripheral evaluation case.
         <xacro:if value="${use_mesh}">
           <origin xyz="${d415_cam_mount_from_center_offset} ${-d415_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
           <geometry>
-            <mesh filename="package://realsense2_description/meshes/d415.stl" />
+            <mesh filename="package://picknik_accessories/descriptions/sensors/d415.stl" />
           </geometry>
         </xacro:if>
         <xacro:unless value="${use_mesh}">


### PR DESCRIPTION
## Problem

`realsense2_description`'s `d415.stl` is a 425k-triangle / 21 MB Catia export. MoveIt Pro's URDF loader hard-rejects any single visual mesh over 10 MB (moveit_pro#19448), so any config that renders the camera (`use_mesh=true`) fails to load in the 3D view with a "URDF Load Error … exceeds the recommended size of 10 MB" overlay.

The mesh is referenced from one shared file — `src/picknik_accessories/descriptions/sensors/realsense_d415.urdf.xacro` — consumed by the UR base config (`use_mesh` true unless gazebo), the Kinova configs, and the space-satellite sims.

## Change

- **Vendor a quadric-decimated `d415.stl`** into `picknik_accessories/descriptions/sensors/`: 425k → 85k triangles, 21 MB → ~4.1 MB. Bounding box preserved within ~0.5% (still the real ~99×23×20 mm D415 silhouette), clearing both the 10 MB and 100k-face caps. `realsense2_description` is apt-only (not vendored), so the mesh had to be brought in-repo.
- **Repoint the shared xacro** from `package://realsense2_description/meshes/d415.stl` to `package://picknik_accessories/descriptions/sensors/d415.stl` — fixes every consuming config in one line. `realsense2_description` stays a dependency for its `_materials` / `_usb_plug` xacro includes.

Source: decimated from the pristine 425,160-tri / 21,258,084-byte Intel D415 mesh that `realsense2_description` serves. Mirrors the equivalent change in `shelf_stocking_ws`.

## Out of scope

The `phoebe_ws` submodule has its own `package://realsense2_description/meshes/d415.stl` reference (`ur5e.macro.xacro`). It's a separate repo — fixing it needs a PR there plus a submodule bump, not done here.

## Verification

- All in-repo (non-submodule) `realsense2_description/meshes/d415.stl` references are repointed; vendored mesh has no NaNs and bbox within 0.5% of the original extent.

**Manual verification** (requires a rebuild — not yet run): `colcon build` a config that uses the wrist/scene camera, reload the backend, hard-refresh the browser, and confirm the robot renders with no URDF load error.