### PR TITLE
Brighten hangar_sim ladders and expand ML box subtrees by default

### DIFF
--- a/src/hangar_sim/description/hangar.xml
+++ b/src/hangar_sim/description/hangar.xml
@@ -399,7 +399,7 @@
           type="mesh"
           name="SM_Ladder_31 geom"
           mesh="SM_Ladder_31"
-          material="metal_hangar"
+          material="white_ladder"
         />
       </body>
     </body>
@@ -1334,7 +1334,7 @@
         type="mesh"
         name="SM_Ladder2 geom"
         mesh="SM_Ladder2"
-        material="metal_hangar"
+        material="white_ladder"
       />
     </body>
     <body
@@ -1347,7 +1347,7 @@
         type="mesh"
         name="SM_Ladder3 geom"
         mesh="SM_Ladder3"
-        material="metal_hangar"
+        material="white_ladder"
       />
     </body>
     <body
@@ -3429,6 +3429,12 @@
       rgba="0.25 0.25 0.25 1.0"
       reflectance="0.8960324823856354"
       metallic="0.7795275449752808"
+    />
+    <material
+      name="white_ladder"
+      rgba="0.95 0.95 0.95 1.0"
+      reflectance="0.5"
+      metallic="0.0"
     />
     <material
       name="glass"

--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -21,7 +21,7 @@
               <SubTree
                 ID="Move Boxes to Loading Zone Start from Waypoint"
                 waypoint_name="View Boxes"
-                _collapsed="true"
+                _collapsed="false"
                 threshold="0.25"
                 prompt="a small brown box"
                 negative_prompts="yellow ladder;"
@@ -34,7 +34,7 @@
                 waypoint_name="View Boxes 2"
                 place_pose="{place_pose}"
                 threshold="0.4"
-                _collapsed="true"
+                _collapsed="false"
                 prompts="small boxes"
                 negative_prompts="gray;gray;rails"
                 erosion_size="2"


### PR DESCRIPTION
Two small hangar_sim tweaks:

- **Ladders:** the three ladders (`SM_Ladder_31`, `SM_Ladder2`, `SM_Ladder3`) now use a new `white_ladder` material (`rgba="0.95 0.95 0.95 1.0"`) instead of the dark grey `metal_hangar`, so they stand out against the floor. Same reflectance/metallic, so they still read as polished metal. The other 84 geoms sharing `metal_hangar` are untouched.
- **`ML Move Boxes to Loading Zone` objective:** the two `Move Boxes to Loading Zone Start from Waypoint` subtrees now default to `_collapsed="false"` so they render expanded in the BT view instead of collapsed.

Before:
<img width="278" height="199" alt="image" src="https://github.com/user-attachments/assets/3fe5e26b-42dc-40f5-8c57-83cc0a5717ae" />


After:
<img width="424" height="332" alt="image" src="https://github.com/user-attachments/assets/3fcfacc9-880e-4796-bad9-cc277c1ff88d" />


## Release notes

None.