### PR TITLE
Standardize MuJoCo timestep across configs and drop CI scene-mutation override

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,12 +172,6 @@ jobs:
       # variant, so a pull failure here points at a missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true
-      # Re-assert MuJoCo timestep on CI as a backstop. Scene files in this repo
-      # are standardized to 0.003s, but this override catches any future scene
-      # whose include chain bypasses that standard, keeping the heavier 3.6.0
-      # constraint solver at-or-under realtime on CI runners. See
-      # PickNikRobotics/moveit_pro#18534 for the underlying flake history.
-      mujoco_ci_timestep: "0.003"
       use_ccache: true
       # Fetch Git LFS through the in-region S3 cache instead of a direct pull.
       # Empty for fork PRs (which get no OIDC token / secrets) so they fall back

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Each joint type contributes to qpos:
 
 After adding or removing bodies with joints, **remove the keyframe** and let MuJoCo use body `pos=` attributes for initial positions.
 
+### Velocity actuators: `armature/kv` time-constant must stay below the timestep
+
+A `<velocity kv="...">` actuator on a joint with `armature="..."` behaves like a first-order servo with time-constant `τ = armature / kv`. If `τ` is larger than the scene `timestep`, the servo cannot inject enough velocity correction per step to overcome external load, and the joint effectively **stops responding to commands** — it stays pinned near zero even at full command. The per-step velocity correction scales as `kv · timestep / armature`, so halving the timestep halves the authority.
+
+This bit `hangar_sim`'s mecanum base: the wheels had `armature="1.0"`, `kv="50"` → `τ = 0.02 s`. It worked only because the timestep was `0.025 s` (above τ). Standardizing the timestep to `0.003 s` dropped it well below τ, the wheel servos lost authority, the wheels pinned at ~0 rad/s, and the base would not drive (the whole-body `ExecuteTrajectory` then hung forever waiting for the base to reach goal). Fix was `kv: 50 → 500` (τ → 0.002 s, below the new timestep), verified in standalone MuJoCo to be stable across `timestep` 0.025→0.002. Lowering `armature` instead also raises authority but went unstable at small timesteps — prefer raising `kv`. (hangar's scene ultimately runs `timestep="0.008"`, coarser than the 0.003 s the other configs use: at 0.003 the CI runner overran ~47% of sim steps and starved controller mode-switching. `kv=500` keeps the wheels valid there too — τ=0.002 s < 0.008 s.)
+
+The two coupled numbers live in different files: the actuator `kv` is in the `<velocity>` blocks of `hangar_sim/description/ur5e_ridgeback.xml` (~line 1709), and the joint `armature` is in the per-wheel includes (`hangar_sim/description/{front,rear}_{left,right}_wheel_link.xml`, the wheel `<joint>`).
+
+Rule of thumb when changing a sim `timestep`: for every velocity actuator, check `armature/kv < timestep`. The symptom of violation is a joint that ignores commands (pinned), not one that oscillates.
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/src/april_tag_sim/description/scene.xml
+++ b/src/april_tag_sim/description/scene.xml
@@ -6,7 +6,7 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
        (picknik_mujoco_ros cameras.cpp). Single shared buffer for all cameras,

--- a/src/dual_arm_sim/description/mujoco/franka3.xml
+++ b/src/dual_arm_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="fanuc scene">
   <compiler angle="radian" autolimits="true" />
-  <option integrator="implicitfast" timestep="0.01">
+  <option integrator="implicitfast" timestep="0.003">
     <flag multiccd="enable" override="enable" />
   </option>
 

--- a/src/grinding_sim/description/scene.xml
+++ b/src/grinding_sim/description/scene.xml
@@ -1,6 +1,8 @@
 <mujoco model="ur20 grinding scene">
   <compiler angle="radian" autolimits="true" assetdir="grinding_sim_assets" />
 
+  <option integrator="implicitfast" timestep="0.003" />
+
   <default>
     <!-- Actuator & joint defaults -->
     <joint axis="0 0 1" range="-6.28319 6.28319" armature="0.5" />

--- a/src/hangar_sim/description/hangar_scene.xml
+++ b/src/hangar_sim/description/hangar_scene.xml
@@ -5,9 +5,16 @@
   <compiler angle="radian" meshdir="assets" autolimits="true" />
   <include file="ur5e_ridgeback.xml" />
   <include file="hangar.xml" />
+  <!-- hangar runs a heavier stack (nav2 / slam_toolbox / fuse + the mecanum
+       base) than the other configs, so it owns a coarser timestep than the
+       0.003 s standard: at 0.003 the CI runner overruns ~47% of sim steps,
+       which starves controller mode-switching and fails most motion
+       objectives. 0.008 keeps the runner at-or-under realtime while staying
+       finer than the original 0.025. Wheel velocity actuators still hold:
+       armature/kv = 1.0/500 = 0.002 s < 0.008 s (see CLAUDE.md). -->
   <option
     integrator="implicitfast"
-    timestep="0.025"
+    timestep="0.008"
     noslip_iterations="5"
     impratio="20"
     cone="elliptic"

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -1709,25 +1709,25 @@
       name="front_right_wheel"
       joint="front_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="front_left_wheel"
       joint="front_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_right_wheel"
       joint="rear_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_left_wheel"
       joint="rear_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
   </actuator>
 

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -16,6 +16,7 @@
   <depend>pluginlib</depend>
 
   <exec_depend>admittance_controller</exec_depend>
+  <exec_depend>clearpath_mecanum_drive_controller</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
@@ -26,6 +27,7 @@
   <exec_depend>picknik_ur_base_config</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>ridgeback_description</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>

--- a/src/kitchen_sim/description/mujoco/franka3.xml
+++ b/src/kitchen_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -6,7 +6,12 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" impratio="10" noslip_iterations="3" />
+  <option
+    integrator="implicitfast"
+    timestep="0.003"
+    impratio="10"
+    noslip_iterations="3"
+  />
 
   <!-- nuser_cam=1 enables per-camera user params: 0=RGB+Depth, 1=RGB-only, 2=3D-lidar -->
   <!-- memory: arena size for contacts/constraints. MuJoCo 3.3+ stopped growing the arena

--- a/src/lab_sim/description/simple_scene.xml
+++ b/src/lab_sim/description/simple_scene.xml
@@ -3,7 +3,12 @@
   <include file="ur5e/ur5e_linear_rail_globals.xml" />
   <include file="robotiq_2f85/robotiq2f85_globals.xml" />
   <compiler angle="radian" autolimits="true" />
-  <option integrator="implicitfast" />
+  <!-- timestep pins this top-level MPC scene to the 0.003 s standard. Required
+       now that the mujoco_ci_timestep CI override (which used to coarsen every
+       scene at build time) is gone: the JTAC/MPC compliance loop flakes when the
+       sim falls under realtime, and this scene is loaded by three non-skipped
+       mpc_pose_tracking objectives in the lab_sim integration test. -->
+  <option integrator="implicitfast" timestep="0.003" />
   <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
        (cameras.cpp). This scene pulls in wrist_camera (1280x720) via the ur5e
        include, so the global must be 1280x720 too. Without it the buffer defaults

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -73,7 +73,7 @@ skip_objectives = {
     "Place Object",
     # Flaky on CI after the MuJoCo 3.2.7 -> 3.6.0 upgrade: the JTAC compliance loop
     # is sensitive to the simulator falling under realtime, and we see ~50% flake
-    # rate even with mujoco_ci_timestep coarsening and CPU pinning. See PR #615.
+    # rate even with the 0.003 s scene timestep and CPU pinning. See PR #615.
     "Push Button With a Trajectory",
     "Record Square Trajectory",
     "Scan Scene - Multiple Point Clouds",

--- a/src/lunar_sim/mjcf/scene.xml
+++ b/src/lunar_sim/mjcf/scene.xml
@@ -1,4 +1,6 @@
 <mujoco model="lunar sim scene">
+  <option integrator="implicitfast" timestep="0.003" />
+
   <default>
     <default class="visual">
       <geom

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
@@ -1,6 +1,11 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
-  <option gravity="0 0 0" />
+  <!-- MuJoCo merges these three <option> blocks: timestep=0.003 (the standard),
+       gravity off, multiccd on, and integrator=implicit. The implicit integrator
+       (not the implicitfast used elsewhere) is intentional for the free-floating
+       zero-g satellite. Keep timestep on this first block; editing a later block
+       must not redeclare/clobber it. -->
+  <option timestep="0.003" gravity="0 0 0" />
   <option>
     <flag multiccd="enable" />
   </option>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
@@ -1,4 +1,5 @@
 <mujoco model="kinova scene">
+  <option timestep="0.003" />
   <include file="gen3_7dof_rafti_fingers.xml" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
@@ -1,5 +1,6 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
+  <option timestep="0.003" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>
     <geom solref=".004 1" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 


### PR DESCRIPTION
## Problem

Two issues, both surfaced while adding CI coverage for `hangar_sim`'s objectives:

1. **CI mutated scene files before build.** The reusable `workspace_integration_test` workflow was passed `mujoco_ci_timestep: "0.003"`, which rewrites every `<mujoco>`-rooted XML under `src/` before build, injecting `<option timestep="0.003"/>` after the opening tag. When a `<mujoco>`-rooted file is `<include>`d **inside a `<body>`** (e.g. `hangar_sim/description/vacuum.xml` at `ur5e_ridgeback.xml:1652`), the injected `<option>` lands inside a body element, which MuJoCo rejects (`Schema violation: unrecognized element 'option'`).
2. **`hangar_sim` had undeclared runtime dependencies.** Its UR5e-on-Ridgeback xacro `$(find ridgeback_description)` and its `platform_velocity_controller` (`clearpath_mecanum_drive_controller/MecanumDriveController`) were never declared in `package.xml`, so a `--packages-up-to hangar_sim` build doesn't install them.

## Approach

Stop CI from mutating scenes; let each scene own a CI-safe timestep. Three commits:

1. **`chore(sim)`: standardize the MuJoCo timestep to 0.003 s** directly in every robot config scene (absorbs #648). **Exception: `hangar_sim` owns `timestep="0.008"`** — its heavier stack (nav2 / slam_toolbox / fuse + the mecanum base) overran ~47% of sim steps at 0.003 on the GPU CI runner; 0.008 drops that to ~0.01% while staying finer than the original 0.025. The mecanum base also needed `wheel kv 50→500` (τ = armature/kv = 0.002 s, still below 0.008; documented in `CLAUDE.md`).
2. **`chore(hangar_sim)`: declare `ridgeback_description` and `clearpath_mecanum_drive_controller`** as exec dependencies so the description and the base controller plugin are present in a `--packages-up-to` build.
3. **`ci`: remove the now-redundant `mujoco_ci_timestep` override.** Every config self-declares its timestep, so the override — and its scene mutation — is unnecessary.

## hangar_sim integration test deferred to a follow-up

This PR originally also added `hangar_sim` to the CI integration-test matrix with a full objectives test (mirroring `lab_sim`). With the timestep, dependency, and scene-mutation issues fixed, the test was unblocked and **51/67 hangar objectives pass** — but ~8 whole-body motion objectives fail *flakily* (varying by distro, mostly sub-second `error_code 99999`) at 0.008 on the non-realtime CI runner. That's a deeper whole-body-planning/realtime investigation, so the test and its matrix entry are **split into a follow-up PR** rather than block this one or be papered over with broad skips. The standardization, dependency, and override fixes here are the prerequisites for that follow-up and stand on their own.

## Verification

- `mj_loadXML` of the standardized scenes loads clean with no injector; applying the CI injector now patches only the top-level `hangar_scene.xml` (loads fine).
- CI: lab_sim integration tests pass (humble + jazzy); no config's scenes are mutated at build time.
- `pre-commit run` passes on the full diff.

### Review follow-ups (also in this PR)

- **`lab_sim/description/simple_scene.xml` now self-declares `timestep="0.003"`.** This top-level MPC scene was the one entry-point the original diff missed: it had an `<option>` with no `timestep`, and it's loaded by three non-skipped `mpc_pose_tracking` objectives in the lab_sim integration test. With the `mujoco_ci_timestep` override gone, it would have silently fallen back to MuJoCo's 0.002 s default — finer than the standard and more likely to overrun realtime, the exact JTAC/MPC flake the override was coarsening. Pinning it keeps those three CI objectives at the standard.
- Stale `mujoco_ci_timestep` reference in `lab_sim/test/objectives_integration_test.py` updated to "the 0.003 s scene timestep" (the mechanism it named is removed in this PR).
- Comment added to the three merged `<option>` blocks in `kinova_sim/.../landsat_scene.xml` documenting that `timestep` lives on the first block and the `integrator="implicit"` (vs `implicitfast`) is intentional for the zero-g satellite — so a future edit to a later block doesn't clobber the timestep.

## Release notes

None — internal CI/config standardization and dependency declarations.

