### PR TITLE
Fix: Remove stale nested fanuc submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "src/external_dependencies/fanuc"]
 	path = src/external_dependencies/fanuc
 	url = https://github.com/PickNikRobotics/fanuc.git
-[submodule "src/picknik_accessories/src/dependencies/fanuc"]
-	path = src/picknik_accessories/src/dependencies/fanuc
-	url = https://github.com/PickNikRobotics/fanuc.git
 [submodule "src/external_dependencies/ros2_kortex_vision"]
 	path = src/external_dependencies/ros2_kortex_vision
 	url = https://github.com/PickNikRobotics/ros2_kortex_vision.git


### PR DESCRIPTION
PR #656 moved \`fanuc\` from \`src/picknik_accessories/src/dependencies/fanuc\` to \`src/external_dependencies/fanuc\` but left the old entry in \`.gitmodules\`. This caused \`git submodule update --init --recursive\` to fail with:

\`\`\`
error: submodule git dir '.../.git/modules/src/picknik_accessories/src/dependencies/fanuc' is inside git dir '.../.git/modules/src/picknik_accessories'
fatal: refusing to create/use '...' in another submodule's git dir
\`\`\`

Removes the stale \`.gitmodules\` entry and the dangling index reference.

## Release notes

None

## Claude agent checks
- [x] `code-reviewer` — no issues
- [x] `test-runner` — no tests applicable (config-only change)
- [x] `platform-architect-bot` — not applicable (no src/**, Dockerfile, or workflow changes)