### PR TITLE
Add hangar_sim objectives integration test in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,12 +172,6 @@ jobs:
       # variant, so a pull failure here points at a missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true
-      # Re-assert MuJoCo timestep on CI as a backstop. Scene files in this repo
-      # are standardized to 0.003s, but this override catches any future scene
-      # whose include chain bypasses that standard, keeping the heavier 3.6.0
-      # constraint solver at-or-under realtime on CI runners. See
-      # PickNikRobotics/moveit_pro#18534 for the underlying flake history.
-      mujoco_ci_timestep: "0.003"
       use_ccache: true
       # Fetch Git LFS through the in-region S3 cache instead of a direct pull.
       # Empty for fork PRs (which get no OIDC token / secrets) so they fall back

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,8 +150,8 @@ jobs:
       fail-fast: false
       matrix:
         # Stream 2 expands this list one PR at a time as each sim gains a
-        # pytest entry. Today only lab_sim has one.
-        config_package: [lab_sim]
+        # pytest entry. lab_sim and hangar_sim have one.
+        config_package: [lab_sim, hangar_sim]
     permissions:
       # contents: read for checkout; id-token: write so the reusable workflow
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
@@ -300,7 +300,7 @@ jobs:
         # Keep in sync with `integration-test.matrix.config_package` above and
         # with the reusable workflow's internal ros_distro matrix. Stream 2
         # expands `config_package` per sim; this matrix expands alongside.
-        config_package: [lab_sim]
+        config_package: [lab_sim, hangar_sim]
         ros_distro: [humble, jazzy]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Each joint type contributes to qpos:
 
 After adding or removing bodies with joints, **remove the keyframe** and let MuJoCo use body `pos=` attributes for initial positions.
 
+### Velocity actuators: `armature/kv` time-constant must stay below the timestep
+
+A `<velocity kv="...">` actuator on a joint with `armature="..."` behaves like a first-order servo with time-constant `τ = armature / kv`. If `τ` is larger than the scene `timestep`, the servo cannot inject enough velocity correction per step to overcome external load, and the joint effectively **stops responding to commands** — it stays pinned near zero even at full command. The per-step velocity correction scales as `kv · timestep / armature`, so halving the timestep halves the authority.
+
+This bit `hangar_sim`'s mecanum base: the wheels had `armature="1.0"`, `kv="50"` → `τ = 0.02 s`. It worked only because the timestep was `0.025 s` (above τ). Standardizing the timestep to `0.003 s` dropped it well below τ, the wheel servos lost authority, the wheels pinned at ~0 rad/s, and the base would not drive (the whole-body `ExecuteTrajectory` then hung forever waiting for the base to reach goal). Fix was `kv: 50 → 500` (τ → 0.002 s, below the new timestep), verified in standalone MuJoCo to be stable across `timestep` 0.025→0.002. Lowering `armature` instead also raises authority but went unstable at small timesteps — prefer raising `kv`. (hangar's scene ultimately runs `timestep="0.008"`, coarser than the 0.003 s the other configs use: at 0.003 the CI runner overran ~47% of sim steps and starved controller mode-switching. `kv=500` keeps the wheels valid there too — τ=0.002 s < 0.008 s.)
+
+The two coupled numbers live in different files: the actuator `kv` is in the `<velocity>` blocks of `hangar_sim/description/ur5e_ridgeback.xml` (~line 1709), and the joint `armature` is in the per-wheel includes (`hangar_sim/description/{front,rear}_{left,right}_wheel_link.xml`, the wheel `<joint>`).
+
+Rule of thumb when changing a sim `timestep`: for every velocity actuator, check `armature/kv < timestep`. The symptom of violation is a joint that ignores commands (pinned), not one that oscillates.
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/src/april_tag_sim/description/scene.xml
+++ b/src/april_tag_sim/description/scene.xml
@@ -6,7 +6,7 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <!-- Offscreen buffer must EXACTLY match every non-lidar camera resolution
        (picknik_mujoco_ros cameras.cpp). Single shared buffer for all cameras,

--- a/src/dual_arm_sim/description/mujoco/franka3.xml
+++ b/src/dual_arm_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="fanuc scene">
   <compiler angle="radian" autolimits="true" />
-  <option integrator="implicitfast" timestep="0.01">
+  <option integrator="implicitfast" timestep="0.003">
     <flag multiccd="enable" override="enable" />
   </option>
 

--- a/src/grinding_sim/description/scene.xml
+++ b/src/grinding_sim/description/scene.xml
@@ -1,6 +1,8 @@
 <mujoco model="ur20 grinding scene">
   <compiler angle="radian" autolimits="true" assetdir="grinding_sim_assets" />
 
+  <option integrator="implicitfast" timestep="0.003" />
+
   <default>
     <!-- Actuator & joint defaults -->
     <joint axis="0 0 1" range="-6.28319 6.28319" armature="0.5" />

--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -34,6 +34,22 @@ install(IMPORTED_RUNTIME_ARTIFACTS moveit_studio_plugins::dummy_controller_handl
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  # End-to-end objectives integration test. Mirrors lab_sim: launches the
+  # hangar_sim backend once and runs every runnable objective against it.
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them too -- the default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded. TIMEOUT and the heartbeat
+  # override are larger than lab_sim's because hangar_sim boots a heavier
+  # stack (nav2 / slam_toolbox / fuse) before the first objective can run.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 900
+          ENV MOVEIT_CONFIG_PACKAGE=hangar_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              MOVEIT_PRO_TEST_HEARTBEAT_TIMEOUT_S=300
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/hangar_sim/description/hangar_scene.xml
+++ b/src/hangar_sim/description/hangar_scene.xml
@@ -5,9 +5,16 @@
   <compiler angle="radian" meshdir="assets" autolimits="true" />
   <include file="ur5e_ridgeback.xml" />
   <include file="hangar.xml" />
+  <!-- hangar runs a heavier stack (nav2 / slam_toolbox / fuse + the mecanum
+       base) than the other configs, so it owns a coarser timestep than the
+       0.003 s standard: at 0.003 the CI runner overruns ~47% of sim steps,
+       which starves controller mode-switching and fails most motion
+       objectives. 0.008 keeps the runner at-or-under realtime while staying
+       finer than the original 0.025. Wheel velocity actuators still hold:
+       armature/kv = 1.0/500 = 0.002 s < 0.008 s (see CLAUDE.md). -->
   <option
     integrator="implicitfast"
-    timestep="0.025"
+    timestep="0.008"
     noslip_iterations="5"
     impratio="20"
     cone="elliptic"

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -1709,25 +1709,25 @@
       name="front_right_wheel"
       joint="front_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="front_left_wheel"
       joint="front_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_right_wheel"
       joint="rear_right_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
     <velocity
       name="rear_left_wheel"
       joint="rear_left_wheel"
       ctrlrange="-15 15"
-      kv="50"
+      kv="500"
     />
   </actuator>
 

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -41,6 +41,11 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>control_msgs</test_depend>
+  <test_depend>moveit_pro_test_utils</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -16,6 +16,7 @@
   <depend>pluginlib</depend>
 
   <exec_depend>admittance_controller</exec_depend>
+  <exec_depend>clearpath_mecanum_drive_controller</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
@@ -26,6 +27,7 @@
   <exec_depend>picknik_ur_base_config</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>ridgeback_description</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>

--- a/src/hangar_sim/test/capture_rosout.py
+++ b/src/hangar_sim/test/capture_rosout.py
@@ -1,0 +1,116 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Standalone /rosout → NDJSON capture, invoked as a subprocess from
+src/hangar_sim/test/conftest.py.
+
+Runs in its own process so no rclpy state lives in the pytest process. The
+integration test's ``execute_objective_resource`` fixture (in
+moveit_pro_test_utils/objective_test_fixture.py) launches the backend via
+``multiprocessing.Process(target=run_launch_files).start()`` — on Linux that
+forks pytest. If pytest has called ``rclpy.init()`` at fork time, the child
+inherits the DDS participant's FDs but not its spinner thread, leaving DDS
+discovery half-initialized; /robot_description then never reaches
+move_group / objective_server_node and BehaviorContext SIGABRTs on boot.
+
+Subscribes to /rosout with the same QoS the rcl logging publisher uses
+(depth=1000, RELIABLE, TRANSIENT_LOCAL, KEEP_LAST). Writes one JSON object
+per line to ``$ROS_LOG_DIR/rosout.ndjson`` (fallback: current dir).
+"""
+
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import rclpy
+from rcl_interfaces.msg import Log
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+# Log message severity byte → ROS log level name. Use literal ints rather
+# than `Log.DEBUG` etc. — the message constants are numpy uint8 in some
+# rclpy builds, which hash differently from Python int and miss the dict
+# lookup, leaving levels in the NDJSON as bare numbers like "30".
+_LEVEL_NAMES = {10: "DEBUG", 20: "INFO", 30: "WARN", 40: "ERROR", 50: "FATAL"}
+
+# Match the /rosout publisher's QoS exactly so a late-joining subscriber gets
+# replayed history (TRANSIENT_LOCAL) up to the publisher's depth. ROS 2's rcl
+# logging handler publishes /rosout with depth=1000 / RELIABLE /
+# TRANSIENT_LOCAL / KEEP_LAST. If the subscriber is VOLATILE, no historical
+# replay happens even if the publisher stores history — both ends must opt in.
+_ROSOUT_QOS = QoSProfile(
+    depth=1000,
+    history=HistoryPolicy.KEEP_LAST,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+
+def main() -> int:
+    out_dir = Path(os.environ.get("ROS_LOG_DIR", "."))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "rosout.ndjson"
+
+    write_lock = threading.Lock()
+
+    rclpy.init()
+    node = rclpy.create_node("test_rosout_capture")
+
+    with open(out_path, "w", encoding="utf-8") as out_file:
+
+        def on_log(msg: Log) -> None:
+            ts = msg.stamp.sec + msg.stamp.nanosec / 1e9
+            entry = {
+                "ts": ts,
+                "level": _LEVEL_NAMES.get(msg.level, str(msg.level)),
+                "node": msg.name,
+                "msg": msg.msg,
+            }
+            with write_lock:
+                out_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                out_file.flush()  # don't lose the last lines on a crash
+
+        node.create_subscription(Log, "/rosout", on_log, _ROSOUT_QOS)
+
+        # rclpy.spin returns when SIGINT triggers rclpy.shutdown(); some
+        # rclpy versions surface that as KeyboardInterrupt instead.
+        try:
+            rclpy.spin(node)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            node.destroy_node()
+            if rclpy.ok():
+                rclpy.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hangar_sim/test/conftest.py
+++ b/src/hangar_sim/test/conftest.py
@@ -1,0 +1,112 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Live per-objective progress + structured /rosout capture for the
+objectives integration test.
+
+Pytest's default ``--capture=fd`` redirects fds 1 and 2, so when CTest kills
+the test on timeout (TIMEOUT 900 in CMakeLists.txt) all per-test output is
+lost and the CI log shows nothing past pytest's "collected N items" header.
+
+The runtest hooks write directly to fd 2, bypassing the capture, so the CI
+log always shows which objective was running when the timeout fired and how
+long each completed objective took.
+
+The ``capture_rosout`` fixture launches ``capture_rosout.py`` as a
+subprocess so no rclpy state lives in the pytest process. The integration
+test's ``execute_objective_resource`` fixture (in
+moveit_pro_test_utils/objective_test_fixture.py) starts the backend via
+``multiprocessing.Process(target=run_launch_files).start()`` — on Linux
+that forks pytest. Any rclpy.init() called in pytest beforehand leaves the
+forked child with a half-initialized DDS participant (FDs inherited, the
+spinner thread does not survive fork), which breaks /robot_description
+discovery and causes BehaviorContext to SIGABRT on backend boot.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_started_at: dict[str, float] = {}
+
+
+def pytest_runtest_logstart(nodeid, location):
+    _started_at[nodeid] = time.monotonic()
+    os.write(2, f"  START   {nodeid}\n".encode())
+
+
+def pytest_runtest_logreport(report):
+    if report.when != "call":
+        return
+    nodeid = report.nodeid
+    start = _started_at.get(nodeid)
+    elapsed_str = f"{time.monotonic() - start:.1f}s" if start is not None else "n/a"
+    outcome = report.outcome.upper()  # PASSED / FAILED / SKIPPED
+    line = f"  {outcome:7s} {nodeid} ({elapsed_str})"
+    if report.failed and report.longrepr:
+        reason = str(report.longrepr).splitlines()[-1][:200]
+        line += f"\n    └─ {reason}"
+    os.write(2, (line + "\n").encode())
+
+
+@pytest.fixture(scope="session", autouse=True)
+def capture_rosout():
+    """Run capture_rosout.py as a subprocess to mirror /rosout to NDJSON.
+
+    Subprocess isolation is mandatory — see the module docstring for the
+    fork/DDS interaction that requires it. The subprocess has its own
+    process image, so any rclpy / DDS state it sets up never reaches the
+    pytest process that later gets forked by execute_objective_resource.
+
+    Creates ``$ROS_LOG_DIR`` synchronously here so the directory exists
+    before backend nodes (also writing into it) start, and so the
+    subprocess's first ``mkdir(exist_ok=True)`` has nothing to race on.
+    """
+    out_dir = Path(os.environ.get("ROS_LOG_DIR", "."))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    script = Path(__file__).parent / "capture_rosout.py"
+    proc = subprocess.Popen([sys.executable, str(script)])
+
+    try:
+        yield
+    finally:
+        # SIGINT triggers rclpy's default shutdown handler in the
+        # subprocess, which lets the script flush the NDJSON file before
+        # exiting. SIGKILL fallback in case the script wedges.
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -1,0 +1,118 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+    wait_for_action_servers,
+)
+
+# hangar_sim is MuJoCo-backed but is not in the harness's default reset
+# registry (only lab_sim and core_integration_config are). Register the
+# standard MuJoCo keyframe-reset hook at import time so the autouse
+# reset_simulation_before_test fixture resets the "default" keyframe between
+# tests instead of silently no-op'ing and letting state leak across tests.
+SIM_RESETTER.register("hangar_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through.
+cancel_objectives = {
+    "Move Boxes Looping",
+    "Plan Path Along Surface - Loop",
+}
+
+# Objectives to skip entirely from integration testing — either they need a
+# live operator interaction with no headless equivalent, or they can't run
+# at-or-under realtime on the CI runner within the per-objective timeout.
+skip_objectives = {
+    # --- Need live operator interaction (no headless equivalent in CI) ---
+    # GetPoseFromUser ("click a goal in the 3D Visualization pane") + nav2.
+    "Navigate to Clicked Point",
+    "Navigate to Clicked Point with Replanning",
+    # Reads pixel_coords from an unset blackboard key populated by a UI click.
+    "Segment Image from Point",
+    "Segment Point Cloud from Clicked Point",
+    # DoTeleoperateAction rejects the goal when no UI tab is subscribed to
+    # /moveit_pro_ui/do_teleoperate/goal (mirrors lab_sim skipping "Teleoperate").
+    "Teleoperate",
+    # GetTextFromUser server is not available headless (mirrors lab_sim skipping
+    # "Marker Visualization Example").
+    "Marker Visualization Example",
+    # --- Need ML models not present in CI ---
+    # Needs models/clip.onnx + models/clipseg.onnx from the moveit_pro_clipseg
+    # submodule, which is not checked out in CI (mirrors lab_sim skipping its
+    # "ML Segment *" objectives).
+    "Segment Image from Text Prompt",
+    # Needs ML perception models not available in CI; hits the 90 s per-objective
+    # timeout waiting on inference.
+    "ML Move Boxes to Loading Zone",
+    # --- Exceed the 90 s per-objective timeout on the CI runner ---
+    # Long whole-body cartesian/spray-coverage motions over the airplane that
+    # don't return within 90 s on the non-realtime CI runner (each consumed the
+    # full per-objective timeout in CI, driving the suite past its CTest budget).
+    "Cartesian Path with Collision Checking",
+    "Find and Spray Plane",
+    "Solution - Find and Spray Plane",
+}
+
+
+# ros2_control's gripper action must be live before any gripper objective is
+# runnable. Query it through the fixture's long-lived node instead of spinning
+# up a throwaway node + ActionClient per test, which would flood DDS discovery
+# on hangar_sim's already-busy graph (nav2 / slam_toolbox / fuse).
+VACUUM_GRIPPER_ACTION = "/vacuum_gripper/gripper_cmd"
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("hangar_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+):
+    wait_for_action_servers(
+        execute_objective_resource.node, [VACUUM_GRIPPER_ACTION], timeout_sec=180
+    )
+    try:
+        run_objective(objective_id, should_cancel, execute_objective_resource)
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during "
+            f"{mode}: {type(e).__name__}: {e}"
+        )

--- a/src/kitchen_sim/description/mujoco/franka3.xml
+++ b/src/kitchen_sim/description/mujoco/franka3.xml
@@ -1,7 +1,7 @@
 <mujoco model="fr3">
   <compiler angle="radian" meshdir="assets" />
 
-  <option integrator="implicitfast" timestep="0.005" />
+  <option integrator="implicitfast" timestep="0.003" />
 
   <default>
     <default class="fr3">

--- a/src/lab_sim/description/scene.xml
+++ b/src/lab_sim/description/scene.xml
@@ -6,7 +6,12 @@
 
   <compiler angle="radian" autolimits="true" />
 
-  <option integrator="implicitfast" impratio="10" noslip_iterations="3" />
+  <option
+    integrator="implicitfast"
+    timestep="0.003"
+    impratio="10"
+    noslip_iterations="3"
+  />
 
   <!-- nuser_cam=1 enables per-camera user params: 0=RGB+Depth, 1=RGB-only, 2=3D-lidar -->
   <!-- memory: arena size for contacts/constraints. MuJoCo 3.3+ stopped growing the arena

--- a/src/lunar_sim/mjcf/scene.xml
+++ b/src/lunar_sim/mjcf/scene.xml
@@ -1,4 +1,6 @@
 <mujoco model="lunar sim scene">
+  <option integrator="implicitfast" timestep="0.003" />
+
   <default>
     <default class="visual">
       <geom

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/landsat_scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
-  <option gravity="0 0 0" />
+  <option timestep="0.003" gravity="0 0 0" />
   <option>
     <flag multiccd="enable" />
   </option>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/rafti_fingers_scene.xml
@@ -1,4 +1,5 @@
 <mujoco model="kinova scene">
+  <option timestep="0.003" />
   <include file="gen3_7dof_rafti_fingers.xml" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/scene.xml
@@ -1,5 +1,6 @@
 <mujoco model="kinova scene">
   <include file="gen3_7dof.xml" />
+  <option timestep="0.003" />
   <statistic center="0.3 0 0.4" extent="1" />
   <default>
     <geom solref=".004 1" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/scene.xml
@@ -1,6 +1,6 @@
 <mujoco model="space satellite scene">
   <compiler angle="radian" meshdir="assets" />
-  <option integrator="implicitfast" gravity="0 0 0" />
+  <option integrator="implicitfast" timestep="0.003" gravity="0 0 0" />
 
   <include file="gen3_7dof_assets.xml" />
 


### PR DESCRIPTION
## Summary

Adds `hangar_sim` to the CI integration-test matrix and a full objectives test (mirroring `lab_sim`). Split out of #686, which carried the prerequisites this PR depends on.

**Stacked on #686** (`feat/hangar-sim-objectives-ci`) — base it there for review; **retarget to `main` once #686 merges**. The diff here is only the hangar test + matrix entries; #686 provides the timestep standardization (hangar @ 0.008), the `ridgeback_description` + `clearpath_mecanum_drive_controller` dependency declarations, and the `mujoco_ci_timestep` override removal.

## What this adds

- `src/hangar_sim/test/{objectives_integration_test.py, conftest.py, capture_rosout.py}` — runs all runnable hangar objectives, self-registers `MUJOCO_RESET_HOOK`, waits on the vacuum gripper action via the fixture's long-lived node, with a tuned `skip_objectives` list.
- `src/hangar_sim/CMakeLists.txt` — `ament_add_pytest_test` wiring (`TIMEOUT 900`, `HEARTBEAT 300`).
- `src/hangar_sim/package.xml` — test-only `<test_depend>`s.
- `.github/workflows/ci.yaml` — `hangar_sim` added to the `integration-test` and `render-report` `config_package` matrices.

## ⚠️ Known issue to resolve before merge

With the #686 fixes in place, hangar **collects and runs** (51/67 pass) and the 900 s CTest timeout is gone, but **~8 whole-body motion objectives fail flakily** on the GPU CI runner — mostly sub-second `error_code 99999`, with the failing set varying by distro (humble vs jazzy). The current `skip_objectives` already covers the clear headless/ONNX/90s-timeout cases (teleoperate, marker viz, ML move boxes, the cartesian/spray timeouts); the remaining fast-`99999` failures (e.g. `solution_move_forward_2m`, `solution_generate_coverage_path`, `point-to-point_trajectory`, `cartesian_draw_geometry_from_file`) look like genuine whole-body planning/control issues at 0.008 on the non-realtime runner, not just slowness.

This PR is **intentionally left for that investigation** — do not merge until the flaky motion objectives are either fixed or skipped with documented, justified reasons.

## Release notes

None — internal CI test coverage.
