### PR TITLE
Fix: Skip ewellix_examples to unblock Jazzy build

### DIFF
--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -31,6 +31,7 @@ build:
     - integration_launch_testing
     - phoebe_hw
     - phoebe_bridgeback_description
+    - ewellix_examples
 test:
   event-handlers:
     - console_direct+
@@ -50,3 +51,4 @@ test:
     - integration_launch_testing
     - phoebe_hw
     - phoebe_bridgeback_description
+    - ewellix_examples


### PR DESCRIPTION
## Problem

Building `moveit_pro_example_ws` with `MOVEIT_ROS_DISTRO=jazzy` fails at the rosdep install step:

```
ewellix_examples: Cannot locate rosdep definition for [ign_ros2_control]
```

`ewellix_examples` (vendored from `clearpathrobotics/ewellix_lift`) hardcodes an unconditional `ign_ros2_control` exec_depend. That package was renamed `gz_ros2_control` on Jazzy (Ignition→Gazebo), so rosdep cannot resolve it.

## Approach

Skip `ewellix_examples` in both the `build` and `test` `packages-skip` lists in `colcon-defaults.yaml`, matching how the `franka_*` and `phoebe_hw` packages are already excluded. Minimal, single-repo change.

The proper fix — a `$ROS_DISTRO`-conditional dep, like the sibling `kortex_description/package.xml` already uses — has to land in the third-party `ewellix_lift` repo three submodule levels down, then bump submodule pointers. Tracked in PickNikRobotics/moveit_pro#19620.

**Tradeoff:** `ewellix_examples` no longer builds on any distro. Acceptable since it is a Clearpath lift example not exercised by `lab_sim` / `hangar_sim`.

Refs PickNikRobotics/moveit_pro#19620