### PR TITLE
Migrate Objectives off deprecated collision Behaviors

### DIFF
--- a/src/factory_sim/objectives/automated_return_held_tool.xml
+++ b/src/factory_sim/objectives/automated_return_held_tool.xml
@@ -29,10 +29,10 @@
           return_tool="{tool_name}"
           tool_1_name="suction_gripper"
           tool_1_return_site="suction_gripper_holder_site"
-          ignore_collisions_between_these_objects_for_tool_1_return="link_5;link_6;suction_gripper"
+          tool_object_name_for_tool_1_return="suction_gripper"
           tool_2_name="inspector"
           tool_2_return_site="inspection_tool_holder_site"
-          ignore_collisions_between_these_objects_for_tool_2_return="link_5;link_6;inspector"
+          tool_object_name_for_tool_2_return="inspector"
         />
         <Decorator ID="ForceFailure">
           <Action

--- a/src/factory_sim/objectives/automated_return_tool_subtree.xml
+++ b/src/factory_sim/objectives/automated_return_tool_subtree.xml
@@ -17,7 +17,7 @@
             _collapsed="true"
             tool_name="{tool_1_name}"
             tool_return_site="{tool_1_return_site}"
-            ignore_collisions_between_these_objects="{ignore_collisions_between_these_objects_for_tool_1_return}"
+            tool_object_name="{tool_object_name_for_tool_1_return}"
           />
         </Decorator>
         <Decorator
@@ -30,7 +30,7 @@
             _collapsed="true"
             tool_name="{tool_2_name}"
             tool_return_site="{tool_2_return_site}"
-            ignore_collisions_between_these_objects="{ignore_collisions_between_these_objects_for_tool_2_return}"
+            tool_object_name="{tool_object_name_for_tool_2_return}"
           />
         </Decorator>
         <Decorator ID="ForceFailure">
@@ -52,16 +52,10 @@
       <inout_port name="return_tool" default="" />
       <inout_port name="tool_1_name" default="" />
       <inout_port name="tool_1_return_site" default="" />
-      <inout_port
-        name="ignore_collisions_between_these_objects_for_tool_1_return"
-        default=""
-      />
+      <inout_port name="tool_object_name_for_tool_1_return" default="" />
       <inout_port name="tool_2_name" default="" />
       <inout_port name="tool_2_return_site" default="" />
-      <inout_port
-        name="ignore_collisions_between_these_objects_for_tool_2_return"
-        default=""
-      />
+      <inout_port name="tool_object_name_for_tool_2_return" default="" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/factory_sim/objectives/automated_tool_changing_example_subtree.xml
+++ b/src/factory_sim/objectives/automated_tool_changing_example_subtree.xml
@@ -31,10 +31,10 @@
             return_tool="{tool_name}"
             tool_1_name="{tool_1_name}"
             tool_1_return_site="{tool_1_return_site}"
-            ignore_collisions_between_these_objects_for_tool_1_return="link_5;link_6;suction_gripper"
+            tool_object_name_for_tool_1_return="suction_gripper"
             tool_2_name="{tool_2_name}"
             tool_2_return_site="{tool_2_return_site}"
-            ignore_collisions_between_these_objects_for_tool_2_return="link_5;link_6;inspector"
+            tool_object_name_for_tool_2_return="inspector"
           />
           <SubTree
             ID="Automated Pickup Tool Subtree"

--- a/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
@@ -41,10 +41,25 @@
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
-        ID="SetupMTCIgnoreCollisionsBetweenObjects"
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="link_6"
         allow_collision="true"
         task="{mtc_task}"
-        object_names="link_5;link_6;suction_gripper"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_6"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
       />
       <Action
         ID="SetupMTCPlanToJointState"

--- a/src/factory_sim/objectives/pick_bracket_part_from_jig_subtree.xml
+++ b/src/factory_sim/objectives/pick_bracket_part_from_jig_subtree.xml
@@ -43,10 +43,25 @@
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
         <Action
-          ID="SetupMTCIgnoreCollisionsBetweenObjects"
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_5"
+          name_b="link_6"
           allow_collision="true"
           task="{mtc_task}"
-          object_names="link_5;link_6;suction_gripper"
+        />
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_5"
+          name_b="suction_gripper"
+          allow_collision="true"
+          task="{mtc_task}"
+        />
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_6"
+          name_b="suction_gripper"
+          allow_collision="true"
+          task="{mtc_task}"
         />
         <Action
           ID="SetupMTCMoveAlongFrameAxis"
@@ -94,10 +109,25 @@
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
         <Action
-          ID="SetupMTCIgnoreCollisionsBetweenObjects"
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_5"
+          name_b="link_6"
           allow_collision="true"
           task="{mtc_task}"
-          object_names="link_5;link_6;suction_gripper"
+        />
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_5"
+          name_b="suction_gripper"
+          allow_collision="true"
+          task="{mtc_task}"
+        />
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name_a="link_6"
+          name_b="suction_gripper"
+          allow_collision="true"
+          task="{mtc_task}"
         />
         <Action
           ID="SetupMTCMoveAlongFrameAxis"

--- a/src/factory_sim/objectives/pick_up_tool_from_holder.xml
+++ b/src/factory_sim/objectives/pick_up_tool_from_holder.xml
@@ -27,10 +27,25 @@
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
-        ID="SetupMTCIgnoreCollisionsBetweenObjects"
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="link_6"
         allow_collision="true"
         task="{mtc_task}"
-        object_names="link_5;link_6;suction_gripper"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_6"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
       />
       <Action
         ID="SetupMTCPlanToPose"

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -23,14 +23,31 @@
       <Decorator
         ID="Precondition"
         else="SUCCESS"
-        if="ignore_collisions_between_these_objects!=&quot;&quot;"
+        if="tool_object_name!=&quot;&quot;"
       >
-        <Action
-          ID="SetupMTCIgnoreCollisionsBetweenObjects"
-          allow_collision="true"
-          task="{mtc_task}"
-          object_names="{ignore_collisions_between_these_objects}"
-        />
+        <Control ID="Sequence">
+          <Action
+            ID="SetupMTCSetCollisionRule"
+            name_a="link_5"
+            name_b="link_6"
+            allow_collision="true"
+            task="{mtc_task}"
+          />
+          <Action
+            ID="SetupMTCSetCollisionRule"
+            name_a="link_5"
+            name_b="{tool_object_name}"
+            allow_collision="true"
+            task="{mtc_task}"
+          />
+          <Action
+            ID="SetupMTCSetCollisionRule"
+            name_a="link_6"
+            name_b="{tool_object_name}"
+            allow_collision="true"
+            task="{mtc_task}"
+          />
+        </Control>
       </Decorator>
       <Action
         ID="SetupMTCPlanToPose"
@@ -91,7 +108,7 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Grasping" />
       </MetadataFields>
-      <inout_port name="ignore_collisions_between_these_objects" default="" />
+      <inout_port name="tool_object_name" default="" />
       <inout_port name="tool_name" default="" />
       <inout_port name="tool_return_site" default="" />
     </SubTree>

--- a/src/factory_sim/objectives/tool_attachment_example.xml
+++ b/src/factory_sim/objectives/tool_attachment_example.xml
@@ -15,7 +15,6 @@
       <SubTree
         ID="Pick Up Tool from Holder"
         _collapsed="true"
-        ignore_collisions_between_these_objects=""
         tool_name="suction_gripper"
         tool_attach_site="suction_gripper_attach_site"
       />
@@ -23,7 +22,7 @@
       <SubTree
         ID="Place Tool in Tool Holder"
         _collapsed="false"
-        ignore_collisions_between_these_objects="link_5;link_6;suction_gripper"
+        tool_object_name="suction_gripper"
         tool_name="suction_gripper"
         tool_return_site="suction_gripper_holder_site"
       />

--- a/src/factory_sim/objectives/vacuum_drop_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/vacuum_drop_bracket_part_subtree.xml
@@ -24,10 +24,25 @@
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
-        ID="SetupMTCIgnoreCollisionsBetweenObjects"
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="link_6"
         allow_collision="true"
         task="{mtc_task}"
-        object_names="link_5;link_6;suction_gripper"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_6"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
       />
       <Action
         ID="SetupMTCPlanToPose"

--- a/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
@@ -32,10 +32,25 @@
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
-        ID="SetupMTCIgnoreCollisionsBetweenObjects"
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="link_6"
         allow_collision="true"
         task="{mtc_task}"
-        object_names="link_5;link_6;suction_gripper"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_5"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
+        name_a="link_6"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
       />
       <Action
         ID="SetupMTCPlanToPose"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -219,10 +219,10 @@
                     />
                     <Action ID="SetupMTCCurrentState" task="{task}" />
                     <Action
-                      ID="SetupMTCUpdateGroupCollisionRule"
+                      ID="SetupMTCSetCollisionRule"
                       allow_collision="true"
-                      group_name="gripper"
-                      object_name="&lt;octomap&gt;"
+                      name_a="gripper"
+                      name_b="&lt;octomap&gt;"
                       task="{task}"
                     />
                     <Action
@@ -261,7 +261,7 @@
                       ik_group="manipulator"
                       ik_timeout_s="0.01"
                       max_ik_solutions="1"
-                      monitored_stage="allow collision (&lt;octomap&gt;, gripper)"
+                      monitored_stage="allow collision (gripper, &lt;octomap&gt;)"
                       target_poses="{grasp_poses}"
                       task="{task}"
                     />

--- a/src/kitchen_sim/objectives/generate_graspable_object.xml
+++ b/src/kitchen_sim/objectives/generate_graspable_object.xml
@@ -100,11 +100,20 @@
         out="{graspable_object}"
         vector_in="{graspable_objects}"
       >
-        <Action
-          ID="ModifyObjectInPlanningScene"
-          apply_planning_scene_service="/apply_planning_scene"
-          object="{graspable_object}"
-        />
+        <Control ID="Sequence">
+          <Action
+            ID="UnpackGraspableObjectMessage"
+            graspable_object="{graspable_object}"
+            object="{collision_object}"
+            object_color="{object_color}"
+            grasp_info="{grasp_info}"
+          />
+          <Action
+            ID="AddCollisionObject"
+            collision_object="{collision_object}"
+            overwrite="true"
+          />
+        </Control>
       </Decorator>
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/add_table_to_planning_scene.xml
+++ b/src/lab_sim/objectives/add_table_to_planning_scene.xml
@@ -8,32 +8,17 @@
   >
     <Control ID="Sequence">
       <Action
-        ID="GetCurrentPlanningScene"
-        planning_scene_msg="{planning_scene}"
-      />
-      <Action
         ID="CreatePoseStamped"
         reference_frame="world"
         pose_stamped="{table_pose}"
         position_xyz="-0.076413; 0.97; 0.42;"
       />
       <Action
-        ID="CreateGraspableObject"
-        cuboid_object="{table_top}"
-        dx="2"
-        dy="1"
-        dz="0.100000"
-        generate_front_face="true"
-        generate_side_faces="true"
-        generate_top_face="true"
+        ID="AddCollisionBox"
         object_id="virtual_table_top"
+        dimensions="2;1;0.1"
         pose="{table_pose}"
-      />
-      <Action
-        ID="AddVirtualObjectToPlanningScene"
-        apply_planning_scene_service="/apply_planning_scene"
-        object="{table_top}"
-        planning_scene_msg="{planning_scene}"
+        overwrite="true"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
+++ b/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
@@ -18,23 +18,11 @@
         position_xyz="{offset}"
       />
       <Action
-        ID="CreateSolidPrimitiveBox"
-        solid_primitive="{solid_primitive}"
+        ID="AddCollisionBox"
+        object_id="{object_id}"
         dimensions="{dimensions}"
-      />
-      <Action
-        ID="CreateCollisionObjectFromSolidPrimitive"
-        collision_object="{collision_object}"
-        object_id="{object_id}"
         pose="{pose_stamped}"
-        solid_primitive="{solid_primitive}"
-      />
-      <SubTree
-        ID="AddCollisionObjectToPlanningScene"
-        _collapsed="false"
-        collision_object="{collision_object}"
-        pose="{pose_stamped}"
-        object_id="{object_id}"
+        overwrite="true"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/addcollisionobjecttoplanningscene.xml
+++ b/src/lab_sim/objectives/addcollisionobjecttoplanningscene.xml
@@ -3,40 +3,14 @@
   <!--//////////-->
   <BehaviorTree
     ID="AddCollisionObjectToPlanningScene"
-    _description="Adds a collision box to the planning scene  with the specified ID and pose."
+    _description="Adds a prebuilt CollisionObject to the planning scene and verifies that it is present."
     _favorite="false"
   >
     <Control ID="Sequence">
       <Action
-        ID="CreateGraspableObject"
-        cuboid_object="{cuboid_object}"
-        dx="0.100000"
-        dy="0.100000"
-        dz="0.100000"
-        generate_front_face="false"
-        generate_side_faces="false"
-        generate_top_face="false"
-        object_id="{object_id}"
-        pose="{pose}"
-      />
-      <Action
-        ID="UnpackGraspableObjectMessage"
-        grasp_info="{grasp_info}"
-        graspable_object="{cuboid_object}"
-        object="{object}"
-        object_color="{object_color}"
-      />
-      <Action
-        ID="CreateGraspableObjectMessage"
-        grasp_info="{grasp_info}"
-        graspable_object="{graspable_object}"
-        object="{collision_object}"
-        object_color="{object_color}"
-      />
-      <Action
-        ID="ModifyObjectInPlanningScene"
-        apply_planning_scene_service="/apply_planning_scene"
-        object="{graspable_object}"
+        ID="AddCollisionObject"
+        collision_object="{collision_object}"
+        overwrite="true"
       />
       <Action
         ID="GetCurrentPlanningScene"
@@ -57,13 +31,9 @@
       </MetadataFields>
       <inout_port name="collision_object" default="{collision_object}" />
       <inout_port name="object_id" default="" type="std::string">
-        ID of collision object in the planning scene
+        ID used to verify the object was added; must match the id field of the
+        wired collision_object.
       </inout_port>
-      <inout_port
-        name="pose"
-        default="{pose_stamped}"
-        type="geometry_msgs::msg::PoseStamped_&lt;std::allocator&lt;void&gt; &gt;"
-      />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
+++ b/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
@@ -66,13 +66,6 @@
           />
           <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />
           <Action
-            ID="SetupMTCUpdateGroupCollisionRule"
-            allow_collision="true"
-            object_name="&lt;octomap&gt;"
-            task="{move_to_pose_task}"
-            group_name="gripper"
-          />
-          <Action
             ID="SetupMTCPlanToPose"
             acceleration_scale_factor="1.000000"
             ik_frame="grasp_link"

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -8,10 +8,6 @@
     <Control ID="Sequence" _collapsed="false">
       <!--Add collision wall at the back of the table to prevent the arm from hitting the shelf-->
       <Action
-        ID="GetCurrentPlanningScene"
-        planning_scene_msg="{planning_scene}"
-      />
-      <Action
         ID="CreatePoseStamped"
         reference_frame="world"
         pose_stamped="{back_wall_pose}"
@@ -19,22 +15,11 @@
         orientation_xyzw="0.000000;0.000000;0.000000;1.000000"
       />
       <Action
-        ID="CreateGraspableObject"
-        cuboid_object="{back_wall_object}"
-        dx="2.0"
-        dy="0.05"
-        dz="1.0"
-        generate_front_face="false"
-        generate_side_faces="false"
-        generate_top_face="false"
-        object_id="back_wall"
+        ID="AddCollisionBox"
+        object_id="virtual_back_wall"
+        dimensions="2.0;0.05;1.0"
         pose="{back_wall_pose}"
-      />
-      <Action
-        ID="AddVirtualObjectToPlanningScene"
-        apply_planning_scene_service="/apply_planning_scene"
-        object="{back_wall_object}"
-        planning_scene_msg="{planning_scene}"
+        overwrite="true"
       />
       <Control
         ID="Sequence"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
@@ -222,13 +222,6 @@
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
-        ID="SetupMTCUpdateGroupCollisionRule"
-        group_name="gripper"
-        object_name="&lt;octomap&gt;"
-        allow_collision="true"
-        task="{mtc_task}"
-      />
-      <Action
         ID="SetupMTCMoveAlongFrameAxis"
         task="{mtc_task}"
         hand_frame="grasp_link"

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/detect_fixed_handle_graspable_object.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/detect_fixed_handle_graspable_object.xml
@@ -99,9 +99,16 @@
         log_level="info"
       />
       <Action
-        ID="ModifyObjectInPlanningScene"
-        object="{handle_object}"
-        apply_planning_scene_service="/apply_planning_scene"
+        ID="UnpackGraspableObjectMessage"
+        graspable_object="{handle_object}"
+        object="{collision_object}"
+        object_color="{object_color}"
+        grasp_info="{grasp_info}"
+      />
+      <Action
+        ID="AddCollisionObject"
+        collision_object="{collision_object}"
+        overwrite="true"
       />
     </Control>
   </BehaviorTree>

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button.xml
@@ -54,14 +54,6 @@
           </Control>
         </Decorator>
         <Action
-          ID="SetupMTCUpdateGroupCollisionRule"
-          name="AllowGripperCollisionWithOctomap"
-          group_name="gripper"
-          object_name="&lt;octomap&gt;"
-          allow_collision="true"
-          task="{push_button_task}"
-        />
-        <Action
           ID="SetupMTCMoveAlongFrameAxis"
           task="{push_button_task}"
           hand_frame="grasp_link"
@@ -74,14 +66,6 @@
           planning_group_name="manipulator"
           velocity_scale="0.05"
           acceleration_scale="0.05"
-        />
-        <Action
-          ID="SetupMTCUpdateGroupCollisionRule"
-          name="ForbidGripperCollisionWithOctomap"
-          group_name="gripper"
-          object_name="&lt;octomap&gt;"
-          allow_collision="false"
-          task="{push_button_task}"
         />
         <Action
           ID="PlanMTCTask"

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/push_button_ml.xml
@@ -105,10 +105,10 @@
           task="{push_along_axis_task}"
         />
         <Action
-          ID="SetupMTCUpdateGroupCollisionRule"
+          ID="SetupMTCSetCollisionRule"
           name="AllowGripperCollisionWithOctomap"
-          group_name="gripper"
-          object_name="&lt;octomap&gt;"
+          name_a="gripper"
+          name_b="&lt;octomap&gt;"
           allow_collision="true"
           task="{push_along_axis_task}"
         />
@@ -127,10 +127,10 @@
           acceleration_scale="0.05"
         />
         <Action
-          ID="SetupMTCUpdateGroupCollisionRule"
+          ID="SetupMTCSetCollisionRule"
           name="ForbidGripperCollisionWithOctomap"
-          group_name="gripper"
-          object_name="&lt;octomap&gt;"
+          name_a="gripper"
+          name_b="&lt;octomap&gt;"
           allow_collision="false"
           task="{push_along_axis_task}"
         />
@@ -172,6 +172,7 @@
         ID="Retreat To Initial Pose"
         pre_approach_robot_state="{pre_approach_robot_state}"
         initial_robot_state="{initial_robot_state}"
+        octomap_present="true"
         _collapsed="true"
       />
     </Control>

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
@@ -8,28 +8,40 @@
         task="{retreat_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{retreat_task}" />
-      <Action
-        ID="SetupMTCUpdateGroupCollisionRule"
-        name="AllowGripperCollisionWithOctomap"
-        group_name="gripper"
-        object_name="&lt;octomap&gt;"
-        allow_collision="true"
-        task="{retreat_task}"
-      />
+      <Decorator
+        ID="Precondition"
+        else="SUCCESS"
+        if="octomap_present == &quot;true&quot;"
+      >
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name="AllowGripperCollisionWithOctomap"
+          name_a="gripper"
+          name_b="&lt;octomap&gt;"
+          allow_collision="true"
+          task="{retreat_task}"
+        />
+      </Decorator>
       <Action
         ID="SetupMTCCartesianMoveToJointState"
         joint_state="{pre_approach_robot_state}"
         planning_group_name="manipulator"
         task="{retreat_task}"
       />
-      <Action
-        ID="SetupMTCUpdateGroupCollisionRule"
-        name="ForbidGripperCollisionWithOctomap"
-        group_name="gripper"
-        object_name="&lt;octomap&gt;"
-        allow_collision="false"
-        task="{retreat_task}"
-      />
+      <Decorator
+        ID="Precondition"
+        else="SUCCESS"
+        if="octomap_present == &quot;true&quot;"
+      >
+        <Action
+          ID="SetupMTCSetCollisionRule"
+          name="ForbidGripperCollisionWithOctomap"
+          name_a="gripper"
+          name_b="&lt;octomap&gt;"
+          allow_collision="false"
+          task="{retreat_task}"
+        />
+      </Decorator>
       <Action
         ID="SetupMTCPlanToJointState"
         joint_state="{initial_robot_state}"
@@ -55,6 +67,10 @@
         default="{pre_approach_robot_state}"
       />
       <input_port name="initial_robot_state" default="{initial_robot_state}" />
+      <input_port name="octomap_present" default="false">
+        Set to "true" only when an octomap has been built earlier in the
+        objective; otherwise the gripper/octomap collision rules are skipped.
+      </input_port>
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>


### PR DESCRIPTION
## Summary

Updates `moveit_pro_example_ws` Objectives to stop using the deprecated GraspableObject-based collision Behaviors, so the example configs no longer emit collision-Behavior deprecation warnings.

## What changed

22 Objectives across 6 configs (`lab_sim`, `factory_sim`, `hangar_sim`, `kitchen_sim`, `kinova_sim`, `picknik_ur_site_config`), each deprecated Behavior swapped for its replacement per the collision-objects migration guide:

- `AddVirtualObjectToPlanningScene`, `CreateSolidPrimitiveBox` + `CreateCollisionObjectFromSolidPrimitive` → `AddCollisionBox`
- `ModifyObjectInPlanningScene` → `AddCollisionObject` (prebuilt object) or `UnpackGraspableObjectMessage` → `AddCollisionObject` (runtime-detected GraspableObject)
- `SetupMTCUpdateGroupCollisionRule`, `SetupMTCIgnoreCollisionsBetweenObjects` → `SetupMTCSetCollisionRule` (vector ignore-lists expand to explicit pairwise rules)

## `<octomap>` collision rules

The old `SetupMTCUpdateGroupCollisionRule` set the ACM entry by name and tolerated an absent octomap (no-op); the new `SetupMTCSetCollisionRule` resolves the name against the planning scene and fails if `<octomap>` isn't present. The rules were handled per whether an octomap actually exists, so this PR is self-contained:

- Removed where no octomap is ever built: `lab_sim/get_collision_free_grasp_subtree`, `kinova_sim/compliant_grasp_rafti_vfc`, and `push_button`'s own rules.
- Kept where the octomap is built first: `hangar_sim/move_boxes_to_loading_zone_from_waypoint` and `push_button_ml`.
- `retreat_to_initial_pose` is shared between a no-octomap caller (`push_button`) and an octomap caller (`push_button_ml`), so its rules are gated on a new `octomap_present` input port (default `false`); `push_button_ml` passes `"true"`.

Every remaining `SetupMTCSetCollisionRule(<octomap>)` runs only when an octomap is in the scene, so the migration does not depend on any behavior-side change.

## Manual verification

`lab_sim`, `factory_sim`, `kitchen_sim`, `hangar_sim` were run in simulation. `picknik_ur_site_config` is hardware-only and was validated by parse/load plus static review.
