### PR TITLE
build(kinova): add websockets + msgpack to the rollout client image deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       --from-paths src \
       --ignore-src
 
+# Python dependencies for the C0 Kinova rollout client (scripts/kinova/rollout.py).
+# The torch-free real-Kinova rollout client runs in the agent_bridge container and uses
+# `websockets` (sync) + `msgpack` to talk to the policy server. These are installed via pip
+# (rather than a rosdep key) because the Ubuntu Jammy apt `python3-websockets` is 9.1, which
+# does not satisfy the required `websockets>=13`. Baking them in here replaces the previous
+# ephemeral `pip install` workaround inside the running container.
+# hadolint ignore=DL3013
+RUN python3 -m pip install --no-cache-dir \
+      "websockets>=13" \
+      "msgpack>=1.0"
+
 # Set up colcon defaults for the new user
 USER ${USERNAME}
 RUN colcon mixin add default \


### PR DESCRIPTION
## What

Bake `websockets>=13` and `msgpack>=1.0` into the MoveIt Pro user-overlay Docker image via a `pip install` layer in the shared `base` stage of the workspace `Dockerfile`.

## Why

This is for the **C0 Kinova rollout client** (`scripts/kinova/rollout.py`) added in end-to-end PR #81 (`c0-kinova-rollout`). That client is a torch-free real-Kinova rollout client whose policy client uses `websockets` (sync) + `msgpack` to talk to a policy server. It runs inside the **agent_bridge container**, so its Python dependencies must live in the image.

This closes the open checklist item in end-to-end PR #81:

> Add msgpack + websockets to the agent_bridge container image so the client runs there.

Today those deps are only `pip install`ed ephemerally into the running container (`moveit_pro-dev-1`, image `moveit-studio-dev:main-humble`), so they vanish on every image rebuild. This change replaces that ephemeral workaround by baking them in at `moveit_pro build` time.

## How

The workspace `Dockerfile` `base` stage is shared by every service via Docker Compose `extends: base` (`base` builds from `context: ${STUDIO_HOST_USER_WORKSPACE}`), so the `agent_bridge` service inherits it. The deps are added with `pip install` right after the existing `rosdep install` step — the same place the Dockerfile already invites additional `pip`/`apt` installs.

### Why pip and not a rosdep key

`python3-websockets` / `python3-msgpack` are valid rosdep keys, but on the Ubuntu Jammy base (humble) the apt `python3-websockets` candidate is **9.1**, which does **not** satisfy the required `websockets>=13`. So `websockets` must come from pip to honor the version constraint; both are installed via pip for consistency.

## Versions

- `websockets>=13`
- `msgpack>=1.0`

(Match end-to-end PR #81's `pyproject`.)

## Validation

- `hadolint` (the repo's pre-commit Dockerfile linter, v2.14.0) passes with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)