### PR TITLE
Migrate deprecated AddToVector usages to PushBackVector

### DIFF
--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_-45.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_-45.xml
@@ -12,9 +12,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Control ID="Fallback">
         <Action

--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_0.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_0.xml
@@ -12,9 +12,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Control ID="Fallback">
         <Action

--- a/src/april_tag_sim/objectives/move_to_and_detect_tag_45.xml
+++ b/src/april_tag_sim/objectives/move_to_and_detect_tag_45.xml
@@ -12,9 +12,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Control ID="Fallback">
         <Action

--- a/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
+++ b/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
@@ -27,9 +27,10 @@
             point_cloud_fragment="{point_cloud_fragment}"
           />
           <Action
-            ID="AddPointCloudToVector"
-            point_cloud="{point_cloud_fragment}"
-            point_cloud_vector="{point_cloud_vector}"
+            ID="PushBackVector"
+            input_vector="{point_cloud_vector}"
+            element="{point_cloud_fragment}"
+            output_vector="{point_cloud_vector}"
           />
         </Control>
       </Decorator>

--- a/src/factory_sim/objectives/automask_camera_iterate_masks.xml
+++ b/src/factory_sim/objectives/automask_camera_iterate_masks.xml
@@ -30,9 +30,8 @@
         <Control ID="Sequence">
           <Action ID="Script" code="mask_label:=&quot;mask &quot;..index" />
           <SubTree ID="CreateVector" _collapsed="true" vector="{one_mask}" />
-          <SubTree
-            ID="AddToVector"
-            _collapsed="false"
+          <Action
+            ID="PushBackVector"
             element="{mask}"
             input_vector="{one_mask}"
             output_vector="{one_mask}"

--- a/src/factory_sim/objectives/look_for_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/look_for_bracket_part_subtree.xml
@@ -110,9 +110,10 @@
         />
         <Action ID="ResetVector" vector="{additional_clouds}" />
         <Action
-          ID="AddPointCloudToVector"
-          point_cloud="{green_bracket_part_cloud}"
-          point_cloud_vector="{additional_clouds}"
+          ID="PushBackVector"
+          input_vector="{additional_clouds}"
+          element="{green_bracket_part_cloud}"
+          output_vector="{additional_clouds}"
         />
         <SubTree
           ID="Visualize Bins and Jig Subtree"

--- a/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
@@ -34,9 +34,10 @@
           pose="{approach_pose}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{approach_pose}"
-          vector="{approach_candidate_pose_vector}"
+          ID="PushBackVector"
+          input_vector="{approach_candidate_pose_vector}"
+          element="{approach_pose}"
+          output_vector="{approach_candidate_pose_vector}"
         />
         <Decorator ID="Repeat" num_cycles="7">
           <Control ID="Sequence" name="">
@@ -48,9 +49,10 @@
               translation_xyz="0;0;0"
             />
             <Action
-              ID="AddPoseStampedToVector"
-              input="{approach_pose}"
-              vector="{approach_candidate_pose_vector}"
+              ID="PushBackVector"
+              input_vector="{approach_candidate_pose_vector}"
+              element="{approach_pose}"
+              output_vector="{approach_candidate_pose_vector}"
             />
             <Action ID="Script" code="approach_count += 1" />
             <Action

--- a/src/factory_sim/objectives/plan_and_execute_with_position_only.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_position_only.xml
@@ -25,9 +25,10 @@
         marker_size="0.100000"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{approach_pose}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{approach_pose}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="VisualizePose"
@@ -37,9 +38,10 @@
         marker_size="0.100000"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{target_pose}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{target_pose}"
+        output_vector="{pose_stamped_vector}"
       />
       <Decorator
         ID="ForceSuccess"

--- a/src/factory_sim/objectives/plan_path_along_surface.xml
+++ b/src/factory_sim/objectives/plan_path_along_surface.xml
@@ -106,10 +106,12 @@
         translation_xyz="0;0;-0.12"
       />
       <Control ID="Sequence">
+        <Action ID="ResetVector" vector="{ik_targets}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{first_pose}"
-          vector="{ik_targets}"
+          ID="PushBackVector"
+          input_vector="{ik_targets}"
+          element="{first_pose}"
+          output_vector="{ik_targets}"
         />
         <Action
           ID="InitializeMTCTask"

--- a/src/factory_sim/objectives/reachability_analysis_for_mesh.xml
+++ b/src/factory_sim/objectives/reachability_analysis_for_mesh.xml
@@ -73,9 +73,10 @@
               translation_xyz="0;0;0"
             />
             <Action
-              ID="AddPoseStampedToVector"
-              input="{output_pose}"
-              vector="{mesh_normal_poses_reoriented}"
+              ID="PushBackVector"
+              input_vector="{mesh_normal_poses_reoriented}"
+              element="{output_pose}"
+              output_vector="{mesh_normal_poses_reoriented}"
             />
           </Control>
         </Decorator>

--- a/src/factory_sim/objectives/reachability_analysis_for_plane.xml
+++ b/src/factory_sim/objectives/reachability_analysis_for_plane.xml
@@ -112,9 +112,10 @@
                   />
                 </Decorator>
                 <Action
-                  ID="AddPoseStampedToVector"
-                  input="{x_incremental_pose_rotated}"
-                  vector="{target_poses}"
+                  ID="PushBackVector"
+                  input_vector="{target_poses}"
+                  element="{x_incremental_pose_rotated}"
+                  output_vector="{target_poses}"
                 />
                 <Action
                   ID="TransformPose"

--- a/src/factory_sim/objectives/visualize_bins_and_jig_subtree.xml
+++ b/src/factory_sim/objectives/visualize_bins_and_jig_subtree.xml
@@ -53,14 +53,16 @@
       />
       <Action ID="ResetVector" vector="{bin_jig_cloud_vector}" />
       <Action
-        ID="AddPointCloudToVector"
-        point_cloud="{bin_table_cloud}"
-        point_cloud_vector="{bin_jig_cloud_vector}"
+        ID="PushBackVector"
+        input_vector="{bin_jig_cloud_vector}"
+        element="{bin_table_cloud}"
+        output_vector="{bin_jig_cloud_vector}"
       />
       <Action
-        ID="AddPointCloudToVector"
-        point_cloud="{jig_cloud}"
-        point_cloud_vector="{bin_jig_cloud_vector}"
+        ID="PushBackVector"
+        input_vector="{bin_jig_cloud_vector}"
+        element="{jig_cloud}"
+        output_vector="{bin_jig_cloud_vector}"
       />
       <Decorator
         ID="ForEach"
@@ -76,9 +78,10 @@
             target_frame="world"
           />
           <Action
-            ID="AddPointCloudToVector"
-            point_cloud="{additional_cloud}"
-            point_cloud_vector="{bin_jig_cloud_vector}"
+            ID="PushBackVector"
+            input_vector="{bin_jig_cloud_vector}"
+            element="{additional_cloud}"
+            output_vector="{bin_jig_cloud_vector}"
           />
         </Control>
       </Decorator>

--- a/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
+++ b/src/hangar_sim/objectives/cartesian_path_with_collision_checking.xml
@@ -37,10 +37,12 @@
         marker_size="0.100000"
         pose="{pose_stamped}"
       />
+      <Action ID="ResetVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
+++ b/src/hangar_sim/objectives/cartesian_plan_simple_square.xml
@@ -35,10 +35,12 @@
         marker_size="0.100000"
         pose="{pose_stamped}"
       />
+      <Action ID="ResetVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -48,9 +50,10 @@
         position_xyz="0;-0.4;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -60,9 +63,10 @@
         position_xyz="0.4;-0.4;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -72,9 +76,10 @@
         position_xyz="0.4;0;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -84,9 +89,10 @@
         position_xyz="0;0;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="VisualizePath"

--- a/src/hangar_sim/objectives/compute_ik_plan_and_move.xml
+++ b/src/hangar_sim/objectives/compute_ik_plan_and_move.xml
@@ -13,10 +13,12 @@
         pose_stamped="{target_pose}"
         position_xyz="0;0;0.3"
       />
+      <Action ID="ResetVector" vector="{target_poses}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{target_pose}"
-        vector="{target_poses}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{target_pose}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="GetCurrentPlanningScene"

--- a/src/hangar_sim/objectives/raster_path_along_fuselage.xml
+++ b/src/hangar_sim/objectives/raster_path_along_fuselage.xml
@@ -86,9 +86,10 @@
       />
       <Decorator ID="ForEach" index="{i1}" out="{p1}" vector_in="{contour_1}">
         <Action
-          ID="AddPoseStampedToVector"
-          input="{p1}"
-          vector="{raster_path}"
+          ID="PushBackVector"
+          input_vector="{raster_path}"
+          element="{p1}"
+          output_vector="{raster_path}"
         />
       </Decorator>
       <!--===== Row 2: middle, z = 1.55, reversed for a lawn-mower turn =====-->
@@ -128,9 +129,10 @@
       />
       <Decorator ID="ForEach" index="{i2}" out="{p2}" vector_in="{contour_2}">
         <Action
-          ID="AddPoseStampedToVector"
-          input="{p2}"
-          vector="{raster_path}"
+          ID="PushBackVector"
+          input_vector="{raster_path}"
+          element="{p2}"
+          output_vector="{raster_path}"
         />
       </Decorator>
       <!--===== Row 3: bottom, z = 1.4, left-to-right =====-->
@@ -165,9 +167,10 @@
       />
       <Decorator ID="ForEach" index="{i3}" out="{p3}" vector_in="{contour_3}">
         <Action
-          ID="AddPoseStampedToVector"
-          input="{p3}"
-          vector="{raster_path}"
+          ID="PushBackVector"
+          input_vector="{raster_path}"
+          element="{p3}"
+          output_vector="{raster_path}"
         />
       </Decorator>
       <!--Visualize and execute the stitched raster as a single Cartesian motion.-->

--- a/src/hangar_sim/objectives/solution_draw_square.xml
+++ b/src/hangar_sim/objectives/solution_draw_square.xml
@@ -35,10 +35,12 @@
         marker_size="0.100000"
         pose="{pose_stamped}"
       />
+      <Action ID="ResetVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -48,9 +50,10 @@
         position_xyz="0;-0.4;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -60,9 +63,10 @@
         position_xyz="0.4;-0.4;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -72,9 +76,10 @@
         position_xyz="0.4;0;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -84,9 +89,10 @@
         position_xyz="0;0;0.4"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{pose_stamped}"
-        vector="{pose_stamped_vector}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{pose_stamped}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="VisualizePath"

--- a/src/kitchen_sim/objectives/take_scene_camera_snapshot.xml
+++ b/src/kitchen_sim/objectives/take_scene_camera_snapshot.xml
@@ -34,10 +34,12 @@
           point_cloud_cropped="{point_cloud_1}"
           crop_box_size="2;5;5"
         />
+        <Action ID="ResetVector" vector="{point_clouds}" />
         <Action
-          ID="AddPointCloudToVector"
-          point_cloud="{point_cloud_1}"
-          point_cloud_vector="{point_clouds}"
+          ID="PushBackVector"
+          input_vector="{point_clouds}"
+          element="{point_cloud_1}"
+          output_vector="{point_clouds}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -53,9 +55,10 @@
           crop_box_size="5;2;5"
         />
         <Action
-          ID="AddPointCloudToVector"
-          point_cloud="{point_cloud_2}"
-          point_cloud_vector="{point_clouds}"
+          ID="PushBackVector"
+          input_vector="{point_clouds}"
+          element="{point_cloud_2}"
+          output_vector="{point_clouds}"
         />
         <Action
           ID="MergePointClouds"

--- a/src/lab_sim/objectives/add_point_cloud_to_vector.xml
+++ b/src/lab_sim/objectives/add_point_cloud_to_vector.xml
@@ -20,9 +20,10 @@
         target_frame="world"
       />
       <Action
-        ID="AddPointCloudToVector"
-        point_cloud="{point_cloud}"
-        point_cloud_vector="{point_cloud_vector}"
+        ID="PushBackVector"
+        input_vector="{point_cloud_vector}"
+        element="{point_cloud}"
+        output_vector="{point_cloud_vector}"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -121,9 +121,10 @@
         />
         <Action ID="ResetPoseStampedVector" vector="{pick_retract_path}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pick_retract_pose}"
-          vector="{pick_retract_path}"
+          ID="PushBackVector"
+          input_vector="{pick_retract_path}"
+          element="{pick_retract_pose}"
+          output_vector="{pick_retract_path}"
         />
         <Action
           ID="PlanCartesianPath"
@@ -260,9 +261,10 @@
           />
           <Action ID="ResetPoseStampedVector" vector="{place_retract_path}" />
           <Action
-            ID="AddPoseStampedToVector"
-            input="{place_retract_pose}"
-            vector="{place_retract_path}"
+            ID="PushBackVector"
+            input_vector="{place_retract_path}"
+            element="{place_retract_pose}"
+            output_vector="{place_retract_path}"
           />
           <Action
             ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/create_pcl_poses_vector.xml
+++ b/src/lab_sim/objectives/create_pcl_poses_vector.xml
@@ -15,10 +15,12 @@
         pose_stamped="{pose_stamped}"
         reference_frame="world"
       />
+      <Action ID="ResetVector" vector="{target_poses}" />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -28,9 +30,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -40,9 +43,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -52,9 +56,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -64,9 +69,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -76,9 +82,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/create_pose_vector.xml
+++ b/src/lab_sim/objectives/create_pose_vector.xml
@@ -15,10 +15,12 @@
         pose_stamped="{pose_stamped}"
         reference_frame="world"
       />
+      <Action ID="ResetVector" vector="{target_poses}" />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -28,9 +30,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -40,9 +43,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -52,9 +56,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -64,9 +69,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -76,9 +82,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -88,9 +95,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -100,9 +108,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{target_poses}"
-        input="{pose_stamped}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{pose_stamped}"
+        output_vector="{target_poses}"
       />
     </Control>
   </BehaviorTree>

--- a/src/lab_sim/objectives/fan_pose_about_tool_z_subtree.xml
+++ b/src/lab_sim/objectives/fan_pose_about_tool_z_subtree.xml
@@ -11,8 +11,8 @@
         name="Init output vector"
         vector="{output_pose_vector}"
       />
-      <SubTree
-        ID="AddToVector"
+      <Action
+        ID="PushBackVector"
         name="Add yaw+0"
         element="{input_pose}"
         input_vector="{output_pose_vector}"
@@ -30,8 +30,8 @@
         marker_text=""
         visualize_pose="false"
       />
-      <SubTree
-        ID="AddToVector"
+      <Action
+        ID="PushBackVector"
         name="Add yaw+90"
         element="{yaw_90}"
         input_vector="{output_pose_vector}"
@@ -49,8 +49,8 @@
         marker_text=""
         visualize_pose="false"
       />
-      <SubTree
-        ID="AddToVector"
+      <Action
+        ID="PushBackVector"
         name="Add yaw+180"
         element="{yaw_180}"
         input_vector="{output_pose_vector}"
@@ -68,8 +68,8 @@
         marker_text=""
         visualize_pose="false"
       />
-      <SubTree
-        ID="AddToVector"
+      <Action
+        ID="PushBackVector"
         name="Add yaw+270"
         element="{yaw_270}"
         input_vector="{output_pose_vector}"

--- a/src/lab_sim/objectives/fuse_multiple_views_subtree.xml
+++ b/src/lab_sim/objectives/fuse_multiple_views_subtree.xml
@@ -10,6 +10,8 @@
     <Control ID="Sequence">
       <SubTree ID="Clear Snapshot" _collapsed="true" />
       <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization" />
+      <!--Start a fresh point cloud vector before accumulating snapshots into it.-->
+      <Action ID="ResetVector" vector="{point_cloud_vector}" />
       <SubTree
         ID="Move to Waypoint"
         _collapsed="true"

--- a/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
+++ b/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
@@ -99,14 +99,16 @@
           />
           <Action ID="ResetPoseStampedVector" vector="{grasp_goal}" />
           <Action
-            ID="AddPoseStampedToVector"
-            input="{pregrasp_grasp}"
-            vector="{grasp_goal}"
+            ID="PushBackVector"
+            input_vector="{grasp_goal}"
+            element="{pregrasp_grasp}"
+            output_vector="{grasp_goal}"
           />
           <Action
-            ID="AddPoseStampedToVector"
-            input="{output_grasp}"
-            vector="{grasp_goal}"
+            ID="PushBackVector"
+            input_vector="{grasp_goal}"
+            element="{output_grasp}"
+            output_vector="{grasp_goal}"
           />
           <Action
             ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/grasp_planning.xml
+++ b/src/lab_sim/objectives/grasp_planning.xml
@@ -22,10 +22,12 @@
           pose_stamped="{grasp_candidate_1}"
           reference_frame="world"
         />
+        <Action ID="ResetVector" vector="{grasp_candidates}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{grasp_candidate_1}"
-          vector="{grasp_candidates}"
+          ID="PushBackVector"
+          input_vector="{grasp_candidates}"
+          element="{grasp_candidate_1}"
+          output_vector="{grasp_candidates}"
         />
         <Action
           ID="VisualizePose"
@@ -42,9 +44,10 @@
           reference_frame="world"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{grasp_candidate_2}"
-          vector="{grasp_candidates}"
+          ID="PushBackVector"
+          input_vector="{grasp_candidates}"
+          element="{grasp_candidate_2}"
+          output_vector="{grasp_candidates}"
         />
         <Action
           ID="VisualizePose"

--- a/src/lab_sim/objectives/pick_1_pill_bottle_with_sam3.xml
+++ b/src/lab_sim/objectives/pick_1_pill_bottle_with_sam3.xml
@@ -131,26 +131,23 @@
           _collapsed="true"
           vector="{drop_path}"
         />
-        <SubTree
-          ID="AddToVector"
+        <Action
+          ID="PushBackVector"
           name="Add up via-point"
-          _collapsed="true"
           element="{up_pose}"
           input_vector="{drop_path}"
           output_vector="{drop_path}"
         />
-        <SubTree
-          ID="AddToVector"
+        <Action
+          ID="PushBackVector"
           name="Add over hover"
-          _collapsed="true"
           element="{over_pose}"
           input_vector="{drop_path}"
           output_vector="{drop_path}"
         />
-        <SubTree
-          ID="AddToVector"
+        <Action
+          ID="PushBackVector"
           name="Add down drop"
-          _collapsed="true"
           element="{down_pose}"
           input_vector="{drop_path}"
           output_vector="{drop_path}"

--- a/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
+++ b/src/lab_sim/objectives/pick_all_bottles_with_apriltags.xml
@@ -127,9 +127,10 @@
               />
               <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
               <Action
-                ID="AddPoseStampedToVector"
-                input="{retract_pose}"
-                vector="{retract_path}"
+                ID="PushBackVector"
+                input_vector="{retract_path}"
+                element="{retract_pose}"
+                output_vector="{retract_path}"
               />
               <Action
                 ID="PlanCartesianPath"
@@ -336,9 +337,10 @@
                 vector="{place_retract_path}"
               />
               <Action
-                ID="AddPoseStampedToVector"
-                input="{place_retract_pose}"
-                vector="{place_retract_path}"
+                ID="PushBackVector"
+                input_vector="{place_retract_path}"
+                element="{place_retract_pose}"
+                output_vector="{place_retract_path}"
               />
               <Action
                 ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/pick_all_pill_bottles.xml
+++ b/src/lab_sim/objectives/pick_all_pill_bottles.xml
@@ -192,18 +192,16 @@
               _collapsed="true"
               vector="{predrop_path}"
             />
-            <SubTree
-              ID="AddToVector"
+            <Action
+              ID="PushBackVector"
               name="Add lift via-point"
-              _collapsed="true"
               element="{lift_via_pose}"
               input_vector="{predrop_path}"
               output_vector="{predrop_path}"
             />
-            <SubTree
-              ID="AddToVector"
+            <Action
+              ID="PushBackVector"
               name="Add predrop hover"
-              _collapsed="true"
               element="{predrop_hover_pose}"
               input_vector="{predrop_path}"
               output_vector="{predrop_path}"
@@ -264,18 +262,16 @@
               _collapsed="true"
               vector="{place_descent_path}"
             />
-            <SubTree
-              ID="AddToVector"
+            <Action
+              ID="PushBackVector"
               name="Add pre-place via-point"
-              _collapsed="true"
               element="{pre_place_pose}"
               input_vector="{place_descent_path}"
               output_vector="{place_descent_path}"
             />
-            <SubTree
-              ID="AddToVector"
+            <Action
+              ID="PushBackVector"
               name="Add place target"
-              _collapsed="true"
               element="{current_bottle_place_pose}"
               input_vector="{place_descent_path}"
               output_vector="{place_descent_path}"
@@ -321,10 +317,9 @@
               _collapsed="true"
               vector="{post_place_retract_path}"
             />
-            <SubTree
-              ID="AddToVector"
+            <Action
+              ID="PushBackVector"
               name="Add post-place retract"
-              _collapsed="true"
               element="{post_place_retract_pose}"
               input_vector="{post_place_retract_path}"
               output_vector="{post_place_retract_path}"

--- a/src/lab_sim/objectives/pick_from_pose.xml
+++ b/src/lab_sim/objectives/pick_from_pose.xml
@@ -47,9 +47,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{grasp_pose_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{grasp_pose}"
-        vector="{grasp_pose_vector}"
+        ID="PushBackVector"
+        input_vector="{grasp_pose_vector}"
+        element="{grasp_pose}"
+        output_vector="{grasp_pose_vector}"
       />
       <Action
         ID="SetupMTCBatchPoseIK"
@@ -73,9 +74,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/pick_from_pose_vector.xml
+++ b/src/lab_sim/objectives/pick_from_pose_vector.xml
@@ -67,9 +67,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/pick_from_pose_with_approval.xml
+++ b/src/lab_sim/objectives/pick_from_pose_with_approval.xml
@@ -47,9 +47,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{grasp_pose_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{grasp_pose}"
-        vector="{grasp_pose_vector}"
+        ID="PushBackVector"
+        input_vector="{grasp_pose_vector}"
+        element="{grasp_pose}"
+        output_vector="{grasp_pose_vector}"
       />
       <Action
         ID="SetupMTCBatchPoseIK"
@@ -79,9 +80,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/place_at_pose.xml
+++ b/src/lab_sim/objectives/place_at_pose.xml
@@ -47,9 +47,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{place_pose_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{place_pose}"
-        vector="{place_pose_vector}"
+        ID="PushBackVector"
+        input_vector="{place_pose_vector}"
+        element="{place_pose}"
+        output_vector="{place_pose_vector}"
       />
       <Action
         ID="SetupMTCBatchPoseIK"
@@ -73,9 +74,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/place_at_pose_vector.xml
+++ b/src/lab_sim/objectives/place_at_pose_vector.xml
@@ -67,9 +67,10 @@
       />
       <Action ID="ResetPoseStampedVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/place_at_pose_with_approval.xml
+++ b/src/lab_sim/objectives/place_at_pose_with_approval.xml
@@ -71,10 +71,12 @@
         pose_stamped="{retract_pose}"
         position_xyz="0;0;-0.1"
       />
+      <Action ID="ResetVector" vector="{retract_path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{retract_pose}"
-        vector="{retract_path}"
+        ID="PushBackVector"
+        input_vector="{retract_path}"
+        element="{retract_pose}"
+        output_vector="{retract_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/place_object.xml
+++ b/src/lab_sim/objectives/place_object.xml
@@ -15,10 +15,12 @@
           pose_stamped="{pose_stamped}"
           reference_frame="world"
         />
+        <Action ID="ResetVector" vector="{place_poses}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{place_poses}"
+          ID="PushBackVector"
+          input_vector="{place_poses}"
+          element="{pose_stamped}"
+          output_vector="{place_poses}"
         />
       </Control>
       <SubTree

--- a/src/lab_sim/objectives/push_button_with_a_trajectory.xml
+++ b/src/lab_sim/objectives/push_button_with_a_trajectory.xml
@@ -37,10 +37,12 @@
         marker_size="0.100000"
         pose="{target_pose}"
       />
+      <Action ID="ResetVector" vector="{path}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{target_pose}"
-        vector="{path}"
+        ID="PushBackVector"
+        input_vector="{path}"
+        element="{target_pose}"
+        output_vector="{path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/reflect_poses_subtree.xml
+++ b/src/lab_sim/objectives/reflect_poses_subtree.xml
@@ -17,9 +17,10 @@
       >
         <Control ID="Sequence">
           <Action
-            ID="AddPoseStampedToVector"
-            input="{single_pose}"
-            vector="{output_poses}"
+            ID="PushBackVector"
+            input_vector="{output_poses}"
+            element="{single_pose}"
+            output_vector="{output_poses}"
           />
           <Action
             ID="TransformPose"
@@ -29,9 +30,10 @@
             quaternion_xyzw="{reflection_axis}"
           />
           <Action
-            ID="AddPoseStampedToVector"
-            input="{rotated_pose}"
-            vector="{output_poses}"
+            ID="PushBackVector"
+            input_vector="{output_poses}"
+            element="{rotated_pose}"
+            output_vector="{output_poses}"
           />
         </Control>
       </Decorator>

--- a/src/lab_sim/objectives/scan_scene_-_multiple_point_clouds.xml
+++ b/src/lab_sim/objectives/scan_scene_-_multiple_point_clouds.xml
@@ -13,6 +13,8 @@
       <!--Clear previous data-->
       <SubTree ID="Clear Snapshot" _collapsed="true" />
       <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization" />
+      <!--Start a fresh point cloud vector before accumulating snapshots into it.-->
+      <Action ID="ResetVector" vector="{point_cloud_vector}" />
       <!--Move to center scan position and capture-->
       <SubTree
         ID="Move to Waypoint"
@@ -35,9 +37,10 @@
         position_xyz="0.80;0;0"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{offset_pose}"
-        vector="{cartesian_path}"
+        ID="PushBackVector"
+        input_vector="{cartesian_path}"
+        element="{offset_pose}"
+        output_vector="{cartesian_path}"
       />
       <Action
         ID="PlanCartesianPath"
@@ -70,9 +73,10 @@
         position_xyz="-1.60;0;0"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{offset_pose}"
-        vector="{cartesian_path}"
+        ID="PushBackVector"
+        input_vector="{cartesian_path}"
+        element="{offset_pose}"
+        output_vector="{cartesian_path}"
       />
       <Action
         ID="PlanCartesianPath"

--- a/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
+++ b/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
@@ -22,10 +22,12 @@
         pose_stamped="{pose1}"
         reference_frame="world"
       />
+      <Action ID="ResetVector" vector="{inspection_poses}" />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{inspection_poses}"
-        input="{pose1}"
+        ID="PushBackVector"
+        input_vector="{inspection_poses}"
+        element="{pose1}"
+        output_vector="{inspection_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -35,9 +37,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{inspection_poses}"
-        input="{pose2}"
+        ID="PushBackVector"
+        input_vector="{inspection_poses}"
+        element="{pose2}"
+        output_vector="{inspection_poses}"
       />
       <Action
         ID="CreatePoseStamped"
@@ -47,9 +50,10 @@
         reference_frame="world"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{inspection_poses}"
-        input="{pose3}"
+        ID="PushBackVector"
+        input_vector="{inspection_poses}"
+        element="{pose3}"
+        output_vector="{inspection_poses}"
       />
       <!--Use ForEachUntilSuccess to find first reachable inspection point (but don't execute yet)-->
       <Decorator
@@ -87,6 +91,7 @@
         joint_trajectory="{joint_traj}"
       />
       <!--Use ForEach to visit all inspection points and gather data-->
+      <Action ID="ResetVector" vector="{point_cloud_vector}" />
       <Decorator
         ID="ForEach"
         vector_in="{inspection_poses}"
@@ -150,9 +155,10 @@
             target_frame="world"
           />
           <Action
-            ID="AddPointCloudToVector"
-            point_cloud="{transformed_cloud}"
-            point_cloud_vector="{point_cloud_vector}"
+            ID="PushBackVector"
+            input_vector="{point_cloud_vector}"
+            element="{transformed_cloud}"
+            output_vector="{point_cloud_vector}"
           />
           <!--Debug: publish individual cloud and current vector size-->
           <Action

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
@@ -11,7 +11,13 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action ID="VisualizeMesh" marker_lifetime="0.0" />
-      <Action ID="AddPoseStampedToVector" input="{mesh_pose}" />
+      <Action ID="ResetVector" vector="{pose_stamped_vector}" />
+      <Action
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{mesh_pose}"
+        output_vector="{pose_stamped_vector}"
+      />
       <Action
         ID="AdjustPoseWithIMarker"
         initial_poses="{pose_stamped_vector}"

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
@@ -20,10 +20,12 @@
           orientation_xyzw="0.707;0.707;0.0;.0.0"
           pose_stamped="{pose_stamped}"
         />
+        <Action ID="ResetVector" vector="{pose_stamped_vector}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -33,9 +35,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -45,9 +48,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -57,9 +61,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
       </Control>
       <Decorator ID="KeepRunningUntilFailure">

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/april_tag_object_registration.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/april_tag_object_registration.xml
@@ -201,20 +201,24 @@
         </Decorator>
         <Action ID="AlwaysSuccess" />
       </Control>
+      <Action ID="ResetVector" vector="{pose_stamped_vector}" />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{pose_stamped_vector}"
-        input="{initial_goal_pose}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{initial_goal_pose}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{pose_stamped_vector}"
-        input="{goal_pose}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{goal_pose}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        vector="{pose_stamped_vector}"
-        input="{hole_object}"
+        ID="PushBackVector"
+        input_vector="{pose_stamped_vector}"
+        element="{hole_object}"
+        output_vector="{pose_stamped_vector}"
       />
       <Action
         ID="VisualizePose"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
@@ -25,10 +25,12 @@
           orientation_xyzw="0.707;0.707;0.0;.0.0"
           pose_stamped="{pose_stamped}"
         />
+        <Action ID="ResetVector" vector="{pose_stamped_vector}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -38,9 +40,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -50,9 +53,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -62,9 +66,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
       </Control>
       <Decorator ID="KeepRunningUntilFailure">

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
@@ -20,10 +20,12 @@
           orientation_xyzw="0.707;0.707;0.0;.0.0"
           pose_stamped="{pose_stamped}"
         />
+        <Action ID="ResetVector" vector="{pose_stamped_vector}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -33,9 +35,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -45,9 +48,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -57,9 +61,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
       </Control>
       <Decorator ID="KeepRunningUntilFailure">

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_detect.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_detect.xml
@@ -45,9 +45,10 @@
             />
           </Decorator>
           <Action
-            ID="AddPoseStampedToVector"
-            input="{computed_pose}"
-            vector="{poses_at_waypoint_vec}"
+            ID="PushBackVector"
+            input_vector="{poses_at_waypoint_vec}"
+            element="{computed_pose}"
+            output_vector="{poses_at_waypoint_vec}"
           />
         </Control>
       </Decorator>
@@ -68,9 +69,10 @@
         pose="{average_pose_stamped}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{average_pose_stamped}"
-        vector="{computed_poses_vector}"
+        ID="PushBackVector"
+        input_vector="{computed_poses_vector}"
+        element="{average_pose_stamped}"
+        output_vector="{computed_poses_vector}"
       />
     </Control>
   </BehaviorTree>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
@@ -45,9 +45,10 @@
             />
           </Decorator>
           <Action
-            ID="AddPoseStampedToVector"
-            input="{computed_pose}"
-            vector="{poses_at_waypoint_vec}"
+            ID="PushBackVector"
+            input_vector="{poses_at_waypoint_vec}"
+            element="{computed_pose}"
+            output_vector="{poses_at_waypoint_vec}"
           />
         </Control>
       </Decorator>
@@ -68,9 +69,10 @@
         pose="{average_pose_stamped}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{average_pose_stamped}"
-        vector="{computed_poses_vector}"
+        ID="PushBackVector"
+        input_vector="{computed_poses_vector}"
+        element="{average_pose_stamped}"
+        output_vector="{computed_poses_vector}"
       />
     </Control>
   </BehaviorTree>

--- a/src/moveit_pro_ur_configs/mock_sim/objectives/move_along_path.xml
+++ b/src/moveit_pro_ur_configs/mock_sim/objectives/move_along_path.xml
@@ -17,10 +17,12 @@
           orientation_xyzw="0.0;1.0;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
+        <Action ID="ResetVector" vector="{pose_stamped_vector}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -30,9 +32,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -42,9 +45,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -54,9 +58,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -66,9 +71,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
       </Control>
       <Decorator ID="KeepRunningUntilFailure">

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_path_ik_example.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_path_ik_example.xml
@@ -14,10 +14,12 @@
           reference_frame="third_grasp_link"
           pose_stamped="{pose_stamped}"
         />
+        <Action ID="ResetVector" vector="{pose_stamped_vector}" />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -26,9 +28,10 @@
           position_xyz="0.2;0.0;0"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -37,9 +40,10 @@
           position_xyz="0.2;0.0;-0.1"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -48,9 +52,10 @@
           position_xyz="0.0;0.0;-0.1"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
         <Action
           ID="CreatePoseStamped"
@@ -58,9 +63,10 @@
           pose_stamped="{pose_stamped}"
         />
         <Action
-          ID="AddPoseStampedToVector"
-          input="{pose_stamped}"
-          vector="{pose_stamped_vector}"
+          ID="PushBackVector"
+          input_vector="{pose_stamped_vector}"
+          element="{pose_stamped}"
+          output_vector="{pose_stamped_vector}"
         />
       </Control>
       <Control ID="Fallback">

--- a/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_pose_ik_example.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/objectives/multi_tip_pose_ik_example.xml
@@ -38,10 +38,12 @@
         marker_size="0.100000"
         pose="{target_pose_1}"
       />
+      <Action ID="ResetVector" vector="{target_poses}" />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{target_pose_1}"
-        vector="{target_poses}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{target_pose_1}"
+        output_vector="{target_poses}"
       />
       <Action
         ID="TransformPose"
@@ -58,9 +60,10 @@
         pose="{target_pose_2}"
       />
       <Action
-        ID="AddPoseStampedToVector"
-        input="{target_pose_2}"
-        vector="{target_poses}"
+        ID="PushBackVector"
+        input_vector="{target_poses}"
+        element="{target_pose_2}"
+        output_vector="{target_poses}"
       />
       <!--Compute
       IK simultaneously for two tips-->

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/create_point_cloud_vector_from_masks.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/create_point_cloud_vector_from_masks.xml
@@ -13,6 +13,7 @@
   >
     <Control ID="Sequence">
       <Action ID="ResetPoseStampedVector" vector="{pose_stamped_vector}" />
+      <Action ID="ResetVector" vector="{point_cloud_vector}" />
       <Decorator
         ID="ForEach"
         vector_in="{masks3d}"
@@ -27,9 +28,10 @@
             point_cloud_fragment="{point_cloud_fragment}"
           />
           <Action
-            ID="AddPointCloudToVector"
-            point_cloud="{point_cloud_fragment}"
-            point_cloud_vector="{point_cloud_vector}"
+            ID="PushBackVector"
+            input_vector="{point_cloud_vector}"
+            element="{point_cloud_fragment}"
+            output_vector="{point_cloud_vector}"
           />
         </Control>
       </Decorator>


### PR DESCRIPTION
## Motivation

Companion to PickNikRobotics/moveit_pro#19664, which deprecates `AddPoseStampedToVector`, `AddPointCloudToVector`, and the `AddToVector` Objective in favor of the generic `PushBackVector` (issue PickNikRobotics/moveit_pro#16574). This migrates the example configs off the deprecated surfaces so they no longer emit deprecation warnings and are ready for the 10.0 removal.

## Brief description

Across all robot configs (50 objectives, 8 config packages), replace every `AddPoseStampedToVector` / `AddPointCloudToVector` / `AddToVector`-subtree usage with `<Action ID="PushBackVector" .../>`. `PushBackVector` requires the vector to already exist (the deprecated behaviors auto-created on first push), so a `ResetVector` seed is prepended only where the vector had no prior creator and is not a caller-provided input/inout port. `PushBackVector` emits `vector<BT::Any>`, which BT.CPP converts to/from the typed vectors that downstream consumers read, so no data-flow changes.

## How it was tested

- `pre-commit run` over all changed files passes (prettier, "Validate Objective favorites").
- Every changed file re-greps clean for the deprecated names and parses as well-formed XML.
- Seeding audited: no unseeded `PushBackVector`, no `ResetVector` placed inside a `ForEach` loop or in front of a caller-owned port.
