### PR TITLE
Add joint end-state check for Move to Arm Upright (hangar_sim)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MOVEIT_PRO_PR_FROM_BODY: ${{ steps.detect_needs.outputs.moveit_pro_pr }}
-          GHCR_URL: ${{ vars.GHCR_URL }}
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
         with:
           # Falls back to the default GITHUB_TOKEN when the App token wasn't
           # minted (no paired PR, not a dispatch). The default is sufficient
@@ -93,14 +93,22 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const event = context.eventName;
-            const ghcrUrl = process.env.GHCR_URL || 'ghcr.io/picknikrobotics';
+            // Docker Hub org that hosts the moveit-studio customer image.
+            // moveit_pro publishes under vars.DOCKERHUB_USERNAME (picknikciuser),
+            // which is the same default the reusable workflow falls back to; that
+            // var is not defined in this repo, so default to the known owner.
+            const dockerhubUsername = process.env.DOCKERHUB_USERNAME || 'picknikciuser';
             let image_ref = '';
             let image_tag = '';
             let git_ref = '';
             let moveit_pro_sha = '';
             let moveit_pro_pr_number = '';
 
-            const sanitizeBranch = (s) => s.replace(/[^a-zA-Z0-9._-]/g, '-');
+            // Mirror moveit_pro's setup_docker_cache "Compute image tag" step
+            // exactly (`echo $TAG | tr '/' '_'`): only the slash is rewritten,
+            // to an underscore. A broader sanitize (e.g. slash -> dash) produces
+            // a tag that does not match the published image and 404s the pull.
+            const sanitizeBranch = (s) => s.replace(/\//g, '_');
 
             if (event === 'repository_dispatch') {
               const p = context.payload.client_payload || {};
@@ -120,7 +128,12 @@ jobs:
                 });
                 moveit_pro_sha = pr.head.sha;
                 moveit_pro_pr_number = needsPr;
-                image_ref = `${ghcrUrl}/moveit-studio:${sanitizeBranch(pr.head.ref)}-{0}-amd64`;
+                // Pull the paired moveit_pro PR's customer image from Docker Hub
+                // — that is where moveit_pro publishes it (the GHCR moveit-studio
+                // retag is gone). Leave the tag suffix-free (`…-amd64`): this
+                // caller sets enable_gpu, so the reusable workflow appends the
+                // -cuda12.6-cudnn9 suffix itself. Baking it here double-appends.
+                image_ref = `${dockerhubUsername}/moveit-studio:${sanitizeBranch(pr.head.ref)}-{0}-amd64`;
               }
             } else {
               // push, schedule, workflow_dispatch. A `workflow_dispatch` input

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -36,7 +36,9 @@ import tf2_ros
 from rclpy.time import Time
 from control_msgs.action import GripperCommand
 from moveit_pro_test_utils.objective_test_fixture import (
+    EndStateSpec,
     ExecuteObjectiveResource,
+    JointTarget,
     MUJOCO_RESET_HOOK,
     MUJOCO_RESET_SERVICE,
     SIM_RESETTER,
@@ -187,6 +189,47 @@ def wait_for_robot_tf(
     )
 
 
+# --- End-state correctness checks ---
+#
+# A small, deterministic set of objectives gets an end-state assertion beyond
+# SUCCESS/FAILURE. Broad population is out of scope (follow-up tied to #17769).
+#
+# "Move to Arm Upright" drives the manipulator group to the "Arm upright"
+# waypoint via the joint_trajectory_controller. We resolve the expected target
+# at runtime from /get_saved_waypoints (same source of truth the objective
+# uses), then restrict the comparison to the manipulator arm joints: the saved
+# waypoint's joint_state also carries the mecanum base joints (linear_x/y,
+# rotational_yaw), which this objective does not command, so asserting them
+# would compare against an uncommanded pose.
+JOINT_CHECK_OBJECTIVE = "Move to Arm Upright"
+JOINT_CHECK_WAYPOINT = "Arm upright"
+MANIPULATOR_ARM_JOINTS = (
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+)
+
+
+def _expected_end_state_by_id(
+    objective_id: str,
+    resource: ExecuteObjectiveResource,
+) -> dict[str, EndStateSpec] | None:
+    """Build the end-state spec for objectives we assert on; None otherwise.
+
+    Resolves the waypoint target lazily, only for the objective under test, so
+    a missing /get_saved_waypoints surfaces solely on the objective that needs
+    it rather than penalizing the whole suite.
+    """
+    if objective_id != JOINT_CHECK_OBJECTIVE:
+        return None
+    waypoint_joints = resource.get_waypoint_target(JOINT_CHECK_WAYPOINT)
+    arm_target = {joint: waypoint_joints[joint] for joint in MANIPULATOR_ARM_JOINTS}
+    return {objective_id: EndStateSpec(joints=JointTarget(positions=arm_target))}
+
+
 @pytest.mark.parametrize(
     "objective_id, should_cancel",
     get_objective_pytest_params("hangar_sim", cancel_objectives, skip_objectives),
@@ -201,8 +244,16 @@ def test_all_objectives(
         execute_objective_resource.node,
         [name for _, name in required_action_servers],
     )
+    expected_end_state_by_id = _expected_end_state_by_id(
+        objective_id, execute_objective_resource
+    )
     try:
-        run_objective(objective_id, should_cancel, execute_objective_resource)
+        run_objective(
+            objective_id,
+            should_cancel,
+            execute_objective_resource,
+            expected_end_state_by_id=expected_end_state_by_id,
+        )
     except AssertionError as e:
         mode = "cancel" if should_cancel else "execute"
         pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")


### PR DESCRIPTION
needs: moveit_pro/#19665

## Motivation

Exercises the new end-state correctness assertions added to `moveit_pro_test_utils` (moveit_pro #19665) against a real config, so a tree that reports `SUCCESS` while leaving the arm in the wrong place is caught — not just SUCCESS/FAILURE.

## Brief description

Wires `expected_end_state_by_id` into the hangar_sim integration suite for one deterministic objective, **"Move to Arm Upright"**:

- Resolves the `Arm upright` target at runtime from `/get_saved_waypoints` (same source of truth the objective moves to), then restricts the comparison to the 6 manipulator arm joints — the saved waypoint also stores the mecanum base joints (`linear_x/y`, `rotational_yaw`), which this objective does not command, so asserting them would compare against an uncommanded pose.
- Default for every other objective is unchanged (SUCCESS-only).

This is the small, deterministic seed set; broad population is a follow-up tied to #17769. An object-pose check (free-joint body via TF) is a fast-follow.

## How it was tested

End-to-end against a live hangar_sim MuJoCo backend: resolved the waypoint, ran "Move to Arm Upright", read `/joint_states` → arm within 5e-5 of target (pass); a +0.5 rad perturbation of the expected target correctly failed the check (anti-no-op gate).

Stacked on moveit_pro #19665 via the `needs:` token above so CI runs against that PR's backend image (which carries the new harness API).

---
**Note:** temporarily carries the CI resolve fix from #700 (Docker Hub `image_ref`) so this PR can run green before #700 merges. Once #700 lands on `main`, rebase and that commit drops.
