### PR TITLE
ci: forward GPU image suffix from dispatch payload (thread end-to-end)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.7.0 # pending: tag cut from moveit_pro_ci#34; re-pin to the v0.7.0 commit SHA once released
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@3a8bd80371004ebc75dbddfed1c13bd012258fc4 # v0.7.0
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
     outputs:
       image_ref: ${{ steps.resolve.outputs.image_ref }}
       image_tag: ${{ steps.resolve.outputs.image_tag }}
+      gpu_image_suffix: ${{ steps.resolve.outputs.gpu_image_suffix }}
       git_ref: ${{ steps.resolve.outputs.git_ref }}
       moveit_pro_sha: ${{ steps.resolve.outputs.moveit_pro_sha }}
       moveit_pro_pr_number: ${{ steps.resolve.outputs.moveit_pro_pr_number }}
@@ -96,6 +97,16 @@ jobs:
             const ghcrUrl = process.env.GHCR_URL || 'ghcr.io/picknikrobotics';
             let image_ref = '';
             let image_tag = '';
+            // GPU image suffix forwarded to moveit_pro_ci's reusable workflow,
+            // which appends it to the pulled image when enable_gpu is set. This
+            // workspace runs integration jazzy-only, and jazzy GPU images
+            // publish under -cuda13.2-cudnn9 (humble would be -cuda12.6-cudnn9),
+            // so that is the default for the non-dispatch paths (push, schedule,
+            // workflow_dispatch, pull_request). On repository_dispatch the value
+            // is taken from the moveit_pro payload so the suffix is threaded
+            // end-to-end (moveit_pro -> here -> moveit_pro_ci) rather than
+            // pinned in two places.
+            let gpu_image_suffix = '-cuda13.2-cudnn9';
             let git_ref = '';
             let moveit_pro_sha = '';
             let moveit_pro_pr_number = '';
@@ -106,6 +117,11 @@ jobs:
               const p = context.payload.client_payload || {};
               image_ref = p.image_ref || '';
               image_tag = p.image_tag || p.base_branch || 'main';
+              // Fall back to the jazzy default only when the field is truly
+              // absent (older moveit_pro that doesn't send it). Nullish
+              // coalescing preserves a deliberate empty string ("" => no GPU
+              // suffix / CPU image), which `||` would wrongly override.
+              gpu_image_suffix = p.gpu_image_suffix ?? gpu_image_suffix;
               git_ref = p.base_branch || '';
               moveit_pro_sha = p.moveit_pro_sha || '';
               moveit_pro_pr_number = String(p.moveit_pro_pr || '');
@@ -134,12 +150,14 @@ jobs:
             core.info(`event=${event}`);
             core.info(`image_ref=${image_ref}`);
             core.info(`image_tag=${image_tag}`);
+            core.info(`gpu_image_suffix=${gpu_image_suffix}`);
             core.info(`git_ref=${git_ref}`);
             core.info(`moveit_pro_sha=${moveit_pro_sha}`);
             core.info(`moveit_pro_pr_number=${moveit_pro_pr_number}`);
 
             core.setOutput('image_ref', image_ref);
             core.setOutput('image_tag', image_tag);
+            core.setOutput('gpu_image_suffix', gpu_image_suffix);
             core.setOutput('git_ref', git_ref);
             core.setOutput('moveit_pro_sha', moveit_pro_sha);
             core.setOutput('moveit_pro_pr_number', moveit_pro_pr_number);
@@ -157,7 +175,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@3a8bd80371004ebc75dbddfed1c13bd012258fc4 # v0.7.0
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.8.0 # pending: tag v0.8.0 from moveit_pro_ci; re-pin to its commit SHA once released
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}
@@ -172,13 +190,14 @@ jobs:
       # software rasterization on the CPU-only picknik-16-amd64 runner — the
       # integration test exercises camera-bearing scenes (apriltag, perception).
       # enable_gpu also switches the container image to a CUDA/cuDNN variant.
-      # Jazzy GPU images now ship as -cuda13.2-cudnn9 (moveit_pro#19583), so we
-      # pass gpu_image_suffix explicitly rather than relying on the reusable
-      # workflow's default (-cuda12.6-cudnn9). A pull failure here points at a
-      # missing CUDA image, not EGL.
+      # The suffix is resolved in the `resolve` job and forwarded here: on a
+      # moveit_pro repository_dispatch it comes from that PR's payload (threaded
+      # end-to-end); on push/schedule/pull_request it defaults to the jazzy
+      # variant -cuda13.2-cudnn9. moveit_pro_ci appends it to the pulled image.
+      # A pull failure here points at a missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true
-      gpu_image_suffix: "-cuda13.2-cudnn9"
+      gpu_image_suffix: ${{ needs.resolve.outputs.gpu_image_suffix }}
       use_ccache: true
       # Fetch Git LFS through the in-region S3 cache instead of a direct pull.
       # Empty for fork PRs (which get no OIDC token / secrets) so they fall back

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.8.0 # pending: tag v0.8.0 from moveit_pro_ci; re-pin to its commit SHA once released
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@b119d40cb5ef0a1fa1514e0424d9e45e192e6429 # v0.8.0
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@b50a6d565338de91ccd4069bbb88414ffdc0b95a # v0.6.0
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@v0.7.0 # pending: tag cut from moveit_pro_ci#34; re-pin to the v0.7.0 commit SHA once released
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}
@@ -171,10 +171,14 @@ jobs:
       # rendering can attach to a real GPU instead of falling back to slow
       # software rasterization on the CPU-only picknik-16-amd64 runner — the
       # integration test exercises camera-bearing scenes (apriltag, perception).
-      # enable_gpu also switches the container image to the -cuda12.6-cudnn9
-      # variant, so a pull failure here points at a missing CUDA image, not EGL.
+      # enable_gpu also switches the container image to a CUDA/cuDNN variant.
+      # Jazzy GPU images now ship as -cuda13.2-cudnn9 (moveit_pro#19583), so we
+      # pass gpu_image_suffix explicitly rather than relying on the reusable
+      # workflow's default (-cuda12.6-cudnn9). A pull failure here points at a
+      # missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true
+      gpu_image_suffix: "-cuda13.2-cudnn9"
       use_ccache: true
       # Fetch Git LFS through the in-region S3 cache instead of a direct pull.
       # Empty for fork PRs (which get no OIDC token / secrets) so they fall back

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,15 +98,15 @@ jobs:
             let image_ref = '';
             let image_tag = '';
             // GPU image suffix forwarded to moveit_pro_ci's reusable workflow,
-            // which appends it to the pulled image when enable_gpu is set. This
-            // workspace runs integration jazzy-only, and jazzy GPU images
-            // publish under -cuda13.2-cudnn9 (humble would be -cuda12.6-cudnn9),
-            // so that is the default for the non-dispatch paths (push, schedule,
-            // workflow_dispatch, pull_request). On repository_dispatch the value
-            // is taken from the moveit_pro payload so the suffix is threaded
-            // end-to-end (moveit_pro -> here -> moveit_pro_ci) rather than
-            // pinned in two places.
-            let gpu_image_suffix = '-cuda13.2-cudnn9';
+            // which appends it to the pulled image when enable_gpu is set.
+            // Defaults to the legacy -cuda12.6-cudnn9, matching moveit_pro_ci's
+            // own backward-compatible default, for the non-dispatch paths
+            // (push, schedule, workflow_dispatch, pull_request). On
+            // repository_dispatch the authoritative per-PR value is taken from
+            // the moveit_pro payload (which derives it from the distro/CUDA
+            // coupling), so the suffix is threaded end-to-end
+            // (moveit_pro -> here -> moveit_pro_ci) rather than pinned here.
+            let gpu_image_suffix = '-cuda12.6-cudnn9';
             let git_ref = '';
             let moveit_pro_sha = '';
             let moveit_pro_pr_number = '';
@@ -117,7 +117,7 @@ jobs:
               const p = context.payload.client_payload || {};
               image_ref = p.image_ref || '';
               image_tag = p.image_tag || p.base_branch || 'main';
-              // Fall back to the jazzy default only when the field is truly
+              // Fall back to the legacy default only when the field is truly
               // absent (older moveit_pro that doesn't send it). Nullish
               // coalescing preserves a deliberate empty string ("" => no GPU
               // suffix / CPU image), which `||` would wrongly override.
@@ -192,8 +192,8 @@ jobs:
       # enable_gpu also switches the container image to a CUDA/cuDNN variant.
       # The suffix is resolved in the `resolve` job and forwarded here: on a
       # moveit_pro repository_dispatch it comes from that PR's payload (threaded
-      # end-to-end); on push/schedule/pull_request it defaults to the jazzy
-      # variant -cuda13.2-cudnn9. moveit_pro_ci appends it to the pulled image.
+      # end-to-end); on push/schedule/pull_request it defaults to the legacy
+      # -cuda12.6-cudnn9. moveit_pro_ci appends it to the pulled image.
       # A pull failure here points at a missing CUDA image, not EGL.
       runner: "picknik-16-amd64-gpu"
       enable_gpu: true


### PR DESCRIPTION
## Summary

The Jazzy-only integration test calls moveit_pro_ci's reusable `workspace_integration_test.yaml` with `enable_gpu: true`. The GPU image suffix must track what moveit_pro actually publishes — Jazzy moved from `-cuda12.6-cudnn9` to `-cuda13.2-cudnn9` ([moveit_pro#19583](https://github.com/PickNikRobotics/moveit_pro/pull/19583)).

**Reworked** from the initial static-hard-code approach: rather than pinning `-cuda13.2-cudnn9` here, the `resolve` job now threads the suffix end-to-end. On a `repository_dispatch` from moveit_pro it reads `gpu_image_suffix` from the PR payload (single source of truth in moveit_pro); on push/schedule/pull_request it defaults to the jazzy variant (this workspace is jazzy-only). The value is forwarded to moveit_pro_ci, which appends it to the pulled image.

## Change

- `resolve` job: new `gpu_image_suffix` output — from `p.gpu_image_suffix ?? default` on dispatch (nullish-coalescing preserves a deliberate `""`), jazzy default otherwise.
- `integration-test`: forwards `gpu_image_suffix: ${{ needs.resolve.outputs.gpu_image_suffix }}` instead of a literal.
- Reusable-workflow pin bumped `v0.7.0` → **v0.8.0** (needs moveit_pro_ci#35).

## Part of a 3-PR chain
1. [moveit_pro_ci#35](https://github.com/PickNikRobotics/moveit_pro_ci/pull/35) → tag **v0.8.0**
2. [moveit_pro#19691](https://github.com/PickNikRobotics/moveit_pro/pull/19691) — emits suffix-free `image_ref` + `gpu_image_suffix` payload
3. **This PR** — forwards the payload field, pins to v0.8.0

## Sequencing
1. Merge moveit_pro_ci#35 → tag v0.8.0
2. Re-pin this PR's `@v0.8.0` to its commit SHA
3. Merge alongside moveit_pro#19691 and moveit_pro#19583

> ⚠️ Draft: CI won't pass until v0.8.0 is tagged from moveit_pro_ci#35 and the pin re-pointed to its SHA. Expected.

## Validation
- `actionlint` clean; `pre-commit` (yamllint/check-yaml/codespell) clean
- Pre-push gate (code-reviewer, platform-architect-bot, security-auditor) run; `??` and end-to-end threading fixes applied