### PR TITLE
Fix: Repeating lab_sim and hangar_sim integration-test flakes

### DIFF
--- a/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
+++ b/src/hangar_sim/objectives/cartesian_draw_geometry_from_file.xml
@@ -38,27 +38,45 @@
           publish_rate="50"
         />
         <Control ID="Sequence" name="TopLevelSequence">
-          <Action ID="WaitForDuration" delay_duration="1" />
-          <Action
-            ID="PlanCartesianPath"
-            acceleration_scale_factor="1.000000"
-            blending_radius="0.001"
-            debug_solution="{debug_solution}"
-            ik_cartesian_space_density="0.010000"
-            ik_joint_space_density="0.100000"
-            joint_trajectory_msg="{joint_trajectory_msg}"
-            path="{pose_stamped_msgs}"
-            planning_group_name="manipulator"
-            position_only="false"
-            tip_links="grasp_link"
-            trajectory_sampling_rate="100"
-            velocity_scale_factor="1.000000"
-          />
-          <Action
-            ID="VisualizePath"
-            marker_lifetime="0.000000"
-            path="{pose_stamped_msgs}"
-          />
+          <!--
+            PublishTF advertises the `local` frame from the parallel branch,
+            so the first plan/visualize attempt can race the TF buffer on a
+            loaded machine. Retry the wait+plan+visualize block until the
+            transform is available instead of relying on a single fixed delay.
+            Inverter + RepeatUnlessFailureEachTick + Inverter is the
+            non-deprecated equivalent of RetryUntilSuccessful: the loop keeps
+            re-ticking while the inner block fails, exits as soon as it
+            succeeds, and gives up after num_cycles failed attempts.
+          -->
+          <Decorator ID="Inverter">
+            <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="5">
+              <Decorator ID="Inverter">
+                <Control ID="Sequence" name="PlanDrawPathSequence">
+                  <Action ID="WaitForDuration" delay_duration="1" />
+                  <Action
+                    ID="PlanCartesianPath"
+                    acceleration_scale_factor="1.000000"
+                    blending_radius="0.001"
+                    debug_solution="{debug_solution}"
+                    ik_cartesian_space_density="0.010000"
+                    ik_joint_space_density="0.100000"
+                    joint_trajectory_msg="{joint_trajectory_msg}"
+                    path="{pose_stamped_msgs}"
+                    planning_group_name="manipulator"
+                    position_only="false"
+                    tip_links="grasp_link"
+                    trajectory_sampling_rate="100"
+                    velocity_scale_factor="1.000000"
+                  />
+                  <Action
+                    ID="VisualizePath"
+                    marker_lifetime="0.000000"
+                    path="{pose_stamped_msgs}"
+                  />
+                </Control>
+              </Decorator>
+            </Decorator>
+          </Decorator>
           <Action
             ID="ExecuteTrajectory"
             execution_pipeline="jtc"
@@ -70,10 +88,6 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Cartesian Draw Geometry From File">
-      <MetadataFields>
-        <Metadata runnable="true" />
-        <Metadata subcategory="Training Examples" />
-      </MetadataFields>
       <MetadataFields>
         <Metadata runnable="true" />
         <Metadata subcategory="Training Examples" />

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -29,12 +29,15 @@
 """Integration tests for the hangar_sim objective library."""
 
 import time
+from pathlib import Path
 
 import pytest
 import rclpy
 import tf2_ros
+import yaml
 from rclpy.time import Time
 from control_msgs.action import GripperCommand
+from controller_manager_msgs.srv import ListControllers
 from moveit_pro_test_utils.objective_test_fixture import (
     EndStateSpec,
     ExecuteObjectiveResource,
@@ -148,6 +151,91 @@ def wait_for_mujoco_reset_service(
     wait_for_services(
         execute_objective_resource.node, [MUJOCO_RESET_SERVICE], timeout_sec=120.0
     )
+
+
+# Controllers the config spawns at startup (config.yaml ros2_control
+# controllers_active_at_startup + controllers_inactive_at_startup), read from
+# the config itself so the list cannot drift from it. The spawners run with
+# --controller-manager-timeout 180 and can lag several minutes behind the
+# first tests on a loaded CI runner, so the first controller-using objective
+# (cartesian_draw_geometry_from_file) raced them and failed SwitchController
+# with "Controller joint_trajectory_controller is not an existing controller"
+# or "command interface platform_velocity_controller/linear_x_joint/velocity
+# is not available".
+_CONFIG_YAML_PATH = Path(__file__).parent.parent / "config" / "config.yaml"
+
+
+def _spawned_controllers_from_config() -> frozenset[str]:
+    """Read the spawned-controller names from hangar_sim's config.yaml."""
+    with _CONFIG_YAML_PATH.open("r", encoding="utf-8") as config_file:
+        ros2_control = yaml.safe_load(config_file)["ros2_control"]
+    return frozenset(
+        ros2_control["controllers_active_at_startup"]
+        + ros2_control["controllers_inactive_at_startup"]
+    )
+
+
+REQUIRED_CONTROLLERS = _spawned_controllers_from_config()
+# A controller in either of these states is loaded and configured; "inactive"
+# is enough for a chained controller to export its command interfaces.
+CONFIGURED_CONTROLLER_STATES = ("inactive", "active")
+CONTROLLER_LOAD_TIMEOUT_S = 300.0
+LIST_CONTROLLERS_CALL_TIMEOUT_S = 10.0
+
+
+@pytest.fixture(scope="module", autouse=True)
+def wait_for_controllers_loaded(
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Block until every spawned controller is loaded and configured.
+
+    Waits for each controller in ``REQUIRED_CONTROLLERS`` to report
+    ``inactive`` or ``active`` from ``/controller_manager/list_controllers``,
+    once per module. ``inactive`` is enough: a configured chained controller
+    (platform_velocity_controller) already exports the command interfaces the
+    whole-body joint_trajectory_controller claims on activation.
+
+    Defined after ``wait_for_mujoco_reset_service`` on purpose: pytest runs
+    module-scoped autouse fixtures in definition order, and the MuJoCo reset
+    service must be warm before the first per-test reset regardless of how
+    long the controller wait takes. Keep this fixture below that one.
+    """
+    node = execute_objective_resource.node
+    client = node.create_client(ListControllers, "/controller_manager/list_controllers")
+    missing = set(REQUIRED_CONTROLLERS)
+    deadline = time.monotonic() + CONTROLLER_LOAD_TIMEOUT_S
+    try:
+        while time.monotonic() < deadline:
+            if not client.wait_for_service(timeout_sec=1.0):
+                continue
+            future = client.call_async(ListControllers.Request())
+            call_deadline = time.monotonic() + LIST_CONTROLLERS_CALL_TIMEOUT_S
+            while not future.done() and time.monotonic() < call_deadline:
+                rclpy.spin_once(node, timeout_sec=0.1)
+            if not future.done():
+                # Abandoning an in-flight future and destroying the client
+                # later trips rcl "use after free" errors — cancel it first.
+                future.cancel()
+                # Pace the retry instead of re-issuing the call back-to-back.
+                rclpy.spin_once(node, timeout_sec=0.5)
+                continue
+            response = future.result()
+            configured = {
+                controller.name
+                for controller in response.controller
+                if controller.state in CONFIGURED_CONTROLLER_STATES
+            }
+            missing = set(REQUIRED_CONTROLLERS) - configured
+            if not missing:
+                return
+            rclpy.spin_once(node, timeout_sec=0.5)
+        pytest.fail(
+            f"Controllers not loaded and configured within "
+            f"{CONTROLLER_LOAD_TIMEOUT_S:.1f}s: {sorted(missing)}. "
+            "Objectives that switch controllers cannot run."
+        )
+    finally:
+        node.destroy_client(client)
 
 
 # Fixed and end-effector frames the Cartesian objectives visualize and plan

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -26,17 +26,233 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Integration tests for the lab_sim objective library."""
+
+import time
+import weakref
+from typing import Any, Optional
+
 import pytest
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.client import Client
+from rclpy.node import Node
 from control_msgs.action import GripperCommand
+from controller_manager_msgs.srv import ListControllers, SwitchController
 from moveit_pro_test_utils.objective_test_fixture import (
     ExecuteObjectiveResource,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
     execute_objective_resource as execute_objective_resource,
     get_objective_pytest_params,
     reset_simulation_before_test as reset_simulation_before_test,
     run_objective,
 )
+
+CONTROLLER_MANAGER_SERVICE_TIMEOUT_S = 10.0
+# The very first reset can run before ros2_control has come up at all, so the
+# initial wait for list_controllers gets a cold-start budget. Once the service
+# has appeared on the graph, subsequent waits return immediately.
+CONTROLLER_MANAGER_COLD_START_TIMEOUT_S = 120.0
+
+# Cached controller_manager service clients, keyed weakly by owning node. The
+# reset hook runs before every test; caching avoids re-running DDS discovery
+# for the same two services on each reset (mirrors the reset_keyframe_client()
+# caching in ExecuteObjectiveResource). The weak keying drops the entry when
+# the node is garbage-collected, so a recreated node can never receive clients
+# that were created on a dead node.
+_controller_manager_clients: (
+    "weakref.WeakKeyDictionary[Node, tuple[Client, Client]]"
+) = weakref.WeakKeyDictionary()
+
+
+def _get_controller_manager_clients(node: Node) -> tuple[Client, Client]:
+    """Return cached (list_controllers, switch_controller) clients for ``node``."""
+    if node not in _controller_manager_clients:
+        _controller_manager_clients[node] = (
+            node.create_client(ListControllers, "/controller_manager/list_controllers"),
+            node.create_client(
+                SwitchController, "/controller_manager/switch_controller"
+            ),
+        )
+    return _controller_manager_clients[node]
+
+
+def _call_service(
+    node: Node, client: Client, request: Any, timeout_sec: float
+) -> Optional[Any]:
+    """Call a service and spin the node until the response arrives or times out.
+
+    Returns the response, or None when the service is unavailable or the call
+    does not complete within ``timeout_sec``.
+    """
+    if not client.wait_for_service(timeout_sec=timeout_sec):
+        return None
+    future = client.call_async(request)
+    deadline = time.monotonic() + timeout_sec
+    while not future.done() and time.monotonic() < deadline:
+        rclpy.spin_once(node, timeout_sec=0.1)
+    if not future.done():
+        future.cancel()
+        return None
+    return future.result()
+
+
+def _wait_until_controllers_active(
+    node: Node,
+    list_client: Client,
+    controller_names: list[str],
+    timeout_sec: float,
+) -> bool:
+    """Poll list_controllers until every named controller reports "active".
+
+    Returns False when the controllers have not all reached "active" within
+    ``timeout_sec``.
+    """
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        response = _call_service(
+            node, list_client, ListControllers.Request(), timeout_sec
+        )
+        if response is not None:
+            active = {
+                controller.name
+                for controller in response.controller
+                if controller.state == "active"
+            }
+            if set(controller_names) <= active:
+                return True
+        rclpy.spin_once(node, timeout_sec=0.1)
+    return False
+
+
+def _controller_safe_mujoco_reset(
+    context: ExecuteObjectiveResource,
+    keyframe_name: str,
+    timeout_sec: float,
+    settle_sec: float,
+) -> Optional[bool]:
+    """Reset the MuJoCo keyframe with active controllers cycled around the reset.
+
+    The plain keyframe reset writes the keyframe qpos/ctrl into the sim, but an
+    active position-holding controller (joint_trajectory_controller after an
+    interrupted or cancelled motion) re-commands its stale hold setpoint on the
+    very next update cycle, driving the arm straight back to the pre-reset pose.
+    The next test then fails PlanToJointGoal start-state validation with
+    "initial joint positions are not valid: self-collision" — the repeating CI
+    flake on mpc_pose_tracking_static_point_cloud_avoidance_with_sphere_down_sample
+    and grasp_pose_using_yaml.
+
+    Cycling fixes that: deactivate every active controller that claims command
+    interfaces (broadcasters claim none and are left alone), reset the keyframe,
+    then reactivate the same set. Re-activation re-initializes each controller's
+    hold state at the post-reset (keyframe) position.
+    """
+    node = context.node
+    list_client, switch_client = _get_controller_manager_clients(node)
+    # Fail closed when the controllers cannot be enumerated: without the
+    # active-controller list the cycling guarantee is gone and a stale hold
+    # setpoint could survive the reset — exactly the flake this hook removes.
+    # Still perform the plain keyframe reset first to restore the best state
+    # we can before the fixture aborts the test.
+    if not list_client.wait_for_service(
+        timeout_sec=CONTROLLER_MANAGER_COLD_START_TIMEOUT_S
+    ):
+        print(
+            "[lab_sim] list_controllers not advertised within "
+            f"{CONTROLLER_MANAGER_COLD_START_TIMEOUT_S:.1f}s; cannot verify "
+            "controller state around the keyframe reset.",
+            flush=True,
+        )
+        MUJOCO_RESET_HOOK(context, keyframe_name, timeout_sec, settle_sec)
+        return False
+    list_response = _call_service(
+        node,
+        list_client,
+        ListControllers.Request(),
+        CONTROLLER_MANAGER_SERVICE_TIMEOUT_S,
+    )
+    if list_response is None:
+        print(
+            "[lab_sim] list_controllers call timed out; cannot verify "
+            "controller state around the keyframe reset.",
+            flush=True,
+        )
+        MUJOCO_RESET_HOOK(context, keyframe_name, timeout_sec, settle_sec)
+        return False
+    holding_controllers = [
+        controller.name
+        for controller in list_response.controller
+        if controller.state == "active" and controller.claimed_interfaces
+    ]
+    deactivate_ok = True
+    if holding_controllers:
+        # STRICT: the set was computed from the live "active" list one call
+        # ago and nothing switches controllers between tests, so a failure
+        # here is a real problem, not an already-inactive controller.
+        deactivate_request = SwitchController.Request()
+        deactivate_request.deactivate_controllers = holding_controllers
+        deactivate_request.strictness = SwitchController.Request.STRICT
+        deactivate_response = _call_service(
+            node,
+            switch_client,
+            deactivate_request,
+            CONTROLLER_MANAGER_SERVICE_TIMEOUT_S,
+        )
+        deactivate_ok = deactivate_response is not None and deactivate_response.ok
+        if not deactivate_ok:
+            # The reset below still runs to restore the best state we can,
+            # but the stale-hold-pose problem this hook exists to fix may
+            # recur — fail closed via the return value so the fixture aborts
+            # the test loudly instead of running on polluted state.
+            print(
+                "[lab_sim] Failed to deactivate controllers "
+                f"{holding_controllers} before keyframe reset.",
+                flush=True,
+            )
+    # settle_sec=0 here: settling is deferred until after reactivation below.
+    reset_ok = MUJOCO_RESET_HOOK(context, keyframe_name, timeout_sec, 0.0)
+    reactivate_ok = True
+    if holding_controllers:
+        # BEST_EFFORT on reactivation: a STRICT failure on one controller
+        # would leave the rest deactivated too. The verification below is the
+        # real gate.
+        activate_request = SwitchController.Request()
+        activate_request.activate_controllers = holding_controllers
+        activate_request.strictness = SwitchController.Request.BEST_EFFORT
+        activate_response = _call_service(
+            node,
+            switch_client,
+            activate_request,
+            CONTROLLER_MANAGER_SERVICE_TIMEOUT_S,
+        )
+        reactivate_ok = activate_response is not None and activate_response.ok
+        if reactivate_ok:
+            # SwitchController returns ok when the switch is accepted, not
+            # when on_activate has run — confirm via list_controllers that
+            # every cycled controller reports "active" again before settling.
+            reactivate_ok = _wait_until_controllers_active(
+                node,
+                list_client,
+                holding_controllers,
+                CONTROLLER_MANAGER_SERVICE_TIMEOUT_S,
+            )
+        if not reactivate_ok:
+            print(
+                "[lab_sim] Failed to reactivate controllers "
+                f"{holding_controllers} after keyframe reset.",
+                flush=True,
+            )
+    if settle_sec > 0:
+        # Best-effort settle for the reactivated controllers to converge on
+        # the keyframe pose before the next test ticks behaviors.
+        time.sleep(settle_sec)
+    return bool(reset_ok) and deactivate_ok and reactivate_ok
+
+
+# Override the fixture's default lab_sim registration ("last call wins") with
+# the controller-cycling variant above.
+SIM_RESETTER.register("lab_sim", _controller_safe_mujoco_reset)
 
 # Looping objectives to cancel partway through
 cancel_objectives = {


### PR DESCRIPTION
## Motivation

The example_ws CI workflow has two repeating integration-test flakes (multiple main-branch failures on 2026-06-08/09):

- **hangar_sim** — `Cartesian Draw Geometry From File` failed in 4 dispatched main runs with error 99999, via two mechanisms: the controller spawners (`--controller-manager-timeout 180`) lag minutes behind the first tests on a loaded runner, so the objective's `SwitchController` hit "Controller joint_trajectory_controller is not an existing controller" / "command interface platform_velocity_controller/linear_x_joint/velocity is not available"; and the objective publishes the `local` TF frame from a parallel `PublishTF` branch, where a single fixed 1 s delay races the TF buffer ("Cannot find transform between frames `world` and `local`").
- **lab_sim** — `mpc_pose_tracking_static_point_cloud_avoidance_with_sphere_down_sample` and `grasp_pose_using_yaml` fail in under a second with `PlanToJointGoal Error: initial joint positions are not valid: self-collision`. The preceding dynamic MPC objective halts mid-motion by design (7 s `Timeout` → `AlwaysSuccess`); the keyframe reset then runs, but the still-active `joint_trajectory_controller` re-commands its stale hold setpoint on the next update cycle and drives the arm straight back into the colliding pose (`handle_keyframe_reset_service` only resets hardware-level commands). This is the same mechanism documented in hangar's "Solution - Draw Picknik" skip comment.

## Brief description

- `lab_sim` test: register a controller-cycling reset hook (`SIM_RESETTER.register("lab_sim", ...)`, last-call-wins over the fixture default) that deactivates active command-claiming controllers (STRICT), resets the keyframe, reactivates them (BEST_EFFORT) and verifies they report `active` again before settling. Fails closed — a failed deactivate/reactivate returns `False` so `reset_simulation_before_test` aborts the test loudly.
- `hangar_sim` test: module-scoped autouse `wait_for_controllers_loaded` fixture that blocks until every controller listed in `config.yaml` (read from the config at import, so the list cannot drift) reports `inactive`/`active` from `/controller_manager/list_controllers`.
- `cartesian_draw_geometry_from_file.xml`: retry the wait+plan+visualize block up to 5 times using `Inverter` + `RepeatUnlessFailureEachTick` + `Inverter` (the non-deprecated equivalent of `RetryUntilSuccessful`, which is slated for removal in 10.0); `ExecuteTrajectory` stays outside the loop. Also drops a pre-existing duplicate `MetadataFields` block.

## How it was tested

- `colcon build --packages-select lab_sim hangar_sim` in the dev container — both clean, no warnings.
- `python3 -m py_compile` on both test modules and XML well-formedness on the objective inside the container (Python 3.10 / Humble image).
- Verified `controller_manager_msgs` field names (`controller`, `claimed_interfaces`, `activate_controllers`/`deactivate_controllers`, `BEST_EFFORT`, `ok`) against the installed Humble messages; same API on Jazzy.
- Imported both modified test modules in-container to exercise the module-level hook registration and the config-derived controller list (all 11 hangar controller names resolved).
- The integration suites themselves run in this PR's CI — that is the end-to-end validation.

## Release notes

None

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` right after the checkbox plus a brief reason. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these. See [`.claude/rules/agent-delegation.md`](../.claude/rules/agent-delegation.md) for when each agent is required.*

- [x] `code-reviewer` (required) — 9 findings addressed (deprecated decorator replaced, deactivate response checked, futures cancelled, clients cached, docstring/annotations added, duplicate MetadataFields removed)
- [x] `test-runner` (required) — built lab_sim + hangar_sim in the dev container; integration suites deferred to this PR's CI
- [x] `platform-architect-bot` (required for backend / C++ / ROS / REST / build-CI changes) — 2 Major + 5 Minor findings addressed (fail-closed reset hook, STRICT deactivate, post-activate verification, config-derived controller list, weakref client cache)
- [x] SKIPPED `frontend-noah-bot` (required when `src/web/frontend/**` changes) — no frontend files changed
- [x] SKIPPED `security-auditor` (required for security-sensitive paths) — test harness and objective XML only

needs: moveit_pro/#19665
