### PR TITLE
Fix: Main CI runs silently pinned to a stale arch-less backend image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,11 +193,27 @@ jobs:
             // suffix-bearing image_ref for every GPU path. Two published tag
             // shapes are reproduced here:
             //   - PR-specific per-arch image:  <tag>-<distro>-amd64<suffix>
-            //     (set above for dispatch / needs-paired-PR)
-            //   - main/release multiarch tag:  <tag>-<distro><suffix>
-            //     (the fallback below for push / schedule / plain PR)
+            //     (set above for dispatch / needs-paired-PR, and the main
+            //     fallback below)
+            //   - release multiarch tag:       <tag>-<distro><suffix>
+            //     (the fallback below for release-branch push / PR)
+            //
+            // The main fallback must use the per-arch shape: moveit_pro
+            // stopped publishing the arch-less main aliases on 2026-06-03
+            // (main-jazzy-cuda12.6-cudnn9 is frozen at that date on Docker
+            // Hub), so push/schedule/plain-PR runs against main were silently
+            // pinned to that week-old image (surfaced as an EndStateSpec
+            // ImportError once example_ws #698 needed a newer moveit_pro API).
+            // The arch-suffixed main-<distro>-amd64<suffix> tags update with
+            // every moveit_pro main merge; -amd64 matches the
+            // picknik-16-amd64-gpu runner below. Release branches (v9.2,
+            // v9.3) only have arch-less tags and keep the multiarch shape.
+            // repository_dispatch is excluded: a payload without image_ref
+            // must not be redirected to today's main image.
             if (image_ref === '') {
-              image_ref = `${dockerhubUsername}/moveit-studio:${image_tag}-{0}`;
+              const archSegment =
+                image_tag === 'main' && event !== 'repository_dispatch' ? '-amd64' : '';
+              image_ref = `${dockerhubUsername}/moveit-studio:${image_tag}-{0}${archSegment}`;
             }
             if (!image_ref_has_suffix) {
               image_ref = `${image_ref}${gpu_image_suffix}`;


### PR DESCRIPTION
## Motivation

Every main-based example_ws CI run (plain PR, push, schedule) has been silently testing against a backend image frozen on **2026-06-03**. The `resolve` job's empty-`image_ref` fallback builds the arch-less Docker Hub alias (`main-<distro>-cuda12.6-cudnn9`) — which moveit_pro stopped publishing on June 3 (`main-jazzy` and `main-jazzy-cuda12.6-cudnn9` both show `last_updated: 2026-06-03T06:05` on Docker Hub, while the arch-suffixed `main-jazzy-amd64-*` tags update with every moveit_pro main merge).

This surfaced when #698 merged: its hangar test needs the `EndStateSpec` API from moveit_pro #19665 (merged today), but every run keeps pulling the June 3 image and fails collection with `ImportError: cannot import name 'EndStateSpec'` — including the main push run for #700's merge and PR #701's re-runs.

## Brief description

In the empty-`image_ref` fallback (post-#702 structure, where the suffix is baked into `image_ref` here), use the per-arch tag shape for main: `main-{0}-amd64` + suffix instead of `main-{0}` + suffix. Scoped deliberately:

- `repository_dispatch` is excluded — a payload without an explicit `image_ref` must not be redirected to today's main image.
- Release branches (`v9.2`, `v9.3`) keep the multiarch arch-less shape — only those tags exist for them on Docker Hub.
- `image_tag` is untouched, so `MOVEIT_DOCKER_TAG` and the ccache key are unchanged.

Tradeoff: a run firing in the short window between a moveit_pro main merge and its tag publication now fails loudly at image pull instead of silently testing a stale image; the job comment names that cause.

## How it was tested

- Verified on Docker Hub: arch-less `main-*` aliases frozen at 2026-06-03; arch-suffixed `main-{jazzy,humble}-amd64[-cuda12.6-cudnn9]` pushed within the last hours (post-#19665, contain `EndStateSpec`); `v9.2-jazzy` exists only arch-less.
- Traced all trigger shapes (PR with/without `needs:` token, push, schedule, workflow_dispatch with/without `image_tag` input, repository_dispatch with/without payload `image_ref`) — only the intended ones take the new path; suffix baking (`image_ref_has_suffix`) is unaffected.
- yamllint / pre-commit pass. This PR's own hangar/lab integration runs are the live validation: they should pull the fresh arch-suffixed image and collect the #698 test successfully.

## Release notes

None

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` right after the checkbox plus a brief reason. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these. See [`.claude/rules/agent-delegation.md`](../.claude/rules/agent-delegation.md) for when each agent is required.*

- [x] `code-reviewer` (required) — P0 repository_dispatch guard + comment notes applied
- [x] SKIPPED `test-runner` (required) — workflow-only change, nothing buildable; this PR's own CI run is the validation
- [x] `platform-architect-bot` (required for backend / C++ / ROS / REST / build-CI changes) — no required changes; pull-failure comment extended per its Minor finding
- [x] SKIPPED `frontend-noah-bot` (required when `src/web/frontend/**` changes) — no frontend files changed
- [x] SKIPPED `security-auditor` (required for security-sensitive paths) — CI image-ref resolution only
