### PR TITLE
Fix: Default jazzy needs: image suffix to cuda13.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,15 +108,16 @@ jobs:
             // in v0.9.0 / PR #37) — so the suffix must live in `image_ref`.
             //
             // example_ws runs integration jazzy-only (humble is disabled), so the
-            // map carries only `jazzy`. The default is the CONSERVATIVE legacy
-            // suffix (-cuda12.6-cudnn9), NOT the newest CUDA the Jazzy migration
-            // targets: moveit_pro owns the distro<->CUDA coupling (its build-matrix
-            // exclusion anchors) and is the single source of truth. On a
-            // repository_dispatch it overrides the per-distro value from its
-            // payload once it publishes a divergent suffix (#19583). To re-enable
-            // humble: add a `humble` entry here AND to integration-test's
-            // `ros_distro` matrix.
-            let gpu_image_suffixes = { jazzy: '-cuda12.6-cudnn9' };
+            // map carries only `jazzy`. The default must track what moveit_pro
+            // actually publishes for jazzy: since the CUDA 13.2 migration
+            // (#19583 fanout), jazzy images carry -cuda13.2-cudnn9 ONLY — the
+            // old -cuda12.6 jazzy variant is no longer built, so a stale default
+            // 404s every `needs:` pull. moveit_pro owns the distro<->CUDA
+            // coupling (its build-matrix exclusion anchors) and is the single
+            // source of truth: on a repository_dispatch its payload overrides
+            // this value. To re-enable humble: add a `humble` entry here AND to
+            // integration-test's `ros_distro` matrix.
+            let gpu_image_suffixes = { jazzy: '-cuda13.2-cudnn9' };
             // The single ros_distro example_ws runs integration on — must match
             // the `integration-test` matrix / `ros_distros` input below. The
             // suffix is selected for THIS distro. If humble is ever re-enabled,


### PR DESCRIPTION
needs: moveit_pro/#19732

## Motivation

Every `pull_request` run with a `needs: moveit_pro/#N` token currently 404s at container init: the resolve step's default jazzy GPU suffix is `-cuda12.6-cudnn9`, but since the CUDA 13.2 migration moveit_pro publishes jazzy images with `-cuda13.2-cudnn9` **only** — the cuda12.6 jazzy tag is no longer built.

## Brief description

Bump the resolve step's default `gpu_image_suffixes` jazzy entry to `-cuda13.2-cudnn9` and update the comment: the default must track what moveit_pro actually publishes, not a "conservative legacy" value that no longer exists. The `repository_dispatch` path is unaffected — moveit_pro's payload (`GPU_IMAGE_SUFFIXES`, moveit_pro `ci.yaml:514`) already overrides this default.

## How it was tested

- `actionlint` + pre-commit clean.
- The `needs:` token above points this PR's own integration run at moveit_pro #19732's jazzy image, which exists only under the cuda13.2 suffix — the run itself validates the fix end-to-end.
