### PR TITLE
Add behavior_hub_catalog config for the Behaviors Hub export

### DIFF
--- a/src/behavior_hub_catalog/CMakeLists.txt
+++ b/src/behavior_hub_catalog/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.22)
+project(behavior_hub_catalog)
+
+find_package(ament_cmake REQUIRED)
+
+# Config-only package: it inherits everything else from lab_sim via
+# `based_on_package`, so only the config directory is installed.
+install(
+  DIRECTORY
+    config
+  DESTINATION
+    share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/behavior_hub_catalog/MOVEIT_PRO_IGNORE
+++ b/src/behavior_hub_catalog/MOVEIT_PRO_IGNORE
@@ -1,0 +1,3 @@
+# Presence of this file hides the package from the MoveIt Pro robot/config picker.
+# This config is generation-only (Behaviors Hub data dump); it still builds and can
+# be launched explicitly via MOVEIT_CONFIG_PACKAGE=behavior_hub_catalog.

--- a/src/behavior_hub_catalog/config/config.yaml
+++ b/src/behavior_hub_catalog/config/config.yaml
@@ -1,0 +1,19 @@
+#
+# Behavior Hub catalog config.
+#
+# Used only to generate the data behind the picknik.ai Behaviors Hub — it is not a
+# robot a user would run. It inherits lab_sim and adds NavBehaviorsLoader so the
+# `/behaviors/data` dump includes Nav behaviors (e.g. `ComputePathToPoseAction`),
+# which lab_sim's loader set omits (see picknik.ai#3086).
+#
+# The backend unions `behavior_loader_plugins` across the whole `based_on_package`
+# chain (moveit_studio_utils_py system_config.get_behavior_loader_plugins), so this
+# config only needs to ADD the missing loader — lab_sim's loaders, objectives, robot,
+# and everything else are inherited automatically and stay in sync with no edits here.
+#
+based_on_package: "lab_sim"
+objectives:
+  behavior_loader_plugins:
+    # Adds the Navigation behaviors on top of lab_sim's set (unioned by the backend).
+    nav:
+      - "moveit_pro::behaviors::NavBehaviorsLoader"

--- a/src/behavior_hub_catalog/package.xml
+++ b/src/behavior_hub_catalog/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<package format="3">
+  <name>behavior_hub_catalog</name>
+  <version>6.5.0</version>
+
+  <description>
+    Behavior Hub catalog configuration. Inherits lab_sim and adds the Navigation
+    behavior loader so the picknik.ai Behaviors Hub data export includes Nav
+    behaviors. Generation-only; not intended as a runnable robot config.
+  </description>
+
+  <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
+  <license>Proprietary</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>lab_sim</exec_depend>
+  <exec_depend>moveit_studio_agent</exec_depend>
+  <exec_depend>moveit_pro_behavior</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/behavior_hub_catalog/package.xml
+++ b/src/behavior_hub_catalog/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>behavior_hub_catalog</name>
-  <version>6.5.0</version>
+  <version>9.4.0</version>
 
   <description>
     Behavior Hub catalog configuration. Inherits lab_sim and adds the Navigation

--- a/src/behavior_hub_catalog/package.xml
+++ b/src/behavior_hub_catalog/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>behavior_hub_catalog</name>
-  <version>9.4.0</version>
+  <version>9.5.0</version>
 
   <description>
     Behavior Hub catalog configuration. Inherits lab_sim and adds the Navigation


### PR DESCRIPTION
## What
Adds a small, generation-only config package, `behavior_hub_catalog`, used to export the data behind the picknik.ai Behaviors Hub.

## Why
The Hub data is dumped from `GET /behaviors/data` of a single running config, and that config's behavior loaders determine which behaviors appear. No single existing config loads the full union — `lab_sim` omits `NavBehaviorsLoader`, so Nav behaviors (e.g. `ComputePathToPoseAction`) were missing from the Hub (PickNikRobotics/picknik.ai#3086). Rather than mutate a real robot config for marketing-data extraction, this dedicated config inherits `lab_sim` and adds the Nav loader.

## How
`config/config.yaml` is `based_on_package: lab_sim` and adds only `objectives.behavior_loader_plugins.nav: [NavBehaviorsLoader]`. The backend unions `behavior_loader_plugins` across the whole inheritance chain (`moveit_studio_utils_py` `get_behavior_loader_plugins`), so everything else — lab_sim's loaders, objectives, robot description — is inherited and stays in sync with no edits here. A `MOVEIT_PRO_IGNORE` marker keeps it out of the user-facing robot picker while still building and being launchable by name.

Verified in-container: resolving this config yields the chain `picknik_ur_base_config → lab_sim → behavior_hub_catalog` and a loader union of lab_sim's 7 loaders + `NavBehaviorsLoader`. `colcon build` succeeds.

Towards PickNikRobotics/picknik.ai#3086. The Hub data refresh (regenerated `behaviors.json` on picknik.ai) is driven by the `update-behavior-hub` skill, which is updated to dump from this config.