### PR TITLE
Bump src package versions to 9.5.0

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,81 @@
+name: Bump version
+
+on:
+  workflow_call:
+    inputs:
+      current_version:
+        description: 'Current version for the bump'
+        required: true
+        type: string
+      new_version:
+        description: 'New version for the bump'
+        required: true
+        type: string
+      base_branch:
+        description: 'Branch to check out and PR against. Defaults to the caller workflow''s ref.'
+        required: false
+        type: string
+        default: ''
+
+  workflow_dispatch:
+    inputs:
+      current_version:
+        description: 'Current version for the bump'
+        required: true
+        type: string
+      new_version:
+        description: 'New version for the bump'
+        required: true
+        type: string
+      base_branch:
+        description: 'Branch to check out and PR against. Defaults to the caller workflow''s ref.'
+        required: false
+        type: string
+        default: ''
+
+env:
+  CURRENT_VERSION: ${{ inputs.current_version }}
+  NEW_VERSION: ${{ inputs.new_version }}
+  BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Input Check
+        run: |
+          echo "# Inputs received " >> $GITHUB_STEP_SUMMARY
+          echo "Input versions: $CURRENT_VERSION && $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "Base branch: $BASE_BRANCH" >> $GITHUB_STEP_SUMMARY
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+
+      - name: Bump version
+        run: |
+          # Source-tree version strings, excluding vendored external_dependencies.
+          mapfile -t SRC_FILES < <(grep -r "$CURRENT_VERSION" --include=package.xml --include=setup.py --include=package.json ./src/ -l | grep -v '^./src/external_dependencies/' || true)
+          for f in "${SRC_FILES[@]}"; do
+            sed -i "s|$CURRENT_VERSION|$NEW_VERSION|g" "$f"
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          title: "Bump version to ${{ inputs.new_version }}"
+          body: |
+            Prep for ${{ inputs.new_version }} release from ${{ inputs.current_version }}.
+          commit-message: "Bump version to ${{ inputs.new_version }}"
+          branch: ${{ inputs.current_version }}-to-${{ inputs.new_version }}
+          base: ${{ env.BASE_BRANCH }}
+          draft: always-true

--- a/src/april_tag_sim/package.xml
+++ b/src/april_tag_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>april_tag_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     MuJoCo simulation configuration package for Picknik's UR robot on a linear

--- a/src/dual_arm_sim/package.xml
+++ b/src/dual_arm_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>dual_arm_sim</name>
-  <version>7.4.0</version>
+  <version>9.5.0</version>
 
   <description>Base configuration package for the Franka arm.</description>
 

--- a/src/example_behaviors/package.xml
+++ b/src/example_behaviors/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package format="3">
   <name>example_behaviors</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
   <description>Example behaviors for MoveIt Pro</description>
 
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>

--- a/src/factory_sim/package.xml
+++ b/src/factory_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>factory_sim</name>
-  <version>7.2.0</version>
+  <version>9.5.0</version>
 
   <description>
     A MoveIt Pro configuration for a Fanuc LR Mate 200iD.

--- a/src/grinding_sim/package.xml
+++ b/src/grinding_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>grinding_sim</name>
-  <version>7.0.0</version>
+  <version>9.5.0</version>
 
   <description>
     Simulation configuration package for Premier Lab's Fanuc R-2000iD/165FH

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>hangar_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
   <description>
     MuJoCo simulation configuration package for Picknik's UR robot on a linear
     rail

--- a/src/kitchen_sim/package.xml
+++ b/src/kitchen_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>kitchen_sim</name>
-  <version>7.4.0</version>
+  <version>9.5.0</version>
 
   <description>Base configuration package for the Franka arm.</description>
 

--- a/src/lab_sim/package.xml
+++ b/src/lab_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>lab_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     MuJoCo simulation configuration package for Picknik's UR robot on a linear

--- a/src/lab_sim_behaviors/package.xml
+++ b/src/lab_sim_behaviors/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package format="3">
   <name>lab_sim_behaviors</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
   <description>Lab sim specific behavior plugins for MoveIt Pro</description>
 
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>

--- a/src/lunar_sim/package.xml
+++ b/src/lunar_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>lunar_sim</name>
-  <version>9.1.0</version>
+  <version>9.5.0</version>
 
   <description>
     MuJoCo simulation configuration package for the dual-arm mobile robot

--- a/src/moveit_pro_franka_configs/franka_base_config/package.xml
+++ b/src/moveit_pro_franka_configs/franka_base_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>franka_base_config</name>
-  <version>7.4.0</version>
+  <version>9.5.0</version>
 
   <description>Base configuration package for the Franka arm.</description>
 

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/package.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>kinova_gen3_base_config</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>Base config package for a Kinova Gen3 system</description>
 

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/package.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>kinova_gen3_site_config</name>
-  <version>5.1.0</version>
+  <version>9.5.0</version>
 
   <description>
     Robot config package for the Kinova Gen3 Dev-003 Robot in the Boulder

--- a/src/moveit_pro_kinova_configs/kinova_sim/package.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>kinova_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     Configuration package for a UR arm that can be simulated with mock hardware

--- a/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/package.xml
+++ b/src/moveit_pro_kinova_configs/moveit_studio_kinova_pstop_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_studio_kinova_pstop_manager</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
   <description>
     Provides a node to monitor the protective stop state of the Kinova, and
     reset protective stops when necessary.

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/package.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>space_satellite_sim</name>
-  <version>0.1.0</version>
+  <version>9.5.0</version>
 
   <description>
     A MoveIt Pro configuration to simulate satellite grappling with a Kinova

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/package.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>space_satellite_sim_camera_cal</name>
-  <version>7.7.0</version>
+  <version>9.5.0</version>
 
   <description>
     MoveIt Pro sub-configuration of the space_satellite_sim package to use for

--- a/src/moveit_pro_ur_configs/mock_sim/package.xml
+++ b/src/moveit_pro_ur_configs/mock_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>mock_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     Configuration package for a UR arm that can be simulated with mock hardware

--- a/src/moveit_pro_ur_configs/multi_arm_sim/package.xml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>multi_arm_sim</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>Example configuration package for multiple UR arms.</description>
 

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/package.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>picknik_ur_base_config</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     Base configuration package for Picknik's UR robot arms

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/package.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>picknik_ur_site_config</name>
-  <version>6.5.0</version>
+  <version>9.5.0</version>
 
   <description>
     Site configuration package for a UR arm that can be simulated with mock

--- a/src/picknik_accessories/package.xml
+++ b/src/picknik_accessories/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="3">
   <name>picknik_accessories</name>
-  <version>6.0.0</version>
+  <version>9.5.0</version>
   <description>
     URDFs and geometry for common objects and attachments.
   </description>


### PR DESCRIPTION
## Problem

Package versions across the first-party `src/` packages in this workspace were inconsistent — ranging from `0.1.0` to `9.1.0`, with most stuck at `6.5.0`. There was also no automated way to bump them for a release.

## Changes

- Set `<version>` to `9.5.0` in all 22 first-party `package.xml` files under `src/`, unifying the previously mixed versions.
- Add a `bump_version` workflow (`workflow_call` + `workflow_dispatch`) that rewrites version strings in `package.xml`/`setup.py`/`package.json` and opens a draft PR.

## Scope and why

- **Vendored deps excluded.** The bump and the workflow both skip `src/external_dependencies/` (Fanuc, Kortex, UR description, etc.) — those are submodules with their own upstream versioning. The workflow enforces this with `grep -v '^./src/external_dependencies/'`.
- **Submodule packages excluded.** `moveit_pro_clipseg`, `moveit_pro_sam2`, and `moveit_pro_sam3` are submodules; their versions are owned by their own repos and are intentionally not touched here.
- The workflow is a trimmed adaptation of the one in `moveit_pro` — the release-notes drafting and `.env`/`moveit_pro_config` bump steps were dropped because this workspace has none of those files.
