### PR TITLE
Improve factory_sim sim and 3D viewer visuals

### DIFF
--- a/src/factory_sim/description/picknik_fanuc.xacro
+++ b/src/factory_sim/description/picknik_fanuc.xacro
@@ -15,6 +15,10 @@
     filename="$(find factory_sim)/description/fanuc_lrmate200id.ros2_control.xacro"
   />
 
+  <material name="pedestal_metal">
+    <color rgba="0.30 0.32 0.35 1.0" />
+  </material>
+
   <link name="world"/>
   <link name="arm_pedestal">
     <visual>
@@ -22,31 +26,36 @@
       <geometry>
         <box size="0.4 0.4 0.3" />
       </geometry>
+      <material name="pedestal_metal" />
     </visual>
     <visual>
       <origin rpy="0 0 0" xyz="0.23 0.05 0.1" />
       <geometry>
         <box size="0.12 0.02 0.02" />
       </geometry>
+      <material name="pedestal_metal" />
     </visual>
     <visual>
       <origin rpy="0 0 0" xyz="0.23 0.11 0.1" />
       <geometry>
         <box size="0.12 0.02 0.02" />
       </geometry>
+      <material name="pedestal_metal" />
     </visual>
     <visual>
       <origin rpy="0 0 0" xyz="0.23 -0.05 0.1" />
       <geometry>
         <box size="0.12 0.02 0.02" />
       </geometry>
+      <material name="pedestal_metal" />
     </visual>
     <visual>
       <origin rpy="0 0 0" xyz="0.23 -0.11 0.1" />
       <geometry>
         <box size="0.12 0.02 0.02" />
       </geometry>
-    </visual>    
+      <material name="pedestal_metal" />
+    </visual>
   </link>
   <joint name="scene_joint" type="fixed">
     <parent link="world" />

--- a/src/factory_sim/description/scene.xml
+++ b/src/factory_sim/description/scene.xml
@@ -20,21 +20,15 @@
       scale="0.001 0.001 0.002"
     />
 
-    <texture
-      type="skybox"
-      builtin="gradient"
-      rgb1="0.3 0.5 0.7"
-      rgb2="0 0 0"
-      width="512"
-      height="3072"
-    />
+    <!-- Blue checker floor: rgb1/rgb2 are the light/dark alternating squares. -->
     <texture
       type="2d"
       name="groundplane"
-      builtin="flat"
-      mark="random"
-      rgb1="0.47 0.42 0.41"
-      markrgb="0.2 0.2 0.2"
+      builtin="checker"
+      mark="edge"
+      rgb1="0.2 0.3 0.4"
+      rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8"
       width="300"
       height="300"
     />
@@ -43,8 +37,13 @@
       texture="groundplane"
       texuniform="true"
       texrepeat="5 5"
-      reflectance="0"
-      metallic="0"
+      reflectance="0.2"
+    />
+    <material
+      name="pedestal_metal"
+      rgba="0.30 0.32 0.35 1"
+      specular="0.4"
+      shininess="0.5"
     />
   </asset>
 
@@ -54,6 +53,10 @@
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
     <global azimuth="120" elevation="-20" offwidth="1280" offheight="720" />
+    <!-- Render quality only (no physics effect): 4x MSAA + larger shadow map.
+         map haze=0.1 is below MuJoCo's 0.3 default, so haze is subtle. -->
+    <quality offsamples="4" shadowsize="4096" />
+    <map haze="0.1" />
   </visual>
 
   <!-- Add Fanuc support files -->
@@ -98,18 +101,38 @@
     />
 
     <body name="arm_pedestal" pos="0.0 0.0 0.15">
-      <geom type="box" size="0.2 0.2 0.15" />
+      <geom type="box" size="0.2 0.2 0.15" material="pedestal_metal" />
       <!-- Holder for tool 1 -->
-      <geom type="box" size="0.06 0.01 0.01" pos="0.23 0.05 0.1" />
-      <geom type="box" size="0.06 0.01 0.01" pos="0.23 0.11 0.1" />
+      <geom
+        type="box"
+        size="0.06 0.01 0.01"
+        pos="0.23 0.05 0.1"
+        material="pedestal_metal"
+      />
+      <geom
+        type="box"
+        size="0.06 0.01 0.01"
+        pos="0.23 0.11 0.1"
+        material="pedestal_metal"
+      />
       <site
         name="suction_gripper_holder_site"
         pos="0.25 0.08 0.15"
         euler="3.1415 0 0"
       />
       <!-- Holder for tool 2 -->
-      <geom type="box" size="0.06 0.01 0.01" pos="0.23 -0.05 0.1" />
-      <geom type="box" size="0.06 0.01 0.01" pos="0.23 -0.11 0.1" />
+      <geom
+        type="box"
+        size="0.06 0.01 0.01"
+        pos="0.23 -0.05 0.1"
+        material="pedestal_metal"
+      />
+      <geom
+        type="box"
+        size="0.06 0.01 0.01"
+        pos="0.23 -0.11 0.1"
+        material="pedestal_metal"
+      />
       <site
         name="inspection_tool_holder_site"
         pos="0.25 -0.08 0.15"


### PR DESCRIPTION
## Problem

`factory_sim` rendered with several flat-gray surfaces and a dated backdrop. The arm pedestal (the block the Fanuc sits on, plus its tool-holder tabs) had no material in either render path, so it showed as MuJoCo's default gray in the sim and flat white in the web 3D viewer. The scene also lacked basic render-quality settings.

## Changes

**MuJoCo sim (`scene.xml`):**
- Removed the gradient skybox so the background is a plain backdrop.
- Switched the floor from a flat brown ground to a blue checker tile.
- Added render-quality settings: `offsamples="4"` (MSAA), `shadowsize="4096"`, and `map haze="0.1"`. Pure render settings — no physics effect.
- Added a `pedestal_metal` material (dark metal) and applied it to the 5 pedestal geoms.

**Web 3D viewer (`picknik_fanuc.xacro`):**
- Defined a matching `pedestal_metal` material and referenced it on the 5 pedestal visuals, so the viewer renders the pedestal consistently with the sim.

## Scope / why

- Visual-only. No collision geometry, masses, joints, or contact parameters were touched.
- The `suction_tool_tip` geom flagged by analysis is `class="collision"`, so it was deliberately left alone.
- The Fanuc arm links and bowls already carry their own colors and were not modified.
- The two render paths are independent (MuJoCo vs. Three.js); the pedestal color is duplicated across both by necessity, kept identical (`0.30 0.32 0.35`).

## Verification

- Analyzer flat-render-risk dropped to 0 in both paths (excluding the intentional collision-geom exclusion).
- `xacro` expands cleanly; both files are well-formed XML.
- Visual confirmation in the running sim / viewer is pending.
