### PR TITLE
Suppress ros2_control overrun warnings in simulation configs

### DIFF
--- a/src/dual_arm_sim/config/control/franka_ros2_control.yaml
+++ b/src/dual_arm_sim/config/control/franka_ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
+++ b/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/grinding_sim/config/control/ur20.ros2_control.yaml
+++ b/src/grinding_sim/config/control/ur20.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/kitchen_sim/config/control/franka_ros2_control.yaml
+++ b/src/kitchen_sim/config/control/franka_ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/moveit_pro_ur_configs/mock_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/mock_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     io_and_status_controller:

--- a/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; overrun handling (overruns.manage) untouched.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     first_io_and_status_controller:


### PR DESCRIPTION
## Problem

On non-realtime machines (Parallels/Docker VMs, dev boxes), running any simulation floods the console with ros2_control overrun warnings:

```
[ros2_control_node] [WARN] Overrun detected! The controller manager missed its desired rate of 600 Hz. The loop took 2.84 ms (missed cycles : 2).
[ros2_control_node] [WARN] Overrun might occur, Total time : 2412 us (Expected < 1666.667 us) --> Read time : 1308 us, Update time : 64 us, Write time : 1039 us
```

These are **new in Jazzy** — the `controller_manager` version Jazzy ships (4.44.0) added an `overruns` reporting feature that Humble's older `controller_manager` did not have. The overruns themselves are harmless in simulation (a control cycle running late in sim has no physical consequence, and MuJoCo's own sim-health reporter confirms physics keeps up), but the WARN spam drowns out useful log output.

## Fix

Set `overruns.print_warnings: false` in the `controller_manager` block of every simulation config. This silences both warnings (they read the same flag). The sibling `overruns.manage` parameter is **left untouched**, so overrun *handling* behavior is unchanged — only the logging is suppressed.

## Scope

Applied to the 9 first-party simulation configs: `lab_sim`, `hangar_sim`, `factory_sim`, `grinding_sim`, `dual_arm_sim`, `kitchen_sim`, `mock_sim`, `multi_arm_sim`, `kinova_sim`.

- `space_satellite_sim` is covered transitively (`based_on_package: kinova_sim`).
- Real-hardware **base/site** configs are intentionally excluded — overrun warnings are meaningful on a physical robot.
- `phoebe_sim` is excluded: it lives in the `phoebe_ws` git submodule (separate repo).

## CI

example_ws CI is Jazzy-only (`humble is disabled` per `ci.yaml`), and `overruns.print_warnings` is a declared parameter in the Jazzy `controller_manager` 4.44.0, so the integration tests that launch `lab_sim`/`hangar_sim` load it without error.



Loading these configs under an older (Humble-era) `controller_manager` that predates the `overruns` parameter group is out of scope and unverified — this workspace targets Jazzy. A customer who copies a sim config into a Humble workspace should confirm load behavior there.
