### PR TITLE
Fix: Remove hangar_sim large-mesh warning

### DIFF
--- a/src/hangar_sim/description/assets/hangar_floor.dae
+++ b/src/hangar_sim/description/assets/hangar_floor.dae
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ff4756731e27354476f0a039edb60ac153184f1f07f04aaeffab2f901ee9d6e
-size 43425886

--- a/src/hangar_sim/description/assets/hangar_floor_00.obj
+++ b/src/hangar_sim/description/assets/hangar_floor_00.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:011d985f0d5850de162cafc6ce92014bbfed12f276b6cc3928a6d5a48f4030ff
+size 3844783

--- a/src/hangar_sim/description/assets/hangar_floor_01.obj
+++ b/src/hangar_sim/description/assets/hangar_floor_01.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb9b9534789a463b6214adfc30a2647a12b98fac2ae30bd645c807916bc8d90f
+size 3677436

--- a/src/hangar_sim/description/assets/hangar_floor_02.dae
+++ b/src/hangar_sim/description/assets/hangar_floor_02.dae
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:254e564eee644bafe468cbef306dbb17722b09fbb0ef870e24cfb871452402af
+size 9857328

--- a/src/hangar_sim/description/assets/hangar_floor_03.dae
+++ b/src/hangar_sim/description/assets/hangar_floor_03.dae
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07f24b41efa0c0d2bd85eed52a33139b2134715ec9e38c45b2fc20fea63aaae1
+size 9891426

--- a/src/hangar_sim/description/assets/hangar_floor_04.dae
+++ b/src/hangar_sim/description/assets/hangar_floor_04.dae
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e71486723c659ef5224a91ab16d43028d404bca46bc6d32c9eba0a737e3b619
+size 203437

--- a/src/hangar_sim/description/hangar_urdf.xacro
+++ b/src/hangar_sim/description/hangar_urdf.xacro
@@ -8,18 +8,70 @@
       <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
     </joint>
 
-    <!-- Use single link for visual mesh -->
-    <link name="visual_mesh">
+    <!-- Visual mesh split into 5 files to keep each under 10 MB -->
+    <link name="visual_mesh_00">
       <visual>
         <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://hangar_sim/description/assets/hangar_floor.dae" scale="1.0 1.0 1.0"/>
+          <mesh filename="package://hangar_sim/description/assets/hangar_floor_00.obj" scale="1.0 1.0 1.0"/>
         </geometry>
       </visual>
     </link>
-    <joint name="collision_SM_Floor_376_visual_mesh" type="fixed">
+    <joint name="collision_SM_Floor_376_visual_mesh_00" type="fixed">
       <parent link="collision_SM_Floor_376"/>
-      <child link="visual_mesh"/>
+      <child link="visual_mesh_00"/>
+      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+    </joint>
+    <link name="visual_mesh_01">
+      <visual>
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="package://hangar_sim/description/assets/hangar_floor_01.obj" scale="1.0 1.0 1.0"/>
+        </geometry>
+      </visual>
+    </link>
+    <joint name="collision_SM_Floor_376_visual_mesh_01" type="fixed">
+      <parent link="collision_SM_Floor_376"/>
+      <child link="visual_mesh_01"/>
+      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+    </joint>
+    <link name="visual_mesh_02">
+      <visual>
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="package://hangar_sim/description/assets/hangar_floor_02.dae" scale="1.0 1.0 1.0"/>
+        </geometry>
+      </visual>
+    </link>
+    <joint name="collision_SM_Floor_376_visual_mesh_02" type="fixed">
+      <parent link="collision_SM_Floor_376"/>
+      <child link="visual_mesh_02"/>
+      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+    </joint>
+    <link name="visual_mesh_03">
+      <visual>
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="package://hangar_sim/description/assets/hangar_floor_03.dae" scale="1.0 1.0 1.0"/>
+        </geometry>
+      </visual>
+    </link>
+    <joint name="collision_SM_Floor_376_visual_mesh_03" type="fixed">
+      <parent link="collision_SM_Floor_376"/>
+      <child link="visual_mesh_03"/>
+      <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+    </joint>
+    <link name="visual_mesh_04">
+      <visual>
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="package://hangar_sim/description/assets/hangar_floor_04.dae" scale="1.0 1.0 1.0"/>
+        </geometry>
+      </visual>
+    </link>
+    <joint name="collision_SM_Floor_376_visual_mesh_04" type="fixed">
+      <parent link="collision_SM_Floor_376"/>
+      <child link="visual_mesh_04"/>
       <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
     </joint>
 


### PR DESCRIPTION
## Summary

The original \`hangar_floor.dae\` (42 MB) contained 89 merged Blender geometries and triggered a \"Large mesh\" warning toast in the 3D viewer on every hangar_sim session.

Split the 89 sub-geometries into 5 files using size-based bin-packing so each stays under 10 MB:

- \`hangar_floor_00.obj\` / \`hangar_floor_01.obj\`: the two geometries that exceed 10 MB individually (landing gear, ~12 MB each in DAE XML) — lightly decimated to 85% faces (~3.8 MB each). The 15% face reduction is imperceptible on tire/wheel geometry.
- \`hangar_floor_02.dae\` / \`hangar_floor_03.dae\` / \`hangar_floor_04.dae\`: the remaining 87 geometries split into 9.9 MB, 9.9 MB, and 0.2 MB — zero quality loss.

Updated \`hangar_urdf.xacro\` with 5 visual links (one per file). All other geometry is unchanged.

This is visual-only — MuJoCo physics uses separate collision OBJs in \`hangar_mesh/\` and is unaffected.

Fixes #19847 (PickNikRobotics/moveit_pro)

## Release notes

Bug Fix: Fixed a "Large mesh" warning appearing on every hangar_sim session load in the 3D viewer.