### PR TITLE
Fix: Use per-arch image tag in v9.4 integration fallback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,29 +191,25 @@ jobs:
             }
 
             // moveit_pro_ci v0.9.0 appends NOTHING, so build a complete,
-            // suffix-bearing image_ref for every GPU path. Two published tag
-            // shapes are reproduced here:
-            //   - PR-specific per-arch image:  <tag>-<distro>-amd64<suffix>
-            //     (set above for dispatch / needs-paired-PR, and the main
-            //     fallback below)
-            //   - release multiarch tag:       <tag>-<distro><suffix>
-            //     (the fallback below for release-branch push / PR)
+            // suffix-bearing image_ref for every GPU path. The fallback below
+            // always uses the per-arch shape — <tag>-<distro>-amd64<suffix> —
+            // matching the picknik-16-amd64-gpu runner below.
             //
-            // The main fallback must use the per-arch shape: moveit_pro
-            // stopped publishing the arch-less main aliases on 2026-06-03
-            // (main-jazzy-cuda12.6-cudnn9 is frozen at that date on Docker
-            // Hub), so push/schedule/plain-PR runs against main were silently
-            // pinned to that week-old image (surfaced as an EndStateSpec
-            // ImportError once example_ws #698 needed a newer moveit_pro API).
-            // The arch-suffixed main-<distro>-amd64<suffix> tags update with
-            // every moveit_pro main merge; -amd64 matches the
-            // picknik-16-amd64-gpu runner below. Release branches (v9.2,
-            // v9.3) only have arch-less tags and keep the multiarch shape.
-            // repository_dispatch is excluded: a payload without image_ref
-            // must not be redirected to today's main image.
+            // moveit_pro no longer publishes arch-less aliases for the lines
+            // this branch targets. `main` froze its arch-less aliases on
+            // 2026-06-03 (main-jazzy-cuda12.6-cudnn9 is stuck at that date on
+            // Docker Hub). The v9.4 line publishes per-arch tags ONLY for the
+            // cuda13.2 jazzy build (internal_binaries pushes
+            // v9.4-jazzy-amd64-cuda13.2-cudnn9 straight to Docker Hub; the
+            // arch-less v9.4-jazzy-cuda13.2-cudnn9 alias is never created —
+            // verified absent on Docker Hub). A push to this branch resolves
+            // image_tag=v9.4, so the old `image_tag === 'main'` gate left the
+            // -amd64 off and the pull 404'd. Always append -amd64 here.
+            //
+            // repository_dispatch is excluded: its payload always carries
+            // image_ref, so it never reaches this fallback.
             if (image_ref === '') {
-              const archSegment =
-                image_tag === 'main' && event !== 'repository_dispatch' ? '-amd64' : '';
+              const archSegment = event !== 'repository_dispatch' ? '-amd64' : '';
               image_ref = `${dockerhubUsername}/moveit-studio:${image_tag}-{0}${archSegment}`;
             }
             if (!image_ref_has_suffix) {


### PR DESCRIPTION
## Problem

Integration runs triggered by a **push to this `v9.4` branch** fail to pull the moveit_pro image. The `resolve` job builds `picknikciuser/moveit-studio:v9.4-jazzy-cuda13.2-cudnn9` (arch-less), which does not exist on Docker Hub:

```
$ # picknikciuser/moveit-studio tags matching v9.4-jazzy:
v9.4-jazzy-amd64
v9.4-jazzy-amd64-cuda13.2-cudnn9   <-- exists
v9.4-jazzy-amd64-rocm7.2.2
# v9.4-jazzy-cuda13.2-cudnn9       <-- does NOT exist
```

The pull 404s and the job fails.

## Root cause

`resolve`'s fallback (`.github/workflows/ci.yaml`) gated the `-amd64` segment to `image_tag === 'main'`. On a push to `v9.4`, `image_tag` is `v9.4`, so the segment was dropped and the arch-less tag was assembled.

moveit_pro's v9.4 line publishes **per-arch tags only** for the cuda13.2 jazzy build — `internal_binaries` pushes `v9.4-jazzy-amd64-cuda13.2-cudnn9` straight to Docker Hub and no arch-less multiarch alias is created. The `(v9.2, v9.3) only have arch-less tags` assumption baked into the old comment is stale for v9.4.

## Fix

Drop the `image_tag === 'main'` gate so the fallback always appends `-amd64`, producing `v9.4-jazzy-amd64-cuda13.2-cudnn9` (which exists) and matching the `picknik-16-amd64-gpu` runner the integration job uses. `repository_dispatch` is still excluded — its payload always carries `image_ref`, so it never reaches this fallback. The moveit_pro-side dispatch template (`…-{0}-amd64`) was already correct and is unchanged.

## Manual verification

- Confirmed the arch-less `v9.4-jazzy-cuda13.2-cudnn9` tag is absent and the `-amd64` variant is present on Docker Hub (query above).
- `pre-commit run --files .github/workflows/ci.yaml` passes (yamllint, check-yaml, codespell).