### PR TITLE
Add weekly objective integration tests for remaining example sims

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,13 @@ on:
     # and `moveit_pro_pr` so this workflow can run the integration suite
     # against the just-built image and post a commit status back to that PR.
     types: [moveit_pro_pr]
-  # Run every 6 hours Mon-Fri
+  # Run lab_sim/hangar_sim every 6 hours Mon-Fri, and the remaining example
+  # sims once a week (Sunday 06:00 UTC). The weekly cron is deliberately off
+  # the 6-hour Mon-Fri grid so the two never collide on the same minute; the
+  # `integration-test-weekly` job below keys on this exact string.
   schedule:
     - cron: "0 */6 * * 1-5"
+    - cron: "0 6 * * 0"
 
 concurrency:
   # Dispatch-triggered runs from different moveit_pro PRs all share the same
@@ -236,6 +240,11 @@ jobs:
 
   integration-test:
     needs: resolve
+    # Runs on every trigger EXCEPT the Sunday weekly cron, which is reserved for
+    # integration-test-weekly (the remaining sims). Without this guard, adding
+    # the second `schedule` cron above would fan this lab_sim/hangar_sim job out
+    # an extra time every Sunday — wasted GPU-runner slots with no PR to gate.
+    if: ${{ github.event_name != 'schedule' || github.event.schedule != '0 6 * * 0' }}
     strategy:
       fail-fast: false
       matrix:
@@ -278,6 +287,135 @@ jobs:
     secrets:
       moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
       lfs_cache_role_arn: ${{ secrets.LFS_CACHE_ROLE_ARN }}
+
+  # Weekly-only integration suite for the remaining example sims. These run far
+  # longer in aggregate than lab_sim/hangar_sim and have no per-PR signal value,
+  # so they are kept off pull_request / push / the 6-hourly cron entirely:
+  # this job fires ONLY on the Sunday weekly cron above and on manual
+  # workflow_dispatch. It is intentionally NOT in `build-status`'s needs list,
+  # so it can never gate a PR. `integration-test` (lab_sim/hangar_sim) remains
+  # the per-PR gate.
+  integration-test-weekly:
+    needs: resolve
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 6 * * 0')
+    strategy:
+      fail-fast: false
+      matrix:
+        config_package: [april_tag_sim, dual_arm_sim, factory_sim, grinding_sim, kitchen_sim]
+    permissions:
+      # contents: read for checkout; id-token: write so the reusable workflow
+      # can assume the LFS S3 cache IAM role via OIDC (matches integration-test).
+      contents: read
+      id-token: write
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@a0e3b30c9aa8f8f82f95c91e5a34989d01caa046 # v0.9.0
+    with:
+      image_tag: ${{ needs.resolve.outputs.image_tag }}
+      image_ref: ${{ needs.resolve.outputs.image_ref }}
+      git_ref: ${{ needs.resolve.outputs.git_ref }}
+      config_package: ${{ matrix.config_package }}
+      # Jazzy-only, matching integration-test.
+      ros_distros: '["jazzy"]'
+      colcon_test_args: "--executor sequential"
+      # GPU runner + enable_gpu for MuJoCo EGL offscreen rendering (camera /
+      # perception scenes), same rationale as integration-test above.
+      runner: "picknik-16-amd64-gpu"
+      enable_gpu: true
+      use_ccache: true
+      # workflow_dispatch from a fork is not a thing (dispatch is repo-scoped),
+      # and the weekly cron always runs on the base repo, so the S3 LFS cache
+      # role is always available here — no fork fallback needed.
+      lfs_cache_s3_bucket: 'picknik-arc-ci-ccache-682033501538'
+      lfs_cache_aws_region: us-east-1
+    secrets:
+      moveit_license_key: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
+      lfs_cache_role_arn: ${{ secrets.LFS_CACHE_ROLE_ARN }}
+
+  # File (or update) a GitHub issue when the weekly sim suite fails. Runs only
+  # when integration-test-weekly actually ran and reported failure — `result`
+  # is 'skipped' on every PR/push/6-hourly run, so this stays dormant outside
+  # the weekly schedule and manual dispatch. Dedupes by title search rather
+  # than a dedicated label (the repo reserves label creation for humans): an
+  # existing open issue gets a fresh comment instead of a duplicate issue.
+  weekly-failure-issue:
+    needs: integration-test-weekly
+    if: always() && needs.integration-test-weekly.result == 'failure'
+    runs-on: ubuntu-22.04
+    steps:
+      # Mint a cross-repo App token so the issue is filed against moveit_pro
+      # (where these objectives and the shared test fixture live), not against
+      # example_ws. Mirrors the integration-status job's token setup. The
+      # workflow's default GITHUB_TOKEN cannot write issues to another repo.
+      - name: Generate cross-repo App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SISTER_REPOS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SISTER_REPOS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            moveit_pro_example_ws
+            moveit_pro
+      - name: Open or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            // File the issue on moveit_pro, not this repo (example_ws).
+            const issueOwner = 'PickNikRobotics';
+            const issueRepo = 'moveit_pro';
+            const title = 'Weekly example_ws sim integration tests are failing';
+            // runUrl points at the example_ws run (this workflow) where the
+            // failing logs and the HTML report live.
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const when = new Date().toISOString();
+            const configs = 'april_tag_sim, dual_arm_sim, factory_sim, grinding_sim, kitchen_sim';
+            const body = [
+              `The weekly objective integration suite reported a failure on ${when}.`,
+              '',
+              `One or more of the following config packages failed: ${configs}.`,
+              'The matrix result is aggregated, so open the run to see which leg(s) failed:',
+              '',
+              `- [Workflow run](${runUrl})`,
+              '',
+              'If a newly-added or renamed objective is the cause, update the ' +
+              '`skip_objectives` / `cancel_objectives` sets (or add an end-state spec) ' +
+              'in that config\'s `test/objectives_integration_test.py`.',
+            ].join('\n');
+            // Dedupe by exact open-issue title rather than creating a new issue
+            // each failing week. search.issuesAndPullRequests title-matches are
+            // fuzzy, so confirm an exact title match before reusing. The search
+            // is best-effort: on a transient API error, fall back to creating an
+            // issue (a possible duplicate is preferable to a silently dropped
+            // failure notification).
+            let existing;
+            try {
+              const found = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${issueOwner}/${issueRepo} is:issue is:open in:title "${title}"`,
+              });
+              existing = found.data.items.find((i) => i.title === title);
+            } catch (e) {
+              core.warning(`Issue dedupe search failed (${e.message}); creating a new issue.`);
+              existing = undefined;
+            }
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: issueOwner,
+                repo: issueRepo,
+                issue_number: existing.number,
+                body,
+              });
+              core.info(`Commented on existing ${issueOwner}/${issueRepo} issue #${existing.number}.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: issueOwner,
+                repo: issueRepo,
+                title,
+                body,
+              });
+              core.info(`Opened ${issueOwner}/${issueRepo} issue #${created.data.number}.`);
+            }
 
   # Single byte-identical commit-status context (`example_ws / integration`)
   # is posted from here only. Per the design doc: the matrix jobs must NOT

--- a/src/april_tag_sim/CMakeLists.txt
+++ b/src/april_tag_sim/CMakeLists.txt
@@ -30,6 +30,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. The default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded, making post-mortem of
+  # objective failures impossible.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=april_tag_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/april_tag_sim/package.xml
+++ b/src/april_tag_sim/package.xml
@@ -28,14 +28,15 @@
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/april_tag_sim/test/objectives_integration_test.py
+++ b/src/april_tag_sim/test/objectives_integration_test.py
@@ -1,0 +1,83 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests for the april_tag_sim objective library."""
+
+import pytest
+
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+)
+
+# april_tag_sim is a MuJoCo-backed sim: reset the keyframe between tests with
+# the default reset hook (no controller cycling needed here — that variant is
+# specific to lab_sim's interrupted-motion flake).
+SIM_RESETTER.register("april_tag_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through rather than run to completion.
+cancel_objectives: set[str] = set()
+
+# Objectives to skip entirely. These need a camera operator, a clicked point,
+# or an AprilTag-detection-driven grasp that the headless CI backend cannot
+# satisfy. SUCCESS-or-skip keeps the suite deterministic; expand this set from
+# the first weekly CI run rather than guessing more aggressively up front.
+skip_objectives: set[str] = {
+    "Collect AprilTag Detection Data",  # Data-collection loop driven by a camera feed.
+    "Collect Angled AprilTag Detection Data",  # Data-collection loop driven by a camera feed.
+    "Collect Parallel AprilTag Detection Data",  # Data-collection loop driven by a camera feed.
+    "Pick April Tag Labeled Object",  # Requires AprilTag detection + a live grasp.
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("april_tag_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Run (or cancel) each april_tag_sim objective and assert it completes without error."""
+    try:
+        run_objective(objective_id, should_cancel, execute_objective_resource)
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during {mode}: "
+            f"{type(e).__name__}: {e}"
+        )

--- a/src/dual_arm_sim/CMakeLists.txt
+++ b/src/dual_arm_sim/CMakeLists.txt
@@ -17,6 +17,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. The default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded, making post-mortem of
+  # objective failures impossible.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=dual_arm_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/dual_arm_sim/package.xml
+++ b/src/dual_arm_sim/package.xml
@@ -20,9 +20,11 @@
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/dual_arm_sim/test/objectives_integration_test.py
+++ b/src/dual_arm_sim/test/objectives_integration_test.py
@@ -1,0 +1,103 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests for the dual_arm_sim objective library."""
+
+import pytest
+
+from moveit_pro_test_utils.objective_test_fixture import (
+    EndStateSpec,
+    ExecuteObjectiveResource,
+    JointTarget,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+)
+
+# dual_arm_sim is a MuJoCo-backed sim: reset the keyframe between tests with the
+# default reset hook.
+SIM_RESETTER.register("dual_arm_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through rather than run to completion.
+cancel_objectives: set[str] = set()
+
+# Objectives to skip entirely. Teleoperate waits on UI input, and the block
+# find/sort objectives drive ML text-prompt segmentation that the headless CI
+# backend cannot satisfy. Expand this set from the first weekly CI run rather
+# than guessing more aggressively up front.
+skip_objectives: set[str] = {
+    "Teleoperate",  # Waits on UI teleoperation input.
+    "Find Green Block",  # ML text-prompt segmentation.
+    "Find Red Block",  # ML text-prompt segmentation.
+    "Sort Blocks",  # ML perception + multi-step grasp pipeline.
+}
+
+# End-state correctness checks beyond SUCCESS/FAILURE. "Move Left Home" and
+# "Move Right Home" each drive one arm to the shared "Home" waypoint. The
+# target is resolved at runtime from /get_saved_waypoints (the same source of
+# truth the objective moves to), restricted to that arm's joint group so the
+# uncommanded arm's joints are not compared.
+expected_end_state_by_id = {
+    "Move Left Home": EndStateSpec(
+        joints=JointTarget(waypoint="Home", joint_group_name="left_manipulator")
+    ),
+    "Move Right Home": EndStateSpec(
+        joints=JointTarget(waypoint="Home", joint_group_name="right_manipulator")
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("dual_arm_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Run (or cancel) each dual_arm_sim objective and assert it completes without error."""
+    try:
+        run_objective(
+            objective_id,
+            should_cancel,
+            execute_objective_resource,
+            expected_end_state_by_id=expected_end_state_by_id,
+        )
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during {mode}: "
+            f"{type(e).__name__}: {e}"
+        )

--- a/src/factory_sim/CMakeLists.txt
+++ b/src/factory_sim/CMakeLists.txt
@@ -33,6 +33,16 @@ install(DIRECTORY "${PICKNIK_ACCESSORIES_PATH}"
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. The default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded, making post-mortem of
+  # objective failures impossible.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=factory_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/factory_sim/package.xml
+++ b/src/factory_sim/package.xml
@@ -20,14 +20,15 @@
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/factory_sim/test/objectives_integration_test.py
+++ b/src/factory_sim/test/objectives_integration_test.py
@@ -1,0 +1,84 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests for the factory_sim objective library."""
+
+import pytest
+
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+)
+
+# factory_sim is a MuJoCo-backed sim: reset the keyframe between tests with the
+# default reset hook.
+SIM_RESETTER.register("factory_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through rather than run to completion.
+cancel_objectives: set[str] = set()
+
+# Objectives to skip entirely. The automask objectives run ML segmentation off
+# a camera feed, and the bin-picking objectives drive the full ML perception +
+# grasp pipeline — neither completes on the headless CI backend. Expand this
+# set from the first weekly CI run rather than guessing more aggressively up
+# front.
+skip_objectives: set[str] = {
+    "Automask from File",  # ML segmentation model.
+    "Automask from Camera",  # ML segmentation model + camera feed.
+    "Automask Camera Iterate Masks",  # ML segmentation model + camera feed.
+    "Pick Brackets from Left Bin",  # ML perception + grasp pipeline.
+    "Pick and Place Brackets from Left Bin",  # ML perception + grasp pipeline.
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("factory_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Run (or cancel) each factory_sim objective and assert it completes without error."""
+    try:
+        run_objective(objective_id, should_cancel, execute_objective_resource)
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during {mode}: "
+            f"{type(e).__name__}: {e}"
+        )

--- a/src/grinding_sim/CMakeLists.txt
+++ b/src/grinding_sim/CMakeLists.txt
@@ -27,6 +27,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. The default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded, making post-mortem of
+  # objective failures impossible.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=grinding_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/grinding_sim/package.xml
+++ b/src/grinding_sim/package.xml
@@ -20,14 +20,15 @@
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/grinding_sim/test/objectives_integration_test.py
+++ b/src/grinding_sim/test/objectives_integration_test.py
@@ -1,0 +1,79 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests for the grinding_sim objective library."""
+
+import pytest
+
+from moveit_pro_test_utils.objective_test_fixture import (
+    ExecuteObjectiveResource,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+)
+
+# grinding_sim is a MuJoCo-backed sim: reset the keyframe between tests with the
+# default reset hook.
+SIM_RESETTER.register("grinding_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through rather than run to completion.
+cancel_objectives: set[str] = set()
+
+# Objectives to skip entirely. Grinding runs an admittance-controlled surface
+# pass that expects an operator to drive the interaction, so it cannot complete
+# unattended. Expand this set from the first weekly CI run rather than guessing
+# more aggressively up front.
+skip_objectives: set[str] = {
+    "Grind Machined Part",  # Admittance surface pass never converges in CI: no contact force.
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("grinding_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Run (or cancel) each grinding_sim objective and assert it completes without error."""
+    try:
+        run_objective(objective_id, should_cancel, execute_objective_resource)
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during {mode}: "
+            f"{type(e).__name__}: {e}"
+        )

--- a/src/kitchen_sim/CMakeLists.txt
+++ b/src/kitchen_sim/CMakeLists.txt
@@ -17,6 +17,16 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Redirect ROS node logs into the test_results tree so the test-results CI
+  # artifact ships them back too. The default ~/.ros/log/ lives on the doomed
+  # container filesystem and never gets uploaded, making post-mortem of
+  # objective failures impossible.
+  ament_add_pytest_test(
+          objectives_integration_test test/objectives_integration_test.py
+          TIMEOUT 600
+          ENV MOVEIT_CONFIG_PACKAGE=kitchen_sim
+              MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
+              ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)
 endif()
 
 ament_package()

--- a/src/kitchen_sim/package.xml
+++ b/src/kitchen_sim/package.xml
@@ -22,9 +22,11 @@
   <test_depend>ament_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/kitchen_sim/test/objectives_integration_test.py
+++ b/src/kitchen_sim/test/objectives_integration_test.py
@@ -1,0 +1,100 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Integration tests for the kitchen_sim objective library."""
+
+import pytest
+
+from moveit_pro_test_utils.objective_test_fixture import (
+    EndStateSpec,
+    ExecuteObjectiveResource,
+    JointTarget,
+    MUJOCO_RESET_HOOK,
+    SIM_RESETTER,
+    execute_objective_resource as execute_objective_resource,
+    get_objective_pytest_params,
+    reset_simulation_before_test as reset_simulation_before_test,
+    run_objective,
+)
+
+# kitchen_sim is a MuJoCo-backed sim: reset the keyframe between tests with the
+# default reset hook.
+SIM_RESETTER.register("kitchen_sim", MUJOCO_RESET_HOOK)
+
+# Looping objectives to cancel partway through rather than run to completion.
+cancel_objectives: set[str] = set()
+
+# Objectives to skip entirely. The segmentation and grasp objectives need a
+# clicked point and ML segmentation that the headless CI backend cannot supply.
+# Expand this set from the first weekly CI run rather than guessing more
+# aggressively up front.
+skip_objectives: set[str] = {
+    "Segment Image from Point",  # Clicked point + ML segmentation.
+    "Segment Image from Prompt",  # ML segmentation.
+    "Segment Point Cloud from Point",  # Clicked point + ML segmentation.
+    "Generate Graspable Object",  # ML segmentation.
+    "Grasp Object from Point",  # Clicked point + ML segmentation.
+}
+
+# End-state correctness checks beyond SUCCESS/FAILURE. "Move Home" and "Move
+# Away" each drive the manipulator to a named waypoint. The target is resolved
+# at runtime from /get_saved_waypoints (the same source of truth the objective
+# moves to); both waypoints carry only the manipulator group, so the default
+# joint group compares exactly the commanded joints.
+expected_end_state_by_id = {
+    "Move Home": EndStateSpec(joints=JointTarget(waypoint="Home")),
+    "Move Away": EndStateSpec(joints=JointTarget(waypoint="Out of the way")),
+}
+
+
+@pytest.mark.parametrize(
+    "objective_id, should_cancel",
+    get_objective_pytest_params("kitchen_sim", cancel_objectives, skip_objectives),
+)
+def test_all_objectives(
+    objective_id: str,
+    should_cancel: bool,
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """Run (or cancel) each kitchen_sim objective and assert it completes without error."""
+    try:
+        run_objective(
+            objective_id,
+            should_cancel,
+            execute_objective_resource,
+            expected_end_state_by_id=expected_end_state_by_id,
+        )
+    except AssertionError as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(f"Objective '{objective_id}' failed to {mode}: {e}")
+    except Exception as e:
+        mode = "cancel" if should_cancel else "execute"
+        pytest.fail(
+            f"Objective '{objective_id}' hit an unexpected error during {mode}: "
+            f"{type(e).__name__}: {e}"
+        )


### PR DESCRIPTION
## Problem

Only `lab_sim` and `hangar_sim` have objective integration tests. The other shipped MuJoCo example sims (the configs the Quick Start tells users to explore via `moveit_pro run --list`) have none, so a regression in their objectives goes unnoticed. Tracks PickNikRobotics/moveit_pro#19619.

## What this does

Adds objective integration tests for the five remaining MuJoCo sims — `april_tag_sim`, `dual_arm_sim`, `factory_sim`, `grinding_sim`, `kitchen_sim` — modeled on the existing `lab_sim`/`hangar_sim` suites and the shared `moveit_pro_test_utils.objective_test_fixture`. Each test runs every *runnable* objective, asserts `SUCCESS` (or a clean cancel for loop objectives), and registers the default MuJoCo keyframe reset hook between tests.

**End-state correctness:** `dual_arm_sim` (`Move Left/Right Home`) and `kitchen_sim` (`Move Home`, `Move Away`) additionally assert the final joint state, resolved at runtime from `/get_saved_waypoints` (the same source of truth the objective moves to). The other three have no clean named-waypoint move, so they assert `SUCCESS` only — matching `lab_sim`'s minimal end-state footprint.

**Skip sets:** camera/ML-segmentation/clicked-point/teleop objectives that the headless CI backend can't satisfy are skipped, following `lab_sim`'s established principle. These are a conservative starting point; they will be refined from the first weekly run rather than guessed exhaustively up front.

## Why weekly (not per-PR)

These five sims in aggregate run far longer than `lab_sim`/`hangar_sim` and carry no per-PR signal. So:

- New `schedule` cron `0 6 * * 0` (Sunday 06:00 UTC, deliberately off the existing Mon–Fri 6-hourly grid).
- New `integration-test-weekly` matrix job runs the five **only** on that cron and on manual `workflow_dispatch`. It is **not** in `build-status`'s `needs`, so it can never gate a PR.
- The existing `integration-test` (lab/hangar) job is guarded to skip the new Sunday cron, so adding the second cron doesn't fan it out an extra time.
- New `weekly-failure-issue` job opens (or comments on an existing, deduped-by-title) GitHub issue when the weekly suite fails — the canonical status record, since there's no PR to annotate.

## Validation

- Reviewed by `code-reviewer` and `platform-architect-bot`; findings applied.
- All 5 packages `colcon build` clean (`ament_add_pytest_test` resolves, `rclpy` test_depend satisfiable).
- Every skip / cancel / end-state name verified against the real `main_tree_to_execute` objective IDs (no silent no-op skips); end-state objectives confirmed runnable and unskipped.
- The integration tests themselves require a GPU MuJoCo backend (the weekly CI runner) and can't run in the local dev container. **After merge, trigger the workflow manually (`workflow_dispatch`) to get the first signal and tune the skip sets** — the Sunday cron won't fire until then.

## Notes

- Milestone unset — leaving the release target for a human to pick.
- The `moveit_pro_test_utils` end-state API (`EndStateSpec`/`JointTarget`/`expected_end_state_by_id`) is already on `moveit_pro` `main`, so the `main` CI image carries it.