### PR TITLE
chore(sim): suppress ros2_control overrun warnings in simulation configs

### DIFF
--- a/src/dual_arm_sim/config/control/franka_ros2_control.yaml
+++ b/src/dual_arm_sim/config/control/franka_ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
+++ b/src/factory_sim/config/control/picknik_fanuc.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/grinding_sim/config/control/ur20.ros2_control.yaml
+++ b/src/grinding_sim/config/control/ur20.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/kitchen_sim/config/control/franka_ros2_control.yaml
+++ b/src/kitchen_sim/config/control/franka_ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/lab_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_controller:

--- a/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     joint_trajectory_admittance_controller:

--- a/src/moveit_pro_ur_configs/mock_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/mock_sim/config/control/picknik_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 600  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     io_and_status_controller:

--- a/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/config/control/picknik_multi_ur.ros2_control.yaml
@@ -1,6 +1,8 @@
 controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
+    overruns:
+      print_warnings: false  # Suppress overrun WARN logs in non-realtime sim; gates the WARN log only; overrun handling itself is unchanged.
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
     first_io_and_status_controller:


### PR DESCRIPTION
Backport of #713 (`2cae6ba4`) from `main` to `v9.4`.

**Problem:** The Jazzy controller_manager 4.44 added non-realtime overrun WARN spam that floods the console in simulation.

**Fix:** Set `overruns.print_warnings: false` in every simulation config's `controller_manager`. Sim-only — real-hardware base/site configs are intentionally left untouched.

9 sim configs touched (dual_arm, factory, grinding, hangar, kitchen, lab, kinova, mock, multi_arm). The 4 unpatched `ros2_control.yaml` files (`picknik_ur_base_config`, `picknik_ur_site_config`, `kinova_gen3_base_config`, `kinova_gen3_site_config`) are real-hardware base/site configs, intentionally left alone.

**Verification:** `overruns.print_warnings` is the correct key — confirmed against ros-controls/ros2_control `jazzy` branch (`controller_manager/src/controller_manager_parameters.yaml`, currently 4.45.2), where `overruns` is a top-level parameter group under the controller_manager namespace, resolving to `controller_manager.ros__parameters.overruns.print_warnings`.
