### PR TITLE
Add constant-speed Cartesian timing to the Grind Machined Part example

### DIFF
--- a/src/grinding_sim/objectives/grind_machined_part.xml
+++ b/src/grinding_sim/objectives/grind_machined_part.xml
@@ -69,7 +69,6 @@
       <!--Plan a Cartesian path that moves the tool tip through the grinding poses-->
       <Action
         ID="PlanCartesianPath"
-        acceleration_scale_factor="1.000000"
         blending_radius="0.020000"
         ik_cartesian_space_density="0.010000"
         ik_joint_space_density="0.100000"
@@ -77,8 +76,7 @@
         planning_group_name="manipulator"
         position_only="false"
         tip_links="grasp_link"
-        trajectory_sampling_rate="100"
-        velocity_scale_factor="0.01"
+        trajectory_timing="[{mode: cartesian_trapezoidal, max_translational_velocity: 0.05, max_rotational_velocity: 0.5, max_translational_acceleration: 0.1, max_rotational_acceleration: 1.0, trajectory_sampling_rate: 100}]"
         debug_solution="{debug_solution}"
         joint_trajectory_msg="{joint_trajectory_msg}"
       />


### PR DESCRIPTION
## Motivation

MoveIt Pro 10.0 adds constant-speed Cartesian timing to `PlanCartesianPath` through the new `trajectory_timing` port. Holding a steady tool speed suits a grinding pass, so this updates the `Grind Machined Part` example to use it. The scalar timing ports it previously used are also now deprecated.

## Brief description

Wires the `PlanCartesianPath` `trajectory_timing` port to constant-speed (Cartesian-trapezoidal) mode at 5 cm/s, so the tool holds a steady Cartesian speed across the grinding poses, with an acceleration ramp at the start and a deceleration ramp at the end. To see the time-optimal default instead, open the `PlanCartesianPath` Behavior and switch the `trajectory_timing` port to time-optimal.

## Notes

- Requires MoveIt Pro 10.0 (the `trajectory_timing` port).
- Walkthrough: [Cartesian Path Following](https://docs.picknik.ai/how_to/robotics_applications/cartesian_path_following/).
