### PR TITLE
Fix: Migrate SubTree interface ports to inout_port

### DIFF
--- a/src/april_tag_sim/objectives/get_april_tag_pose_from_image.xml
+++ b/src/april_tag_sim/objectives/get_april_tag_pose_from_image.xml
@@ -39,9 +39,9 @@
         <Metadata subcategory="Perception - 2D Image" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <input_port name="camera_info" default="{camera_info}" />
-      <output_port name="detection_pose" default="{detection_pose}" />
-      <input_port name="image" default="{image}" />
+      <inout_port name="camera_info" default="{camera_info}" />
+      <inout_port name="detection_pose" default="{detection_pose}" />
+      <inout_port name="image" default="{image}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
+++ b/src/dual_arm_sim/objectives/create_point_cloud_vector_from_masks.xml
@@ -38,9 +38,9 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Create Point Cloud Vector From Masks">
-      <input_port name="masks3d" default="/wrist_camera/camera_info" />
-      <input_port name="point_cloud" default="/wrist_camera/camera_info" />
-      <output_port name="point_cloud_vector" default="{point_cloud_vector}" />
+      <inout_port name="masks3d" default="/wrist_camera/camera_info" />
+      <inout_port name="point_cloud" default="/wrist_camera/camera_info" />
+      <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
       <MetadataFields>
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />

--- a/src/dual_arm_sim/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/dual_arm_sim/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -47,18 +47,18 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="{image_topic_name}" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="{image_topic_name}" />
+      <inout_port
         name="masks_visualization_topic"
         default="{masks_visualization_topic}"
       />
-      <output_port name="masks2d" default="{masks2d}" />
-      <input_port name="model_package" default="{model_package}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <inout_port name="masks2d" default="{masks2d}" />
+      <inout_port name="model_package" default="{model_package}" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/dual_arm_sim/objectives/segment_point_cloud_from_text.xml
+++ b/src/dual_arm_sim/objectives/segment_point_cloud_from_text.xml
@@ -80,26 +80,26 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Segment Point Cloud from Text Prompt Subtree">
-      <input_port
+      <inout_port
         name="camera_topic_name"
         default="/wrist_camera/camera_info"
       />
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="/wrist_camera/color" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="/wrist_camera/color" />
+      <inout_port
         name="masks_visualization_topic"
         default="/masks_visualization"
       />
-      <output_port name="masks3d" default="{masks3d}" />
-      <input_port name="model_package" default="lab_sim" />
-      <output_port name="point_cloud" default="{point_cloud}" />
-      <output_port name="point_cloud_vector" default="{point_cloud_vector}" />
-      <input_port name="points_topic_name" default="/wrist_camera/points" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
-      <input_port name="use_latest_transform" default="false" />
+      <inout_port name="masks3d" default="{masks3d}" />
+      <inout_port name="model_package" default="lab_sim" />
+      <inout_port name="point_cloud" default="{point_cloud}" />
+      <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
+      <inout_port name="points_topic_name" default="/wrist_camera/points" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
+      <inout_port name="use_latest_transform" default="false" />
       <MetadataFields>
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />

--- a/src/factory_sim/objectives/load_bracket_part_pointcloud_subtree.xml
+++ b/src/factory_sim/objectives/load_bracket_part_pointcloud_subtree.xml
@@ -37,9 +37,9 @@
         <Metadata subcategory="Perception - 3D Point Cloud" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <output_port name="bracket_part_cloud" default="{bracket_part_cloud}" />
-      <input_port name="color" default="255;0;0" />
-      <input_port name="initial_pose" default="{initial_pose}" />
+      <inout_port name="bracket_part_cloud" default="{bracket_part_cloud}" />
+      <inout_port name="color" default="255;0;0" />
+      <inout_port name="initial_pose" default="{initial_pose}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/factory_sim/objectives/retract.xml
+++ b/src/factory_sim/objectives/retract.xml
@@ -43,8 +43,8 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>
-      <input_port name="distance" default="0.1" />
-      <input_port name="ignore_environment_collisions" default="false" />
+      <inout_port name="distance" default="0.1" />
+      <inout_port name="ignore_environment_collisions" default="false" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/grinding_sim/objectives/load_engine_block_pointcloud.xml
+++ b/src/grinding_sim/objectives/load_engine_block_pointcloud.xml
@@ -30,9 +30,9 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Load Engine Block Pointcloud">
-      <input_port name="color" default="255;0;0" />
-      <input_port name="initial_pose" default="{initial_pose}" />
-      <output_port name="engine_block_cloud" default="{engine_block_cloud}" />
+      <inout_port name="color" default="255;0;0" />
+      <inout_port name="initial_pose" default="{initial_pose}" />
+      <inout_port name="engine_block_cloud" default="{engine_block_cloud}" />
       <MetadataFields>
         <Metadata subcategory="Perception - 3D Point Cloud" />
         <Metadata runnable="false" />

--- a/src/grinding_sim/objectives/register_machined_part.xml
+++ b/src/grinding_sim/objectives/register_machined_part.xml
@@ -97,7 +97,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Register Machined Part">
-      <output_port name="registered_pose" default="{registered_pose}" />
+      <inout_port name="registered_pose" default="{registered_pose}" />
       <MetadataFields>
         <Metadata subcategory="Perception - 3D Point Cloud" />
         <Metadata runnable="true" />

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -358,13 +358,13 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
-      <input_port name="erosion_size" default="0" />
-      <input_port name="negative_prompts" default="{negative_prompts}" />
-      <input_port name="place_pose" default="{place_pose}" />
+      <inout_port name="erosion_size" default="0" />
+      <inout_port name="negative_prompts" default="{negative_prompts}" />
+      <inout_port name="place_pose" default="{place_pose}" />
       <inout_port name="prompt" default="{prompt}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
-      <input_port name="waypoint_name" default="View Boxes" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
+      <inout_port name="waypoint_name" default="View Boxes" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/hangar_sim/objectives/move_to_a_stampedpose.xml
+++ b/src/hangar_sim/objectives/move_to_a_stampedpose.xml
@@ -70,11 +70,11 @@
         <Metadata subcategory="Motion - Execute" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <input_port
+      <inout_port
         name="controller_names"
         default="/joint_trajectory_controller"
       />
-      <input_port name="target_pose" default="{pose_stamped}" />
+      <inout_port name="target_pose" default="{pose_stamped}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/hangar_sim/objectives/move_to_pose_no_preview.xml
+++ b/src/hangar_sim/objectives/move_to_pose_no_preview.xml
@@ -49,7 +49,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Move to Pose No Preview">
-      <input_port name="target_pose" default="{target_pose}" />
+      <inout_port name="target_pose" default="{target_pose}" />
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
         <Metadata runnable="false" />

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -233,9 +233,9 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Request Teleoperation">
-      <input_port name="enable_user_interaction" default="false" />
-      <input_port name="user_interaction_prompt" default="" />
-      <input_port name="initial_teleop_mode" default="3" />
+      <inout_port name="enable_user_interaction" default="false" />
+      <inout_port name="user_interaction_prompt" default="" />
+      <inout_port name="initial_teleop_mode" default="3" />
       <MetadataFields>
         <Metadata subcategory="User Input" />
         <Metadata runnable="false" />

--- a/src/lab_sim/objectives/add_poses_to_mtc_task.xml
+++ b/src/lab_sim/objectives/add_poses_to_mtc_task.xml
@@ -59,14 +59,14 @@
         <Metadata subcategory="Motion - Task Planning" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <input_port
+      <inout_port
         name="controller_names"
         default="/joint_trajectory_admittance_controller;/robotiq_gripper_controller"
       />
-      <input_port name="ik_frame" default="grasp_link" />
+      <inout_port name="ik_frame" default="grasp_link" />
       <inout_port name="mtc_task" default="{mtc_task}" />
-      <input_port name="planning_group_name" default="manipulator" />
-      <input_port name="target_poses" default="{target_poses}" />
+      <inout_port name="planning_group_name" default="manipulator" />
+      <inout_port name="target_poses" default="{target_poses}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/add_waypoints_to_mtc_task.xml
+++ b/src/lab_sim/objectives/add_waypoints_to_mtc_task.xml
@@ -39,7 +39,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Add Waypoints to MTC Task">
-      <input_port name="joint_group_name" default="manipulator" />
+      <inout_port name="joint_group_name" default="manipulator" />
       <inout_port name="mtc_task" default="{mtc_task}" />
       <MetadataFields>
         <Metadata subcategory="Motion - Task Planning" />

--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -292,8 +292,8 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>
-      <input_port name="pick" default="" />
-      <input_port name="place" default="" />
+      <inout_port name="pick" default="" />
+      <inout_port name="place" default="" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/create_pcl_poses_vector.xml
+++ b/src/lab_sim/objectives/create_pcl_poses_vector.xml
@@ -95,7 +95,7 @@
         <Metadata subcategory="Vector Handling" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <output_port name="target_poses" default="{target_poses}" />
+      <inout_port name="target_poses" default="{target_poses}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/create_pose_vector.xml
+++ b/src/lab_sim/objectives/create_pose_vector.xml
@@ -117,7 +117,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Create Pose Vector">
-      <output_port name="target_poses" default="{target_poses}" />
+      <inout_port name="target_poses" default="{target_poses}" />
       <MetadataFields>
         <Metadata subcategory="Vector Handling" />
         <Metadata runnable="false" />

--- a/src/lab_sim/objectives/force_relaxation.xml
+++ b/src/lab_sim/objectives/force_relaxation.xml
@@ -70,9 +70,9 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Motion - Controls" />
       </MetadataFields>
-      <input_port name="relaxation_time_ms" default="500" />
-      <input_port name="tip_link" default="grasp_link" />
-      <input_port name="wrench_gain" default="0.01" />
+      <inout_port name="relaxation_time_ms" default="500" />
+      <inout_port name="tip_link" default="grasp_link" />
+      <inout_port name="wrench_gain" default="0.01" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/get_april_tag_pose_from_image.xml
+++ b/src/lab_sim/objectives/get_april_tag_pose_from_image.xml
@@ -41,9 +41,9 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - 2D Image" />
       </MetadataFields>
-      <input_port name="camera_info" default="{camera_info}" />
-      <output_port name="detection_pose" default="{detection_pose}" />
-      <input_port name="image" default="{image}" />
+      <inout_port name="camera_info" default="{camera_info}" />
+      <inout_port name="detection_pose" default="{detection_pose}" />
+      <inout_port name="image" default="{image}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/lab_sim/objectives/plan_move_to_pose.xml
+++ b/src/lab_sim/objectives/plan_move_to_pose.xml
@@ -30,8 +30,8 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Plan Move To Pose">
-      <input_port name="target_pose" default="{target_pose}" />
-      <output_port
+      <inout_port name="target_pose" default="{target_pose}" />
+      <inout_port
         name="move_to_pose_solution"
         default="{move_to_pose_solution}"
       />

--- a/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
+++ b/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
@@ -215,18 +215,18 @@
         <Metadata runnable="true" />
       </MetadataFields>
       <!--Output ports-->
-      <output_port name="current_cloud" default="{current_cloud}" />
-      <output_port name="current_pose" default="{current_pose}" />
-      <output_port name="first_solution" default="{first_solution}" />
-      <output_port name="image" default="{image}" />
-      <output_port name="inspection_poses" default="{inspection_poses}" />
-      <output_port name="joint_traj" default="{joint_traj}" />
-      <output_port name="merged_cloud" default="{merged_cloud}" />
-      <output_port name="move_solution" default="{move_solution}" />
-      <output_port name="point_cloud_vector" default="{point_cloud_vector}" />
-      <output_port name="reachable_pose" default="{reachable_pose}" />
-      <output_port name="replay_solution" default="{replay_solution}" />
-      <output_port name="transformed_cloud" default="{transformed_cloud}" />
+      <inout_port name="current_cloud" default="{current_cloud}" />
+      <inout_port name="current_pose" default="{current_pose}" />
+      <inout_port name="first_solution" default="{first_solution}" />
+      <inout_port name="image" default="{image}" />
+      <inout_port name="inspection_poses" default="{inspection_poses}" />
+      <inout_port name="joint_traj" default="{joint_traj}" />
+      <inout_port name="merged_cloud" default="{merged_cloud}" />
+      <inout_port name="move_solution" default="{move_solution}" />
+      <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
+      <inout_port name="reachable_pose" default="{reachable_pose}" />
+      <inout_port name="replay_solution" default="{replay_solution}" />
+      <inout_port name="transformed_cloud" default="{transformed_cloud}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_franka_configs/franka_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/moveit_pro_franka_configs/franka_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -47,18 +47,18 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="{image_topic_name}" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="{image_topic_name}" />
+      <inout_port
         name="masks_visualization_topic"
         default="{masks_visualization_topic}"
       />
-      <output_port name="masks2d" default="{masks2d}" />
-      <input_port name="model_package" default="{model_package}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <inout_port name="masks2d" default="{masks2d}" />
+      <inout_port name="model_package" default="{model_package}" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/get_imarker_pose_from_mesh_visualization.xml
@@ -28,10 +28,10 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Get IMarker Pose From Mesh Visualization">
-      <output_port name="adjusted_poses" default="{adjusted_poses}" />
-      <input_port name="mesh_path" default="{mesh_path}" />
-      <input_port name="mesh_pose" default="{mesh_pose}" />
-      <input_port name="_collapsed" default="false" />
+      <inout_port name="adjusted_poses" default="{adjusted_poses}" />
+      <inout_port name="mesh_path" default="{mesh_path}" />
+      <inout_port name="mesh_pose" default="{mesh_pose}" />
+      <inout_port name="_collapsed" default="false" />
       <MetadataFields>
         <Metadata subcategory="User Input" />
       </MetadataFields>

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_to_joint_state.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_to_joint_state.xml
@@ -24,18 +24,18 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Move to Joint State">
-      <input_port name="target_joint_state" default="{target_joint_state}" />
-      <input_port name="joint_group_name" default="manipulator" />
-      <input_port name="link_padding" default="0.01" />
-      <input_port name="keep_orientation_tolerance" default="0.05" />
-      <input_port name="keep_orientation" default="false" />
-      <input_port name="velocity_scale_factor" default="1.0" />
-      <input_port name="acceleration_scale_factor" default="1.0" />
-      <input_port
+      <inout_port name="target_joint_state" default="{target_joint_state}" />
+      <inout_port name="joint_group_name" default="manipulator" />
+      <inout_port name="link_padding" default="0.01" />
+      <inout_port name="keep_orientation_tolerance" default="0.05" />
+      <inout_port name="keep_orientation" default="false" />
+      <inout_port name="velocity_scale_factor" default="1.0" />
+      <inout_port name="acceleration_scale_factor" default="1.0" />
+      <inout_port
         name="controller_names"
         default="joint_trajectory_admittance_controller"
       />
-      <input_port
+      <inout_port
         name="controller_action_server"
         default="/joint_trajectory_admittance_controller/follow_joint_trajectory"
       />

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/sample_april_tag.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/sample_april_tag.xml
@@ -56,7 +56,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Sample April Tag">
-      <input_port name="tag_id" default="-1" />
+      <inout_port name="tag_id" default="-1" />
       <MetadataFields>
         <Metadata subcategory="Perception - Image Processing" />
         <Metadata runnable="false" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/sample_april_tag.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/objectives/sample_april_tag.xml
@@ -56,7 +56,7 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Sample April Tag">
-      <input_port name="tag_id" default="-1" />
+      <inout_port name="tag_id" default="-1" />
       <MetadataFields>
         <Metadata subcategory="Perception - Image Processing" />
         <Metadata runnable="false" />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_-_detect_tags.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_-_detect_tags.xml
@@ -129,16 +129,16 @@
         name="camera_info_topic"
         default="/scene_camera/camera_info"
       />
-      <input_port
+      <inout_port
         name="camera_mounting_frame"
         default="scene_camera_mount_link"
       />
-      <input_port
+      <inout_port
         name="camera_optical_frame"
         default="scene_camera_color_optical_frame"
       />
       <inout_port name="mounting_pose_parent_frame" default="world" />
-      <input_port
+      <inout_port
         name="mounting_pose_save_file"
         default="calibrated_scene_camera_mounting_pose.txt"
       />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_-_tag_tfs.xml
@@ -120,16 +120,16 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - Camera Calibration" />
       </MetadataFields>
-      <input_port
+      <inout_port
         name="camera_mounting_frame"
         default="scene_camera_mount_link"
       />
-      <input_port
+      <inout_port
         name="camera_optical_frame"
         default="scene_camera_color_optical_frame"
       />
       <inout_port name="mounting_pose_parent_frame" default="world" />
-      <input_port
+      <inout_port
         name="mounting_pose_save_file"
         default="calibrated_scene_camera_mount_pose.txt"
       />

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_detect.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_detect.xml
@@ -92,7 +92,7 @@
         name="computed_poses_vector"
         default="{computed_poses_vector}"
       />
-      <input_port name="waypoint_name" default="{waypoint_name}" />
+      <inout_port name="waypoint_name" default="{waypoint_name}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/calibrate_camera_at_waypoint_-_tag_tfs.xml
@@ -90,8 +90,8 @@
         name="computed_poses_vector"
         default="{computed_poses_vector}"
       />
-      <input_port name="parameters" default="{parameters}" />
-      <input_port name="waypoint_name" default="{waypoint_name}" />
+      <inout_port name="parameters" default="{parameters}" />
+      <inout_port name="waypoint_name" default="{waypoint_name}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/camera_pose_from_cal_tool_-_detect_tags.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/camera_pose_from_cal_tool_-_detect_tags.xml
@@ -88,7 +88,7 @@
         name="camera_optical_frame"
         default="{camera_optical_frame}"
       />
-      <output_port name="computed_pose" default="{computed_pose}" />
+      <inout_port name="computed_pose" default="{computed_pose}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/camera_pose_from_cal_tool_-_tag_tfs.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/camera_pose_from_cal_tool_-_tag_tfs.xml
@@ -64,7 +64,7 @@
         name="camera_optical_frame"
         default="{camera_optical_frame}"
       />
-      <output_port name="computed_pose" default="{computed_pose}" />
+      <inout_port name="computed_pose" default="{computed_pose}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/get_pose_from_tf_frame.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/objectives/get_pose_from_tf_frame.xml
@@ -25,9 +25,9 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - Camera Calibration" />
       </MetadataFields>
-      <input_port name="pose_frame" default="{pose_frame_name}" />
-      <input_port name="reference_frame" default="{reference_frame_name}" />
-      <output_port name="tf_pose" default="{tf_pose}" />
+      <inout_port name="pose_frame" default="{pose_frame_name}" />
+      <inout_port name="reference_frame" default="{reference_frame_name}" />
+      <inout_port name="tf_pose" default="{tf_pose}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/create_point_cloud_vector_from_masks.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/create_point_cloud_vector_from_masks.xml
@@ -39,9 +39,9 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Create Point Cloud Vector From Masks">
-      <input_port name="masks3d" default="/wrist_camera/camera_info" />
-      <input_port name="point_cloud" default="/wrist_camera/camera_info" />
-      <output_port name="point_cloud_vector" default="{point_cloud_vector}" />
+      <inout_port name="masks3d" default="/wrist_camera/camera_info" />
+      <inout_port name="point_cloud" default="/wrist_camera/camera_info" />
+      <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
       <MetadataFields>
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -47,18 +47,18 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="{image_topic_name}" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="{image_topic_name}" />
+      <inout_port
         name="masks_visualization_topic"
         default="{masks_visualization_topic}"
       />
-      <output_port name="masks2d" default="{masks2d}" />
-      <input_port name="model_package" default="{model_package}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <inout_port name="masks2d" default="{masks2d}" />
+      <inout_port name="model_package" default="{model_package}" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_point_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_point_subtree.xml
@@ -51,22 +51,22 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port
+      <inout_port
         name="decoder_model_path"
         default="models/sam2_decoder.onnx"
       />
-      <input_port
+      <inout_port
         name="encoder_model_path"
         default="models/sam2_hiera_large_encoder.onnx"
       />
-      <input_port name="image_topic_name" default="/wrist_camera/color" />
-      <input_port
+      <inout_port name="image_topic_name" default="/wrist_camera/color" />
+      <inout_port
         name="masks_visualization_topic"
         default="/masks_visualization"
       />
-      <output_port name="masks2d" default="{masks2d}" />
-      <input_port name="model_package" default="moveit_pro_sam2" />
-      <output_port name="pixel_coords" default="{pixel_coords}" />
+      <inout_port name="masks2d" default="{masks2d}" />
+      <inout_port name="model_package" default="moveit_pro_sam2" />
+      <inout_port name="pixel_coords" default="{pixel_coords}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_text_prompt_subtree.xml
@@ -42,19 +42,19 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="{image_topic_name}" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="{image_topic_name}" />
+      <inout_port
         name="masks_visualization_topic"
         default="{masks_visualization_topic}"
       />
-      <output_port name="masks2d" default="{masks2d}" />
-      <input_port name="model_package" default="{model_package}" />
-      <input_port name="negative_prompts" default="{negative_prompts}" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <inout_port name="masks2d" default="{masks2d}" />
+      <inout_port name="model_package" default="{model_package}" />
+      <inout_port name="negative_prompts" default="{negative_prompts}" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_clicked_point_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_clicked_point_subtree.xml
@@ -59,16 +59,16 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Segment Point Cloud from Clicked Point Subtree">
-      <input_port name="camera_topic_name" default="{camera_topic_name}" />
-      <input_port name="decoder_model_path" default="{decoder_model_path}" />
-      <input_port name="encoder_model_path" default="{encoder_model_path}" />
-      <input_port name="image_topic_name" default="{image_topic_name}" />
-      <input_port
+      <inout_port name="camera_topic_name" default="{camera_topic_name}" />
+      <inout_port name="decoder_model_path" default="{decoder_model_path}" />
+      <inout_port name="encoder_model_path" default="{encoder_model_path}" />
+      <inout_port name="image_topic_name" default="{image_topic_name}" />
+      <inout_port
         name="masks_visualization_topic"
         default="{masks_visualization_topic}"
       />
-      <input_port name="model_package" default="{model_package}" />
-      <input_port name="points_topic_name" default="{points_topic_name}" />
+      <inout_port name="model_package" default="{model_package}" />
+      <inout_port name="points_topic_name" default="{points_topic_name}" />
       <MetadataFields>
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
@@ -83,25 +83,25 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <input_port
+      <inout_port
         name="camera_topic_name"
         default="/wrist_camera/camera_info"
       />
-      <input_port name="clip_model_path" default="{clip_model_path}" />
-      <input_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <input_port name="erosion_size" default="{erosion_size}" />
-      <input_port name="image_topic_name" default="/wrist_camera/color" />
-      <input_port
+      <inout_port name="clip_model_path" default="{clip_model_path}" />
+      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
+      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="image_topic_name" default="/wrist_camera/color" />
+      <inout_port
         name="masks_visualization_topic"
         default="/masks_visualization"
       />
-      <output_port name="masks3d" default="{masks3d}" />
-      <input_port name="model_package" default="moveit_pro_clipseg" />
-      <output_port name="point_cloud" default="{point_cloud}" />
-      <output_port name="point_cloud_vector" default="{point_cloud_vector}" />
-      <input_port name="points_topic_name" default="/wrist_camera/points" />
-      <input_port name="prompts" default="{prompts}" />
-      <input_port name="threshold" default="{threshold}" />
+      <inout_port name="masks3d" default="{masks3d}" />
+      <inout_port name="model_package" default="moveit_pro_clipseg" />
+      <inout_port name="point_cloud" default="{point_cloud}" />
+      <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
+      <inout_port name="points_topic_name" default="/wrist_camera/points" />
+      <inout_port name="prompts" default="{prompts}" />
+      <inout_port name="threshold" default="{threshold}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/visualize_segmented_point_cloud.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/visualize_segmented_point_cloud.xml
@@ -38,8 +38,8 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Visualize Segmented Point Cloud">
-      <input_port name="masks3d" default="{masks3d}" />
-      <input_port name="point_cloud" default="{point_cloud}" />
+      <inout_port name="masks3d" default="{masks3d}" />
+      <inout_port name="point_cloud" default="{point_cloud}" />
       <MetadataFields>
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
@@ -62,15 +62,15 @@
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Retreat To Initial Pose">
-      <input_port
+      <inout_port
         name="pre_approach_robot_state"
         default="{pre_approach_robot_state}"
       />
-      <input_port name="initial_robot_state" default="{initial_robot_state}" />
-      <input_port name="octomap_present" default="false">
+      <inout_port name="initial_robot_state" default="{initial_robot_state}" />
+      <inout_port name="octomap_present" default="false">
         Set to "true" only when an octomap has been built earlier in the
         objective; otherwise the gripper/octomap collision rules are skipped.
-      </input_port>
+      </inout_port>
       <MetadataFields>
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>


### PR DESCRIPTION
## Problem

SubTree ports are always bidirectional. 41 objectives across the example configs declare their SubTree interface with `<input_port>`/`<output_port>`, so the on-disk source is mis-authored. The REST converter fix (PickNikRobotics/moveit_pro#19904) normalizes this on read, but the source data is unchanged and the legacy `GET /behaviors/data` XML endpoint still emits directional tags to external LLM tooling.

## Approach

Rewrite the 171 directional ports inside the `<SubTree>` declarations to `<inout_port>`. The change is scoped to each objective's own SubTree interface definition — behavior port declarations and every other element are untouched. Multi-line and text-content port elements have both their opening and closing tags rewritten.

## Scope

- 41 files, 171 ports (172 lines: one port spans multiple lines).
- Per-config: kinova 11, lab_sim 9, ur 8, hangar 4, dual_arm 3, grinding 2, factory 2, franka 1, april_tag 1.
- Note: #19906 reports 42/180 measured on `main`; on `v9.4` it is 41/171 because the `external_dependencies` objective (1 file, 9 ports) does not exist on this branch. It needs the same fix when v9.4 merges forward.

## Verification

- Every changed line is a port tag (a diff filtered to non-port lines is empty).
- All 41 files re-parse as well-formed XML.
- Zero directional SubTree ports remain; no non-SubTree port was altered.

Read-side display was already fixed in #19904; this aligns the source data so the regression lint in `moveit_pro_lint` can be enabled afterward.

Refs PickNikRobotics/moveit_pro#19906