### PR TITLE
Fix: Open grasp-pose teleop in Interactive Marker view

### DIFF
--- a/src/lab_sim/objectives/grasp_pose_tuning_with_april_tag.xml
+++ b/src/lab_sim/objectives/grasp_pose_tuning_with_april_tag.xml
@@ -71,7 +71,7 @@
         ID="Request Teleoperation"
         _collapsed="true"
         enable_user_interaction="true"
-        initial_teleop_mode="3"
+        initial_teleop_mode="4"
         user_interaction_prompt="Teleoperate end effector to grasp pose"
         controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
         max_ik_solutions="8"


### PR DESCRIPTION
## Problem

The `Grasp Pose Tuning With April Tag` Objective (lab_sim) prompts the user to *"Teleoperate end effector to grasp pose"*. It set `initial_teleop_mode="3"` (`MOVE_TO_WAYPOINT`), which is the frontend's `DEFAULT_SIDEBAR_MODE`. For a default-mode goal the UI follows the persisted last-used teleop tab (`lastTeleopMode` in localStorage), so a fresh user lands in the **waypoints** view instead of the **Interactive Marker** — the natural tool for dragging the gripper to a pose.
## Approach

Set `initial_teleop_mode="4"` (`INTERACTIVE_MARKER`). The frontend applies a non-default `initial_mode` **verbatim** (`teleoperation-context.tsx`, `onGoalAccepted`), so this step now opens the Interactive Marker regardless of localStorage. One-character data change; no frontend change — the mechanism already exists.

## Scope

Only this Objective. The generic `Teleoperate` / `Request Teleoperation` Objectives keep `initial_teleop_mode="3"` (general teleop legitimately honors the last-used tab); this fix targets the grasp-positioning step where the Interactive Marker is the intuitive view.

## Doc impact

None. The how-to ([Grasping with Fiducials](https://docs.picknik.ai/how_to/robotics_applications/defining_a_grasp_pose/)) describes the step generically ("teleoperate the robot to an acceptable grasp pose") and its teleop GIFs show the 3D viewport, not the teleop sidebar, so no text or screenshot goes stale.

Refs PickNikRobotics/moveit_pro#17741