### PR TITLE
Add Bug type and example_ws label to weekly failure issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -404,12 +404,41 @@ jobs:
               });
               core.info(`Commented on existing ${issueOwner}/${issueRepo} issue #${existing.number}.`);
             } else {
-              const created = await github.rest.issues.create({
-                owner: issueOwner,
-                repo: issueRepo,
-                title,
-                body,
-              });
+              // `type` is the native org-level issue Type (moveit_pro triages
+              // failures by Type); `labels` marks the issue as originating from
+              // example_ws so it can be filtered in moveit_pro's shared tracker.
+              // Both are applied best-effort: if the create rejects them (e.g.
+              // the "Bug" type is renamed), retry with just title/body so the
+              // failure notification still lands rather than throwing and being
+              // silently dropped — same fail-open intent as the search above.
+              let created;
+              try {
+                created = await github.rest.issues.create({
+                  owner: issueOwner,
+                  repo: issueRepo,
+                  title,
+                  body,
+                  type: 'Bug',
+                  labels: ['example_ws'],
+                });
+              } catch (e) {
+                // Only retry on a 422 (the type/labels were rejected). Any other
+                // error — including a lost response after the issue was already
+                // created remotely — must rethrow, or the retry would file a
+                // duplicate issue.
+                if (e?.status !== 422) {
+                  throw e;
+                }
+                core.warning(
+                  `Create with type/labels rejected (${e.message}); retrying without them.`
+                );
+                created = await github.rest.issues.create({
+                  owner: issueOwner,
+                  repo: issueRepo,
+                  title,
+                  body,
+                });
+              }
               core.info(`Opened ${issueOwner}/${issueRepo} issue #${created.data.number}.`);
             }
 


### PR DESCRIPTION
## What

The `weekly-failure-issue` job (from #721) files a GitHub issue on `PickNikRobotics/moveit_pro` when the weekly sim integration suite fails. This tags that issue with:
- the native **Bug** issue Type (org-level field moveit_pro triages by), and
- the **`example_ws`** label (marks repo-of-origin in moveit_pro's shared tracker).

Both verified to exist in moveit_pro. The same `type: "Bug"` pattern is already used by moveit_pro's own `e2e-nightly.yaml` / `benchmarks-nightly.yaml`.

## Fail-open

`type`/`labels` are applied best-effort: the `issues.create` call is wrapped so that if it rejects them (e.g. the "Bug" type is later renamed), it retries with just `title`/`body`. The failure notification must always land — same fail-open intent as the dedupe search above it. Without the wrap, a rejected `type` would throw and silently drop the notification.

## Reviewed
- `code-reviewer` + `platform-architect-bot`. The architect's blocker (unwrapped create dropping the notification) is fixed by the retry above.

## Notes for the reviewer
- **App grant**: this relies on the `SISTER_REPOS` GitHub App installation having **Issues: write** on `moveit_pro`. That's a different grant than the commit-status write the `integration-status` job uses, so it hasn't been exercised yet — please confirm the installation has it (if not, even the bare retry create fails). The weekly cron hasn't fired, so this path is still unrun.
- The comment-on-existing-issue branch does **not** retroactively apply the Type/label — a recurring issue opened before this change keeps its original (untyped) state. Intended.