### PR TITLE
Fix: Vacuum grasp pierces the box and gets stuck during Execute MTC Solution

### DIFF
--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -189,7 +189,7 @@
                       ID="CreatePoseStamped"
                       reference_frame="world"
                       pose_stamped="{ee_to_tcp}"
-                      position_xyz="0;0;0"
+                      position_xyz="0;0;0.045"
                       orientation_xyzw="0;0;0;1"
                     />
                     <Action


### PR DESCRIPTION
While executing the Objective `ML Move Boxes to Loading Zone`, when the robot picks a box (during the `Execute MTC Solution` behavior), the vacuum end-effector pierces the box and gets stuck. The EE frame (`grasp_link`) sits above the cups, but we pass a zero cup offset (`ee_to_tcp = 0;0;0`), so we aim `grasp_link` at the surface and drive the cups ~4.5 cm into the box. With position-only control and `goal_duration_tolerance = -1`, it just sits frozen. It happens worse on the cloud but locally too.

Fix: set `ee_to_tcp` to `0;0;0.045` so the cup lands on the surface. This solves the problem locally.
