### PR TITLE
Fix: Segment Image from Text Prompt looks at boxes before segmenting

### DIFF
--- a/src/hangar_sim/objectives/segment_image_from_text_prompt.xml
+++ b/src/hangar_sim/objectives/segment_image_from_text_prompt.xml
@@ -8,6 +8,20 @@
   >
     <Control ID="Sequence">
       <SubTree
+        ID="Move to Waypoint (JTC)"
+        _collapsed="true"
+        acceleration_scale_factor="1.0"
+        controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_controller"
+        joint_group_name="manipulator"
+        keep_orientation="false"
+        keep_orientation_link_names="grasp_link"
+        keep_orientation_tolerance="0.05"
+        link_padding="0.0"
+        velocity_scale_factor="1.0"
+        waypoint_name="View Boxes"
+      />
+      <SubTree
         ID="Segment Image from Text Prompt Subtree"
         _collapsed="true"
         clip_model_path="models/clip.onnx"


### PR DESCRIPTION


https://github.com/user-attachments/assets/077879f4-ce82-4a92-9dab-9f4572a9e893



## Motivation

Closes PickNikRobotics/moveit_pro#20054. The `hangar_sim` example Objective **Segment Image from Text Prompt** failed out-of-the-box: from the default startup/reset pose the wrist camera does not frame the boxes, so CLIPSeg legitimately returned zero masks and the Objective errored with `GetMasks2DFromTextQuery Error — CLIPSeg found no masks for prompts [small boxes]`.

## Brief description

Prepend a `Move to Waypoint (JTC)` step to the existing **View Boxes** waypoint before the text-segmentation subtree, so the wrist camera is framing the boxes when CLIPSeg runs. This mirrors how the working `ML Move Boxes to Loading Zone` Objective positions the arm (`waypoint_name="View Boxes"`) before its ML perception. No prompt/threshold change was needed.

## How it was tested

Verified live on a running `hangar_sim` backend (web UI): Run **Segment Image from Text Prompt** from the default pose — the arm now moves to **View Boxes**, masks render on `/masks_visualization`, and the Objective Succeeds. Previously it failed on the first tick.
