### PR TITLE
Fix: Configure safe colcon overrides

### DIFF
--- a/colcon-defaults.yaml
+++ b/colcon-defaults.yaml
@@ -3,6 +3,9 @@ build:
   # Enable this for bidirectional syncing from the UI
   symlink-install: true
   allow-overriding:
+    - ewellix_description
+    - franka_description
+    - kortex_description
     - robotiq_description
     - ur_description
   mixin:
@@ -16,37 +19,7 @@ build:
     - build-testing-on
     - coverage-gcc
     - coverage-pytest
-  packages-skip:
-    - libfranka
-    - franka_bringup
-    - franka_example_controllers
-    - franka_fr3_moveit_config
-    - franka_gazebo_bringup
-    - franka_ign_ros2_control
-    - franka_gripper
-    - franka_hardware
-    - franka_robot_state_broadcaster
-    - franka_ros2
-    - franka_semantic_components
-    - integration_launch_testing
-    - phoebe_hw
-    - phoebe_bridgeback_description
 test:
   event-handlers:
     - console_direct+
     - desktop_notification+
-  packages-skip:
-    - libfranka
-    - franka_bringup
-    - franka_example_controllers
-    - franka_fr3_moveit_config
-    - franka_gazebo_bringup
-    - franka_ign_ros2_control
-    - franka_gripper
-    - franka_hardware
-    - franka_robot_state_broadcaster
-    - franka_ros2
-    - franka_semantic_components
-    - integration_launch_testing
-    - phoebe_hw
-    - phoebe_bridgeback_description


### PR DESCRIPTION
## Problem

Adds already-installed packages to `colcon-defaults.yaml`, where workspace-specific colcon overrides are already configured. The same file also still skipped several packages that no longer exist in this workspace, which leaves stale `packages-skip` entries in both build and test defaults.

Replacement for PickNikRobotics/moveit_pro#20084.

## Approach

- Added `ewellix_description`, `franka_description`, and `kortex_description` to `build.allow-overriding` in `colcon-defaults.yaml`.
- Kept the existing safe overrides for `robotiq_description` and `ur_description`.
- Removed the stale build/test `packages-skip` lists after verifying the listed packages are not present in the current workspace package set.

## Validation

- Parsed `colcon-defaults.yaml` with PyYAML and verified every `allow-overriding` entry has a matching `package.xml` in the initialized workspace.
- Verified no `packages-skip` keys remain in the build/test defaults.
- `pre-commit run -a`

## Release notes

- Bug Fix: Fixed misleading workspace build warnings for safe description package overrides in the example workspace.
