### PR TITLE
Add SAM3 perception and persistent placed-box obstacles to hangar_sim ML Move Boxes

### DIFF
--- a/src/hangar_sim/objectives/calibrate_sam3_mask_areas.xml
+++ b/src/hangar_sim/objectives/calibrate_sam3_mask_areas.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Calibrate SAM3 Mask Areas">
+  <!--
+    Diagnostic Objective for tuning FilterMasks2DByArea thresholds.
+
+    Grabs the current wrist camera image, runs SAM3 with the prompt and
+    confidence threshold below, then steps through every detected mask one
+    at a time: each tick overwrites /masks_visualization with a single mask
+    labeled by its pixel area (e.g. "area=8500 px"), waits 1.5 seconds, then
+    moves on to the next. Also logs all areas in order so you can pause and
+    correlate them.
+
+    Use the values you see to pick min_area / max_area in the production
+    pipeline (move_boxes_to_loading_zone_from_waypoint.xml). Move the robot
+    to the waypoint you want to calibrate against (e.g. View Boxes) before
+    running.
+
+    Edit text_prompt and confidence_threshold in the Script at the top to
+    match the values you're tuning for. Edit delay_duration on the
+    WaitForDuration node to slow down or speed up the cycle.
+  -->
+  <BehaviorTree
+    ID="Calibrate SAM3 Mask Areas"
+    _description="Runs SAM3 segmentation on the current wrist camera image, then cycles /masks_visualization through each detected mask labeled with its pixel area. Use to pick FilterMasks2DByArea thresholds."
+    _favorite="true"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action
+        ID="Script"
+        code="prompt := 'a single small orange cube box'; threshold := 0.25"
+      />
+      <Action
+        ID="GetImage"
+        topic_name="/wrist_camera/color"
+        message_out="{image}"
+        message_timeout_sec="5.000000"
+        publisher_timeout_sec="5.000000"
+      />
+      <Action
+        ID="GetMasks2DFromExemplar"
+        model_package="moveit_pro_sam3"
+        encoder_model_path="models/sam3_vision_encoder.onnx"
+        decoder_model_path="models/sam3_decoder.onnx"
+        geometry_encoder_model_path="models/sam3_geometry_encoder.onnx"
+        text_encoder_model_path="models/sam3_text_encoder.onnx"
+        confidence_threshold="{threshold}"
+        target_image="{image}"
+        text_prompt="{prompt}"
+        masks2d="{masks2d}"
+        mask_count="{mask_count}"
+      />
+      <Action
+        ID="Script"
+        code="header := &quot;SAM3 prompt=&quot;..prompt..&quot; threshold=&quot;..threshold..&quot; returned &quot;..mask_count..&quot; masks. Cycling visualization...&quot;"
+      />
+      <Action ID="LogMessage" message="{header}" log_level="info" />
+      <Decorator ID="ForEach" vector_in="{masks2d}" index="{idx}" out="{mask}">
+        <Control ID="Sequence">
+          <Action
+            ID="GetMask2DProperties"
+            mask="{mask}"
+            width="{w}"
+            height="{h}"
+            area="{area}"
+          />
+          <!--
+            Build a single-mask vector containing only the current ForEach
+            element, then publish it with a single-element label string. This
+            avoids the multi-label string accumulator (which BTCPP4 tinyscript
+            can't build via self-referential ..-concat) by leaning on the
+            per-tick PublishMask2D pattern from
+            src/factory_sim/objectives/automask_camera_iterate_masks.xml.
+          -->
+          <SubTree ID="CreateVector" _collapsed="true" vector="{one_mask}" />
+          <SubTree
+            ID="AddToVector"
+            _collapsed="true"
+            element="{mask}"
+            input_vector="{one_mask}"
+            output_vector="{one_mask}"
+          />
+          <Action
+            ID="Script"
+            code="mask_label := &quot;area=&quot;..area..&quot; px&quot;"
+          />
+          <Action
+            ID="PublishMask2D"
+            image="{image}"
+            masks="{one_mask}"
+            masks_visualization_topic="/masks_visualization"
+            opacity="0.500000"
+            bounding_box_labels="{mask_label}"
+          />
+          <Action
+            ID="Script"
+            code="line := &quot;  mask&quot;..idx..&quot;: area=&quot;..area..&quot; px bbox=&quot;..w..&quot;x&quot;..h"
+          />
+          <Action ID="LogMessage" message="{line}" log_level="info" />
+          <Action ID="WaitForDuration" delay_duration="1.5" />
+        </Control>
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Calibrate SAM3 Mask Areas">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/hangar_sim/objectives/calibrate_sam3_mask_areas.xml
+++ b/src/hangar_sim/objectives/calibrate_sam3_mask_areas.xml
@@ -22,7 +22,7 @@
   <BehaviorTree
     ID="Calibrate SAM3 Mask Areas"
     _description="Runs SAM3 segmentation on the current wrist camera image, then cycles /masks_visualization through each detected mask labeled with its pixel area. Use to pick FilterMasks2DByArea thresholds."
-    _favorite="true"
+    _favorite="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action

--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -29,9 +29,9 @@
         outer init only matters if the Subtree fails before either of those resets
         runs.
 
-        Compatibility note: this Objective relies on three runtime contracts that the
+        Compatibility note: this Objective relies on four runtime contracts that the
         loaded `moveit_pro` build must satisfy — `ScriptCondition` (built-in BT.CPP 4),
-        `GetMasks2DFromExemplar` (SAM3 multimodal segmenter, 9.3+) which exposes the
+        `GetMasks2DFromExemplar` (SAM3 multimodal segmenter, 9.1+) which exposes the
         `mask_count` output port the inner Subtree uses, `RepeatUnlessFailureEachTick`
         (9.3+), and BT.CPP 4's SKIPPED-status propagation through `_skipIf`-decorated
         nodes and parent Sequences. Older runtimes will either fail to load the tree

--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="ML Move Boxes to Loading Zone">
-  <!--//////////-->
   <BehaviorTree
     ID="ML Move Boxes to Loading Zone"
     _description="Move all of the boxes into the loading zone using ML perception."
@@ -14,33 +13,85 @@
         orientation_xyzw="0;1.0;0;0"
         position_xyz="-4.5;8.4;0.5"
       />
-      <Decorator ID="RetryUntilSuccessful" num_attempts="1000">
-        <Decorator ID="ForceFailure">
+      <!--Initialize the drained signal and the per-iteration pick flags.
+
+        `drained := false` is the load-bearing one — if the very first iteration of
+        the loop below fails before the in-loop `Script(drained := ...)` runs, the
+        post-loop `ScriptCondition(drained)` would otherwise read an undefined value.
+
+        `picked_at_wp1 := false` / `picked_at_wp2 := false` are defensive. Each pick
+        waypoint Subtree resets its `picked_box` output port at the top of its own
+        body and again before wp2 below, so the in-loop reads are always fresh; this
+        outer init only matters if the Subtree fails before either of those resets
+        runs.
+
+        Compatibility note: this Objective relies on three runtime contracts that the
+        loaded `moveit_pro` build must satisfy — `ScriptCondition` (built-in BT.CPP 4),
+        `GetMasks2DFromExemplar` (SAM3 multimodal segmenter, 9.3+) which exposes the
+        `mask_count` output port the inner Subtree uses, `RepeatUnlessFailureEachTick`
+        (9.3+), and BT.CPP 4's SKIPPED-status propagation through `_skipIf`-decorated
+        nodes and parent Sequences. Older runtimes will either fail to load the tree
+        or behave incorrectly on the `_skipIf` paths.-->
+      <Action
+        ID="Script"
+        code="picked_at_wp1 := false; picked_at_wp2 := false; drained := false"
+      />
+      <!--Loop the pick cycle until the scene is drained (drained=true), and surface
+        real pick errors as Objective FAILURE.
+
+        Each iteration: visit `View Boxes`, then `View Boxes 2` (only if the first
+        did not pick — saves a redundant scan once the first waypoint is the
+        productive one). Each Subtree returns SUCCESS with `picked_box` set true
+        or false on the happy path, and FAILURE only on real pick errors (the
+        inner Subtree's `Inverter > ForEach > Inverter` retains the existing "try
+        each mask, succeed if any" resilience — see that Subtree for the per-mask
+        FAILURE caveat).
+
+        The Script step computes whether anything was picked this cycle; the inner
+        `ScriptCondition(!drained)` converts a "nothing picked" cycle into FAILURE
+        that breaks the `RepeatUnlessFailureEachTick(-1)` loop.
+
+        The outer Fallback then distinguishes the two FAILURE causes of the loop:
+          - drained=true  → expected exit, the post-loop ScriptCondition succeeds → SUCCESS.
+          - drained=false → real pick error propagated from a Subtree, the post-loop
+                            ScriptCondition also fails → Objective FAILURE.-->
+      <Control ID="Fallback">
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
           <Control ID="Sequence">
-            <Control ID="Fallback">
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes"
-                _collapsed="false"
-                threshold="0.25"
-                prompt="a small brown box"
-                negative_prompts="yellow ladder;"
-                prompts="small boxes"
-                place_pose="{place_pose}"
-                erosion_size="10"
-              />
-              <SubTree
-                ID="Move Boxes to Loading Zone Start from Waypoint"
-                waypoint_name="View Boxes 2"
-                place_pose="{place_pose}"
-                threshold="0.4"
-                _collapsed="false"
-                prompts="small boxes"
-                negative_prompts="gray;gray;rails"
-                erosion_size="2"
-                prompt="{prompt}"
-              />
-            </Control>
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              _collapsed="true"
+              waypoint_name="View Boxes"
+              confidence_threshold="0.25"
+              text_prompt="a single small orange cube box"
+              place_pose="{place_pose}"
+              picked_box="{picked_at_wp1}"
+            />
+            <!--Reset picked_at_wp2 before the (possibly-skipped) wp2 SubTree so the
+              "did wp2 contribute this iteration?" reading is never stale from a prior
+              iteration. Without this, `_skipIf="picked_at_wp1"` would leave the wp2
+              SubTree's output port unwritten and the next Script would OR against a
+              stale value. The drained computation happens to be correct today (wp1
+              picked, so the OR short-circuits true), but any future read of
+              picked_at_wp2 — telemetry, an extra waypoint, etc. — would see stale
+              data and the invariant "picked_at_wpN iff wpN picked in this iteration"
+              would silently break.-->
+            <Action ID="Script" code="picked_at_wp2 := false" />
+            <SubTree
+              ID="Move Boxes to Loading Zone Start from Waypoint"
+              _collapsed="true"
+              _skipIf="picked_at_wp1"
+              waypoint_name="View Boxes 2"
+              confidence_threshold="0.25"
+              text_prompt="a single small orange cube box"
+              place_pose="{place_pose}"
+              picked_box="{picked_at_wp2}"
+            />
+            <Action
+              ID="Script"
+              code="drained := !(picked_at_wp1 || picked_at_wp2)"
+            />
+            <Action ID="ScriptCondition" code="!drained" />
             <Action
               ID="TransformPose"
               input_pose="{place_pose}"
@@ -49,7 +100,8 @@
             />
           </Control>
         </Decorator>
-      </Decorator>
+        <Action ID="ScriptCondition" code="drained" />
+      </Control>
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
+++ b/src/hangar_sim/objectives/ml_move_boxes_to_loading_zone.xml
@@ -6,6 +6,10 @@
     _favorite="true"
   >
     <Control ID="Sequence">
+      <!--Clear any collision objects left in the planning scene by a previous run of this
+          Objective (the per-box "placed_box_N" obstacles added below persist until removed).
+          Without this, stale boxes from the last run would block planning at their old poses.-->
+      <Action ID="ResetPlanningSceneObjects" />
       <Action
         ID="CreatePoseStamped"
         reference_frame="world"
@@ -34,7 +38,7 @@
         or behave incorrectly on the `_skipIf` paths.-->
       <Action
         ID="Script"
-        code="picked_at_wp1 := false; picked_at_wp2 := false; drained := false"
+        code="picked_at_wp1 := false; picked_at_wp2 := false; drained := false; placed_count := 0"
       />
       <!--Loop the pick cycle until the scene is drained (drained=true), and surface
         real pick errors as Objective FAILURE.
@@ -65,6 +69,7 @@
               confidence_threshold="0.25"
               text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
+              placed_count="{placed_count}"
               picked_box="{picked_at_wp1}"
             />
             <!--Reset picked_at_wp2 before the (possibly-skipped) wp2 SubTree so the
@@ -85,6 +90,7 @@
               confidence_threshold="0.25"
               text_prompt="a single small orange cube box"
               place_pose="{place_pose}"
+              placed_count="{placed_count}"
               picked_box="{picked_at_wp2}"
             />
             <Action

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -9,6 +9,7 @@
     _description="Move boxes to loading zone from waypoint"
     waypoint_name="View Boxes"
     place_pose="{place_pose}"
+    placed_count="{placed_count}"
     confidence_threshold="{confidence_threshold}"
     text_prompt="{text_prompt}"
     _favorite="false"
@@ -412,6 +413,38 @@
                     timeout="10.000000"
                     gripper_command_action_name="/vacuum_gripper/gripper_cmd"
                   />
+                  <!--Box released at the loading zone. Drop a persistent collision obstacle at the
+                      commanded place pose under a unique id ("placed_box_N"), then advance the counter
+                      so the next box gets its own id. place_pose is built in the world frame by the
+                      parent Objective, so the obstacle lands where the box was actually placed; later
+                      picks then plan the whole-body base around every already-placed box instead of
+                      driving over them (#19973). We add the obstacle here (after release) rather than
+                      attaching the carried box, because the ICP target_pose is base-relative and
+                      mislabeled world, which placed earlier attempts ~10 m off the robot.-->
+                  <Action
+                    ID="Script"
+                    code="placed_box_id := 'placed_box_' .. placed_count"
+                  />
+                  <!--Drop the obstacle pose from the place-pose hover height (z=0.5) down to the
+                      floor where the released box actually rests. TransformPose applies the offset in
+                      place_pose's body frame; place_pose points straight down (180 deg about Y), so a
+                      local +0.4 z maps to world -0.4 z, leaving x/y unchanged. Output to a separate
+                      pose so the parent's place motion still targets the original place_pose.-->
+                  <Action
+                    ID="TransformPose"
+                    input_pose="{place_pose}"
+                    output_pose="{placed_box_pose}"
+                    translation_xyz="0;0;0.4"
+                  />
+                  <Action
+                    ID="AddCollisionMesh"
+                    object_id="{placed_box_id}"
+                    mesh_file_path="package://hangar_sim/objectives/box.stl"
+                    pose="{placed_box_pose}"
+                    scale="1;1;1"
+                    overwrite="true"
+                  />
+                  <Action ID="Script" code="placed_count := placed_count + 1" />
                   <!--
                       A full pick+place cycle completed. The parent Objective reads
                       picked_box to decide whether to continue the outer loop or exit
@@ -438,6 +471,7 @@
       />
       <output_port name="picked_box" default="{picked_box}" />
       <input_port name="place_pose" default="{place_pose}" />
+      <inout_port name="placed_count" default="0" />
       <input_port name="text_prompt" default="{text_prompt}" />
       <input_port name="waypoint_name" default="View Boxes" />
     </SubTree>

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -223,7 +223,7 @@
                     end_effector_group_name="gripper"
                     generate_centroid_grasps="true"
                     grasp_poses="{grasp_poses}"
-                    num_orientation_samples="20"
+                    num_orientation_samples="8"
                     padding_dimension="0.01"
                     planning_scene_msg="{planning_scene}"
                     samples_per_plane="2"
@@ -239,10 +239,7 @@
                     world frame. SAM3's per-detection yaw is noisy and arbitrary
                     for a rotationally-symmetric brown cube, so letting it
                     rotate the gripper makes the wrist angle drift with
-                    detection noise instead of staying consistent across picks
-                    and can land the IK solver in awkward configurations that
-                    self-collide once the box is attached (see the bump to
-                    `max_ik_solutions="16"` below for the same reason).
+                    detection noise instead of staying consistent across picks.
 
                     We overwrite each grasp's orientation with a fixed
                     "gripper pointing straight down" quaternion (matching the
@@ -330,7 +327,7 @@
                     end_effector_link="grasp_link"
                     ik_group="manipulator"
                     ik_timeout_s="0.01"
-                    max_ik_solutions="16"
+                    max_ik_solutions="8"
                     monitored_stage="allow collision (gripper, &lt;octomap&gt;)"
                     target_poses="{leveled_grasp_poses}"
                     task="{task}"
@@ -402,6 +399,47 @@
                     gripper_command_action_name="/vacuum_gripper/gripper_cmd"
                     position="1.0"
                   />
+                  <!--Lift the box straight up ~10 cm right after grasping to clear the surface before
+                      transiting, so it does not drag along the ground. grasp_link points straight down at
+                      the grasp, so a grasp_link-relative -Z move is world +Z (up); mirrors the standard
+                      pick retreat (retract_xyz default 0;0;-0.1).-->
+                  <Action
+                    ID="CreatePoseStamped"
+                    reference_frame="grasp_link"
+                    pose_stamped="{lift_pose}"
+                    position_xyz="0;0;-0.1"
+                  />
+                  <Action ID="ResetPoseStampedVector" vector="{lift_path}" />
+                  <Action
+                    ID="PushBackVector"
+                    input_vector="{lift_path}"
+                    element="{lift_pose}"
+                    output_vector="{lift_path}"
+                  />
+                  <Action
+                    ID="PlanCartesianPath"
+                    acceleration_scale_factor="1.000000"
+                    blending_radius="0.020000"
+                    ik_cartesian_space_density="0.010000"
+                    ik_joint_space_density="0.100000"
+                    joint_trajectory_msg="{joint_trajectory_msg}"
+                    path="{lift_path}"
+                    planning_group_name="manipulator"
+                    position_only="false"
+                    tip_links="grasp_link"
+                    trajectory_sampling_rate="100"
+                    velocity_scale_factor="1.000000"
+                  />
+                  <!--Execute the lift on the JTC pipeline. ExecuteTrajectory defaults to the JTAC
+                      (admittance) controller, which hangar_sim does not run; this objective uses
+                      joint_trajectory_controller everywhere, so target it explicitly or the lift fails
+                      with "action server not available" and the cycle stalls.-->
+                  <Action
+                    ID="ExecuteTrajectory"
+                    execution_pipeline="jtc"
+                    controller_action_name="/joint_trajectory_controller/follow_joint_trajectory"
+                    joint_trajectory_msg="{joint_trajectory_msg}"
+                  />
                   <SubTree
                     ID="Move to Pose No Preview"
                     _collapsed="true"
@@ -413,14 +451,9 @@
                     timeout="10.000000"
                     gripper_command_action_name="/vacuum_gripper/gripper_cmd"
                   />
-                  <!--Box released at the loading zone. Drop a persistent collision obstacle at the
-                      commanded place pose under a unique id ("placed_box_N"), then advance the counter
-                      so the next box gets its own id. place_pose is built in the world frame by the
-                      parent Objective, so the obstacle lands where the box was actually placed; later
-                      picks then plan the whole-body base around every already-placed box instead of
-                      driving over them (#19973). We add the obstacle here (after release) rather than
-                      attaching the carried box, because the ICP target_pose is base-relative and
-                      mislabeled world, which placed earlier attempts ~10 m off the robot.-->
+                  <!--Box released at the loading zone: drop a persistent collision obstacle at the place
+                      pose (floor height) under a unique id so the whole-body base plans around every
+                      already-placed box instead of driving over them (#19973).-->
                   <Action
                     ID="Script"
                     code="placed_box_id := 'placed_box_' .. placed_count"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -9,14 +9,18 @@
     _description="Move boxes to loading zone from waypoint"
     waypoint_name="View Boxes"
     place_pose="{place_pose}"
-    threshold="{threshold}"
-    prompt="{prompt}"
-    negative_prompts="{negative_prompts}"
-    prompts="{prompts}"
-    erosion_size="0"
+    confidence_threshold="{confidence_threshold}"
+    text_prompt="{text_prompt}"
     _favorite="false"
   >
     <Control ID="Sequence">
+      <!--
+        Reset the picked_box output port at the very top so the invariant
+        "picked_box reflects what happened on THIS Subtree invocation, not the
+        previous one" holds even if a step BEFORE the pick loop (waypoint motion,
+        point-cloud capture, image fetch, etc.) fails.
+      -->
+      <Action ID="Script" code="picked_box := false" />
       <Action
         ID="MoveGripperAction"
         position="0.0"
@@ -92,262 +96,332 @@
         publisher_timeout_sec="5.000000"
       />
       <Control ID="Sequence">
+        <!--
+          SAM3 text-prompt segmentation. Unlike the previous CLIPSeg + SAM2-refine
+          chain, SAM3 produces high-quality per-detection masks directly from a text
+          prompt, so no point-prompt refinement step is needed. The Behavior returns
+          SUCCESS with `mask_count == 0` when nothing is detected, which the
+          `_skipIf` below uses to bypass the pick loop and let the Subtree exit
+          cleanly with `picked_box=false`.
+        -->
         <Action
-          ID="GetMasks2DFromTextQuery"
-          image="{image}"
-          masks2d="{clip_masks2d}"
-          threshold="{threshold}"
-          clipseg_model_path="models/clipseg.onnx"
-          clip_model_path="models/clip.onnx"
-          model_package="moveit_pro_clipseg"
-          prompts="{prompts}"
-          negative_prompts="{negative_prompts}"
-          erosion_size="{erosion_size}"
+          ID="GetMasks2DFromExemplar"
+          model_package="moveit_pro_sam3"
+          encoder_model_path="models/sam3_vision_encoder.onnx"
+          decoder_model_path="models/sam3_decoder.onnx"
+          geometry_encoder_model_path="models/sam3_geometry_encoder.onnx"
+          text_encoder_model_path="models/sam3_text_encoder.onnx"
+          confidence_threshold="{confidence_threshold}"
+          target_image="{image}"
+          text_prompt="{text_prompt}"
+          masks2d="{masks2d}"
+          mask_count="{mask_count}"
+        />
+        <!--
+          Drop both oversized false positives (SAM3 occasionally returns a
+          single mask covering most of the image — e.g., the cart frame, which
+          measured ~26,285 px in calibration) and tiny edge-fragment detections
+          (~778 px in calibration). Real boxes in this scene measured
+          3,949–20,643 px; thresholds sit ~2x outside that range on the low
+          end and ~12% inside the cart-vs-largest-real gap on the high end.
+          Re-run "Calibrate SAM3 Mask Areas" if the camera, lens, or scale
+          changes.
+        -->
+        <Action
+          ID="FilterMasks2DByArea"
+          masks="{masks2d}"
+          min_area="2000"
+          max_area="23000"
+          filtered_masks="{masks2d}"
+        />
+        <Action
+          ID="GetSizeOfVector"
+          vector_in="{masks2d}"
+          vector_size="{mask_count}"
         />
         <Action
           ID="PublishMask2D"
           image="{image}"
-          masks="{clip_masks2d}"
+          masks="{masks2d}"
           masks_visualization_topic="/masks_visualization"
           opacity="0.500000"
         />
-        <Decorator ID="Inverter">
-          <Decorator
-            ID="ForEach"
-            vector_in="{clip_masks2d}"
-            index="{index}"
-            out="{clip_mask2d}"
-          >
-            <Decorator ID="Inverter">
+        <!--
+          Skip the pick pipeline entirely when SAM3 found nothing — `picked_box`
+          stays false from the reset at the top, the Subtree returns SUCCESS,
+          and the parent Objective treats it as "scanned and found nothing"
+          rather than a real pick error. The Inverter+ForEach+Inverter pattern
+          below short-circuits on the first successful pick and silently retries
+          on per-mask failure; the Subtree only returns FAILURE if every detected
+          object failed to pick. Non-recoverable per-mask faults (e.g. controller
+          deactivation, execution abort) are currently indistinguishable from
+          recoverable ones (e.g. unreachable IK) inside this loop — see
+          PickNikRobotics/moveit_pro#19238 for the follow-up to differentiate.
+        -->
+        <Decorator ID="Inverter" _skipIf="mask_count == 0">
+          <Control ID="Sequence">
+            <Action
+              ID="GetMasks3DFromMasks2D"
+              camera_info="{camera_info}"
+              masks2d="{masks2d}"
+              point_cloud="{point_cloud_cropped}"
+              masks3d="{masks3d}"
+            />
+            <Decorator
+              ID="ForEach"
+              vector_in="{masks3d}"
+              index="{index}"
+              out="{mask3d}"
+            >
               <Control ID="Sequence">
                 <Action
-                  ID="GetCenterFromMask2D"
-                  mask="{clip_mask2d}"
-                  center="{pixel_coords}"
-                />
-                <Action
-                  ID="GetMasks2DFromPointQuery"
-                  image="{image}"
-                  pixel_coords="{pixel_coords}"
-                  masks2d="{masks2d}"
-                  model_package="moveit_pro_sam2"
-                  decoder_model_path="models/sam2_decoder.onnx"
-                  encoder_model_path="models/sam2_hiera_large_encoder.onnx"
-                />
-                <Action
-                  ID="PublishMask2D"
-                  image="{image}"
-                  masks="{masks2d}"
-                  masks_visualization_topic="/masks_visualization"
-                  opacity="0.500000"
-                />
-                <Action
-                  ID="GetMasks3DFromMasks2D"
-                  camera_info="{camera_info}"
-                  masks2d="{masks2d}"
+                  ID="GetPointCloudFromMask3D"
+                  mask3d="{mask3d}"
                   point_cloud="{point_cloud_cropped}"
-                  masks3d="{masks3d}"
+                  point_cloud_fragment="{point_cloud_fragment}"
                 />
-                <Decorator
-                  ID="ForEach"
-                  vector_in="{masks3d}"
-                  index="{index}"
-                  out="{mask3d}"
-                >
-                  <Control ID="Sequence">
-                    <Action
-                      ID="GetPointCloudFromMask3D"
-                      mask3d="{mask3d}"
-                      point_cloud="{point_cloud_cropped}"
-                      point_cloud_fragment="{point_cloud_fragment}"
-                    />
-                    <Action
-                      ID="SendPointCloudToUI"
-                      pcd_topic="/pcd_pointcloud_captures"
-                      point_cloud="{point_cloud_fragment}"
-                    />
-                  </Control>
-                </Decorator>
                 <Action
-                  ID="GetGraspableObjectsFromMasks3D"
-                  base_frame="world"
-                  masks3d="{masks3d}"
-                  minimum_face_area="0.0003"
-                  plane_inlier_threshold="0.01"
-                  point_cloud="{point_cloud_cropped}"
-                  graspable_objects="{graspable_objects}"
-                  face_separation_threshold="0.2"
+                  ID="SendPointCloudToUI"
+                  pcd_topic="/pcd_pointcloud_captures"
+                  point_cloud="{point_cloud_fragment}"
                 />
-                <Decorator
-                  ID="ForEach"
-                  vector_in="{graspable_objects}"
-                  index="{index}"
-                  out="{graspable_object}"
-                >
-                  <Control ID="Sequence">
-                    <Action
-                      ID="CreatePoseStamped"
-                      reference_frame="world"
-                      pose_stamped="{ee_to_tcp}"
-                      position_xyz="0;0;0.045"
-                      orientation_xyzw="0;0;0;1"
-                    />
-                    <Action
-                      ID="GetCurrentPlanningScene"
-                      planning_scene_msg="{planning_scene}"
-                    />
-                    <Action
-                      ID="GenerateVacuumGraspPoses"
-                      ee_to_tcp_tf="{ee_to_tcp}"
-                      end_effector_group_name="gripper"
-                      generate_centroid_grasps="true"
-                      grasp_poses="{grasp_poses}"
-                      num_orientation_samples="20"
-                      padding_dimension="0.01"
-                      planning_scene_msg="{planning_scene}"
-                      samples_per_plane="2"
-                      target_object="{graspable_object}"
-                      ui_grasp_link="grasp_link"
-                    />
-                    <Action
-                      ID="InitializeMTCTask"
-                      controller_names="joint_trajectory_controller"
-                      task="{task}"
-                      task_id=""
-                      trajectory_monitoring="false"
-                      timeout="-1.000000"
-                    />
-                    <Action ID="SetupMTCCurrentState" task="{task}" />
-                    <Action
-                      ID="SetupMTCSetCollisionRule"
-                      allow_collision="true"
-                      name_a="gripper"
-                      name_b="&lt;octomap&gt;"
-                      task="{task}"
-                    />
-                    <Action
-                      ID="SetupMTCConnectWithProRRT"
-                      acceleration_scale_factor="1.000000"
-                      keep_orientation="false"
-                      keep_orientation_link_names="grasp_link"
-                      keep_orientation_tolerance="0.100000"
-                      link_padding="0.000000"
-                      max_iterations="5000"
-                      planning_group_name="manipulator"
-                      seed="0"
-                      task="{task}"
-                      trajectory_sampling_rate="100"
-                      velocity_scale_factor="1.000000"
-                    />
-                    <Action
-                      ID="SetupMTCMoveAlongFrameAxis"
-                      acceleration_scale="1.000000"
-                      axis_frame="grasp_link"
-                      axis_x="0.000000"
-                      axis_y="0.000000"
-                      axis_z="1.000000"
-                      hand_frame="grasp_link"
-                      ignore_environment_collisions="false"
-                      max_distance="0.2"
-                      min_distance="0.05"
-                      planning_group_name="manipulator"
-                      task="{task}"
-                      velocity_scale="1.000000"
-                    />
-                    <Action
-                      ID="SetupMTCBatchPoseIK"
-                      end_effector_group="moveit_ee"
-                      end_effector_link="grasp_link"
-                      ik_group="manipulator"
-                      ik_timeout_s="0.01"
-                      max_ik_solutions="1"
-                      monitored_stage="allow collision (gripper, &lt;octomap&gt;)"
-                      target_poses="{grasp_poses}"
-                      task="{task}"
-                    />
-                    <Control ID="Parallel" success_count="2" failure_count="1">
-                      <Control ID="Sequence">
-                        <Action
-                          ID="PlanMTCTask"
-                          solution="{solution}"
-                          task="{task}"
-                        />
-                        <SubTree
-                          ID="Execute MTC Solution (JTC)"
-                          solution="{solution}"
-                          goal_duration_tolerance="-1.0"
-                        />
-                      </Control>
-                      <Control ID="Sequence" name="TopLevelSequence">
-                        <Action
-                          ID="LoadPointCloudFromFile"
-                          color="0;255;0"
-                          file_path="box.stl"
-                          point_cloud="{box_mesh}"
-                          frame_id="world"
-                          num_sampled_points="50000"
-                          scale="1.000000"
-                        />
-                        <Action
-                          ID="GetCentroidFromPointCloud"
-                          point_cloud="{point_cloud_fragment}"
-                          output_pose="{point_cloud_fragment_center}"
-                        />
-                        <Action
-                          ID="TransformPointCloud"
-                          input_cloud="{box_mesh}"
-                          transform_pose="{point_cloud_fragment_center}"
-                          output_cloud="{box_mesh}"
-                        />
-                        <Action
-                          ID="RegisterPointClouds"
-                          target_point_cloud="{point_cloud_fragment}"
-                          target_pose_in_base_frame="{target_pose}"
-                          base_point_cloud="{box_mesh}"
-                          max_correspondence_distance="0.05"
-                          max_iterations="40"
-                        />
-                        <Action
-                          ID="TransformPointCloud"
-                          input_cloud="{box_mesh}"
-                          transform_pose="{target_pose}"
-                          output_cloud="{icp_cloud}"
-                        />
-                        <Action
-                          ID="TransformPointCloudFrame"
-                          input_cloud="{icp_cloud}"
-                          output_cloud="{icp_cloud}"
-                          target_frame="world"
-                        />
-                        <Action
-                          ID="SendPointCloudToUI"
-                          pcd_topic="/pcd_pointcloud_captures"
-                          point_cloud="{icp_cloud}"
-                        />
-                      </Control>
-                    </Control>
-                    <Action
-                      ID="MoveGripperAction"
-                      timeout="10.000000"
-                      gripper_command_action_name="/vacuum_gripper/gripper_cmd"
-                      position="1.0"
-                    />
-                    <SubTree
-                      ID="Move to Pose No Preview"
-                      _collapsed="true"
-                      target_pose="{place_pose}"
-                    />
-                    <Action
-                      ID="MoveGripperAction"
-                      position="0.0"
-                      timeout="10.000000"
-                      gripper_command_action_name="/vacuum_gripper/gripper_cmd"
-                    />
-                  </Control>
-                </Decorator>
               </Control>
             </Decorator>
-          </Decorator>
+            <Action
+              ID="GetGraspableObjectsFromMasks3D"
+              base_frame="world"
+              masks3d="{masks3d}"
+              minimum_face_area="0.0003"
+              plane_inlier_threshold="0.01"
+              point_cloud="{point_cloud_cropped}"
+              graspable_objects="{graspable_objects}"
+              face_separation_threshold="0.2"
+            />
+            <Decorator
+              ID="ForEach"
+              vector_in="{graspable_objects}"
+              index="{index}"
+              out="{graspable_object}"
+            >
+              <Decorator ID="Inverter">
+                <Control ID="Sequence">
+                  <Action
+                    ID="CreatePoseStamped"
+                    reference_frame="world"
+                    pose_stamped="{ee_to_tcp}"
+                    position_xyz="0;0;0.045"
+                    orientation_xyzw="0;0;0;1"
+                  />
+                  <Action
+                    ID="GetCurrentPlanningScene"
+                    planning_scene_msg="{planning_scene}"
+                  />
+                  <Action
+                    ID="GenerateVacuumGraspPoses"
+                    ee_to_tcp_tf="{ee_to_tcp}"
+                    end_effector_group_name="gripper"
+                    generate_centroid_grasps="true"
+                    grasp_poses="{grasp_poses}"
+                    num_orientation_samples="20"
+                    padding_dimension="0.01"
+                    planning_scene_msg="{planning_scene}"
+                    samples_per_plane="2"
+                    target_object="{graspable_object}"
+                    ui_grasp_link="grasp_link"
+                  />
+                  <!--
+                    Discard the box-yaw component from every generated grasp.
+
+                    `GenerateVacuumGraspPoses` builds each grasp as
+                    `R_world_to_object * (face/position/flip/wrist samples)`, so
+                    the box's detected yaw rotates every candidate orientation in
+                    world frame. SAM3's per-detection yaw is noisy and arbitrary
+                    for a rotationally-symmetric brown cube, so letting it
+                    rotate the gripper makes the wrist angle drift with
+                    detection noise instead of staying consistent across picks
+                    and can land the IK solver in awkward configurations that
+                    self-collide once the box is attached (see the bump to
+                    `max_ik_solutions="16"` below for the same reason).
+
+                    We overwrite each grasp's orientation with a fixed
+                    "gripper pointing straight down" quaternion (matching the
+                    outer Objective's `place_pose`). The vacuum gripper is
+                    rotationally symmetric about its approach axis, so the pick
+                    is unaffected. Tradeoff: this collapses the 20 wrist-angle
+                    samples to one orientation per (face, position, flip), so
+                    candidates that previously succeeded only at a non-trivial
+                    wrist angle will now fail IK. The centroid-grasp sample and
+                    the bidirectional flip variant remain, which has been
+                    sufficient for top-face picks of cubes in hangar_sim.
+                  -->
+                  <Action
+                    ID="ResetPoseStampedVector"
+                    vector="{leveled_grasp_poses}"
+                  />
+                  <Decorator
+                    ID="ForEach"
+                    vector_in="{grasp_poses}"
+                    index="{grasp_index}"
+                    out="{grasp_pose}"
+                  >
+                    <Control ID="Sequence">
+                      <Action
+                        ID="OverridePoseOrientation"
+                        input_pose="{grasp_pose}"
+                        orientation_xyzw="0;1.0;0;0"
+                        output_pose="{leveled_grasp_pose}"
+                      />
+                      <Action
+                        ID="AddPoseStampedToVector"
+                        input="{leveled_grasp_pose}"
+                        vector="{leveled_grasp_poses}"
+                      />
+                    </Control>
+                  </Decorator>
+                  <Action
+                    ID="InitializeMTCTask"
+                    controller_names="joint_trajectory_controller"
+                    task="{task}"
+                    task_id=""
+                    trajectory_monitoring="false"
+                    timeout="-1.000000"
+                  />
+                  <Action ID="SetupMTCCurrentState" task="{task}" />
+                  <Action
+                    ID="SetupMTCSetCollisionRule"
+                    allow_collision="true"
+                    name_a="gripper"
+                    name_b="&lt;octomap&gt;"
+                    task="{task}"
+                  />
+                  <Action
+                    ID="SetupMTCConnectWithProRRT"
+                    acceleration_scale_factor="1.000000"
+                    keep_orientation="false"
+                    keep_orientation_link_names="grasp_link"
+                    keep_orientation_tolerance="0.100000"
+                    link_padding="0.000000"
+                    max_iterations="5000"
+                    planning_group_name="manipulator"
+                    seed="0"
+                    task="{task}"
+                    trajectory_sampling_rate="100"
+                    velocity_scale_factor="1.000000"
+                  />
+                  <Action
+                    ID="SetupMTCMoveAlongFrameAxis"
+                    acceleration_scale="1.000000"
+                    axis_frame="grasp_link"
+                    axis_x="0.000000"
+                    axis_y="0.000000"
+                    axis_z="1.000000"
+                    hand_frame="grasp_link"
+                    ignore_environment_collisions="false"
+                    max_distance="0.2"
+                    min_distance="0.05"
+                    planning_group_name="manipulator"
+                    task="{task}"
+                    velocity_scale="1.000000"
+                  />
+                  <Action
+                    ID="SetupMTCBatchPoseIK"
+                    end_effector_group="moveit_ee"
+                    end_effector_link="grasp_link"
+                    ik_group="manipulator"
+                    ik_timeout_s="0.01"
+                    max_ik_solutions="16"
+                    monitored_stage="allow collision (gripper, &lt;octomap&gt;)"
+                    target_poses="{leveled_grasp_poses}"
+                    task="{task}"
+                  />
+                  <Control ID="Parallel" success_count="2" failure_count="1">
+                    <Control ID="Sequence">
+                      <Action
+                        ID="PlanMTCTask"
+                        solution="{solution}"
+                        task="{task}"
+                      />
+                      <SubTree
+                        ID="Execute MTC Solution (JTC)"
+                        solution="{solution}"
+                        goal_duration_tolerance="-1.0"
+                      />
+                    </Control>
+                    <Control ID="Sequence" name="TopLevelSequence">
+                      <Action
+                        ID="LoadPointCloudFromFile"
+                        color="0;255;0"
+                        file_path="box.stl"
+                        point_cloud="{box_mesh}"
+                        frame_id="world"
+                        num_sampled_points="50000"
+                        scale="1.000000"
+                      />
+                      <Action
+                        ID="GetCentroidFromPointCloud"
+                        point_cloud="{point_cloud_fragment}"
+                        output_pose="{point_cloud_fragment_center}"
+                      />
+                      <Action
+                        ID="TransformPointCloud"
+                        input_cloud="{box_mesh}"
+                        transform_pose="{point_cloud_fragment_center}"
+                        output_cloud="{box_mesh}"
+                      />
+                      <Action
+                        ID="RegisterPointClouds"
+                        target_point_cloud="{point_cloud_fragment}"
+                        target_pose_in_base_frame="{target_pose}"
+                        base_point_cloud="{box_mesh}"
+                        max_correspondence_distance="0.05"
+                        max_iterations="40"
+                      />
+                      <Action
+                        ID="TransformPointCloud"
+                        input_cloud="{box_mesh}"
+                        transform_pose="{target_pose}"
+                        output_cloud="{icp_cloud}"
+                      />
+                      <Action
+                        ID="TransformPointCloudFrame"
+                        input_cloud="{icp_cloud}"
+                        output_cloud="{icp_cloud}"
+                        target_frame="world"
+                      />
+                      <Action
+                        ID="SendPointCloudToUI"
+                        pcd_topic="/pcd_pointcloud_captures"
+                        point_cloud="{icp_cloud}"
+                      />
+                    </Control>
+                  </Control>
+                  <Action
+                    ID="MoveGripperAction"
+                    timeout="10.000000"
+                    gripper_command_action_name="/vacuum_gripper/gripper_cmd"
+                    position="1.0"
+                  />
+                  <SubTree
+                    ID="Move to Pose No Preview"
+                    _collapsed="true"
+                    target_pose="{place_pose}"
+                  />
+                  <Action
+                    ID="MoveGripperAction"
+                    position="0.0"
+                    timeout="10.000000"
+                    gripper_command_action_name="/vacuum_gripper/gripper_cmd"
+                  />
+                  <!--
+                      A full pick+place cycle completed. The parent Objective reads
+                      picked_box to decide whether to continue the outer loop or exit
+                      cleanly when both view waypoints stop yielding picks.
+                    -->
+                  <Action ID="Script" code="picked_box := true" />
+                </Control>
+              </Decorator>
+            </Decorator>
+          </Control>
         </Decorator>
       </Control>
     </Control>
@@ -358,13 +432,14 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
-      <inout_port name="erosion_size" default="0" />
-      <inout_port name="negative_prompts" default="{negative_prompts}" />
-      <inout_port name="place_pose" default="{place_pose}" />
-      <inout_port name="prompt" default="{prompt}" />
-      <inout_port name="prompts" default="{prompts}" />
-      <inout_port name="threshold" default="{threshold}" />
-      <inout_port name="waypoint_name" default="View Boxes" />
+      <input_port
+        name="confidence_threshold"
+        default="{confidence_threshold}"
+      />
+      <output_port name="picked_box" default="{picked_box}" />
+      <input_port name="place_pose" default="{place_pose}" />
+      <input_port name="text_prompt" default="{text_prompt}" />
+      <input_port name="waypoint_name" default="View Boxes" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -82,6 +82,10 @@ skip_objectives = {
     # same class lab_sim skips for the same reason.
     "ML Move Boxes to Loading Zone",
     "Move Boxes Looping",  # KeepRunningUntilFailure loop over the ML pick pipeline above.
+    # SAM3 diagnostic: needs the moveit_pro_sam3 model package, which the CI
+    # image does not ship (GetMasks2DFromExemplar fails to resolve the encoder
+    # model path). Same ML-inference class as the skips above.
+    "Calibrate SAM3 Mask Areas",
     "Segment Image from Point",
     "Segment Image from Text Prompt",
     "Segment Point Cloud from Clicked Point",


### PR DESCRIPTION
[written by AI]

## Problem

Two issues in hangar_sim's `ML Move Boxes to Loading Zone`: (1) perception used the CLIPSeg+SAM2 pipeline with an unbounded `RetryUntilSuccessful(1000)` loop that never terminated and hid real errors (moveit_pro#19112); (2) already-placed boxes were invisible to planning, so the base could drive over them and the arm could sweep through them (part of moveit_pro#19973).

**Full objective run, sped up ~13×** (7.6 min real time → 35 s) — every scattered box picked off the hangar floor and placed in the loading zone, objective terminating with SUCCESS via the new drain detection. Higher-quality 720p: [pr746_full_run.mp4](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/pr746_full_run.mp4) (1.6 MB).

![Sped-up full run of ML Move Boxes to Loading Zone](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/pr746_full_run.gif)

## Changes

- **SAM3 perception**: migrate to `GetMasks2DFromExemplar` (single text-prompted segmenter, replaces CLIPSeg+SAM2 pair), add `FilterMasks2DByArea`, and restructure the loop to be drain-aware: `RepeatUnlessFailureEachTick` + a `drained` script flag, so the objective terminates SUCCESS when the scene is empty and FAILURE on real pick errors instead of retrying forever. Includes a `calibrate_sam3_mask_areas` diagnostic objective.
- **Persistent placed-box obstacles**: each placed box becomes its own world collision object (`placed_box_N`, `AddCollisionMesh` with `overwrite`), pose dropped to floor height via a body-frame `TransformPose`; `ResetPlanningSceneObjects` at objective start clears stale objects from prior runs. Subsequent base/arm plans route around placed boxes.
- **Grasp-pose leveling**: every candidate grasp's orientation is overridden to straight-down (`ForEach` → `OverridePoseOrientation` → rebuilt vector) before MTC planning, discarding noisy segmentation yaw. Note this makes the wrist-orientation samples duplicates of each other (see tuning below).
- **Post-grasp lift + pick tuning**: 10 cm Cartesian lift along `grasp_link` −Z (world up) before transit so the box clears the surface; `num_orientation_samples` 20→8 and `max_ik_solutions` 16→8 (pose IK is the cycle-time bottleneck; with leveling the orientation samples collapse anyway — a follow-up may reduce to 1).

## Behavior-tree renderings (MoveIt Pro editor)

**Top-level Objective** — drain-aware loop: init scripts, then `Fallback[RepeatUnlessFailureEachTick → ScriptCondition(drained)]` alternating the two view-waypoint SubTree calls (second gated by `_skipIf: picked_at_wp1`):

![Top-level tree in the MoveIt Pro editor](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/ui_ml_move_boxes.png)

**Pick subtree** — full shape at a glance, then readable sections left to right:

![Full subtree overview](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/ui_move_boxes_subtree_overview.png)

| Section | Rendering |
|---|---|
| Capture + SAM3 perception + 3D extraction | ![perception section](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/ui_move_boxes_subtree_zoom_1_perception.png) |
| Grasp generation + MTC task assembly | ![pick section](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/ui_move_boxes_subtree_zoom_2_pick.png) |
| Lift + place + placed-box obstacles | ![place section](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/ui_move_boxes_subtree_zoom_3_place.png) |

<details>
<summary><b>Annotated structure diagrams</b> (green = new in this PR vs. gray = pre-existing, derived from the diff — shows what changed structurally, which the editor view can't)</summary>

Structural changes worth a reviewer's attention: the pick-resilience retry loop moved from iterating 2D masks (with per-mask SAM2 refinement, now removed) to iterating post-3D-extraction `graspable_objects`; the `_skipIf: mask_count == 0` on the outer `Inverter` is what lets a "scanned, found nothing" pass exit SUCCESS with `picked_box=false`, which the parent's drain logic depends on.

![Top-level annotated](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/bt_ml_move_boxes.png)
![Subtree part 1 annotated](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/bt_move_boxes_subtree_1_perception.png)
![Subtree part 2 annotated](https://raw.githubusercontent.com/PickNikRobotics/moveit_pro_example_ws/assets/pr746-bt-diagrams/bt_move_boxes_subtree_2_pick_place.png)

</details>

<sub>Images live on the `assets/pr746-bt-diagrams` branch. UI renderings captured from the live editor; annotated diagrams generated programmatically from the XML.</sub>

## Scope note (2026-07-02 rescope)

An earlier revision of this PR carried `cost_joint_names`/`cost_joint_weights` yaw-bias ports that depended on core PR moveit_pro#20073; that PR and example_ws#736 are **closed** and the ports are removed — this PR is standalone-mergeable on current `main`. The base-yaw pirouette those ports partially mitigated is fixed properly elsewhere: controller-level mitigation in #753 (`angle_wraparound` on the yaw JTC gain, validated 14 runs / 0 spins) and the core representation-splice fix tracked in moveit_pro#20250.

## Verification

- Heavily exercised live on 2026-07-02 (this objective content was the test vehicle for the #753 validation campaign): 11 reset-controlled + 3 human-driven runs — SAM3 picking 7/7 boxes on successful runs, drain-detection terminating with objective SUCCESS in ~7.5 min, `placed_box_*` obstacles present in the planning scene, placed boxes landing in a clean line in the loading zone.
- Post-rescope retest of the exact merged content (ports removed, rebased on main): end-to-end run against a live backend — terminal SUCCESS in ~8.4 min, 7 distinct box welds, spin detector CLEAN (599.9 s joint recording), zero ERROR lines, `placed_box_0..7` world collision objects verified via `/get_planning_scene`. (Object count was 8 rather than the expected 7, most likely carryover from a preceding hung attempt on the same backend session — the persistence mechanism itself is working; noting for transparency.)
- Known unrelated flake: the objective can hang silently mid-move (moveit_pro#20238, pre-existing, ~half of runs in stress testing) — orthogonal to this PR's changes.

## Release notes

- Enhancement: Migrated the hangar_sim `ML Move Boxes to Loading Zone` Objective to SAM3 perception with drain-aware looping, so it finishes when the boxes are gone and reports real failures instead of retrying forever.
- Enhancement: Placed boxes in hangar_sim are now added to the planning scene as obstacles, so the robot plans around boxes it has already placed.
