### PR TITLE
Fix: Update lab_sim skip list for renamed Marker Visualization objective (v8.10 backport)

### DIFF
--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -76,7 +76,7 @@ skip_objectives = {
     "Inspector",
     "Pick 1 Pill Bottle",
     "AddBottlesToPlanningScene",
-    "Interactive Marker Visualization",  # Server not available for GetTextFromUser
+    "Marker Visualization Example",  # Server not available for GetTextFromUser
     "Octomap Example",  # Requires user input to clear the octomap.
 }
 


### PR DESCRIPTION
[written by AI]

Backports the skip-list fix in #462 to `v8.10`.

`lab_sim`'s integration test skips objectives by name. moveit_pro renamed this objective to `Marker Visualization Example`, so the stale skip entry stopped matching; the objective then ran in headless CI, where its `GetTextFromUser` step has no `/request_text_from_prompts` server and failed. Correcting the name re-skips it.

## Release notes

None
