### PR TITLE
Fix: Stop hangar_sim base pirouette by enabling JTC yaw angle_wraparound

### DIFF
--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -239,6 +239,14 @@ joint_trajectory_controller:
       rotational_yaw_joint:
         p: 2.0
         ff_velocity_scale: 1.0
+        # The base yaw is a continuous joint that accumulates past +/-pi over a run. Without wraparound the
+        # velocity controller drives error = command - state literally, so a goal expressed as a 2*pi-shifted
+        # equivalent of the current heading makes the base spin a full turn the long way (the "pirouette" of
+        # moveit_pro#19973). Wrapping the error to the shortest path keeps it on the short arc for any goal
+        # representation. This mitigates the upstream trajectory-representation splice tracked in that issue
+        # but is the correct configuration for a continuous joint regardless. Humble-specific: Jazzy's
+        # joint_trajectory_controller detects continuous joints from the URDF and wraps automatically.
+        angle_wraparound: true
     constraints:
       stopped_velocity_tolerance: 0.0
       goal_time: 0.0


### PR DESCRIPTION
[written by AI]

## Problem

The hangar_sim omni base intermittently (~1 in 3 objective runs) performs a sudden ~360° in-place spin ("pirouette") at a pick, at ~99°/s, often followed by wedging against the staging shelf. Reported as part of PickNikRobotics/moveit_pro#19973.

`rotational_yaw_joint` is a continuous joint whose value legitimately accumulates past ±π over a multi-pick run. MTC pick solutions splice sub-trajectories built in two different yaw representations: the `pro_rrt` Connect segment is anchored to the robot's raw accumulated yaw, while IK-derived segments carry the canonical [−π,π] representation (`RobotState::setFromIK` → `enforcePositionBounds` normalizes continuous joints; verified at `pose_ik.cpp` `unwindAndCheckLimits` and `revolute_joint_model.cpp:90`). Once the raw yaw has drifted outside [−π,π], a goal can arrive exactly 2π away from the robot's state. The velocity-interface `joint_trajectory_controller` computes `error = desired − current` literally when `angle_wraparound` is unset (default `false`), so it drives the 2π error the long way — a full-turn spin that ends at the physically intended heading. Live log capture of the two representations in one pick, 2π apart: Connect goal wrapped to `−4.004` rad while the adjacent Cartesian segment runs at `+2.279` rad (−4.004 + 2π = 2.279).

## Fix

Set `gains.rotational_yaw_joint.angle_wraparound: true` on the JTC. The controller then wraps the position error to the shortest arc, so any 2π-shifted goal representation produces the short move. This is the documented, intended configuration for a continuous joint under `joint_trajectory_controller` (parameter present since ros2_controllers 2.x; verified against the installed 2.52.1 schema). It is the only JTC-driven continuous joint in this repo — the arm joints are revolute with position limits, wheel joints are driven by the mecanum controller, and Kinova continuous joints are gripper mimics.

Cross-distro behavior: on Humble (ros2_controllers 2.52.1) the parameter is opt-in with default `false` — this line is required. On Jazzy, `joint_trajectory_controller` detects continuous joints from the URDF and enables wraparound automatically ([jazzy `on_init`](https://github.com/ros-controls/ros2_controllers/blob/jazzy/joint_trajectory_controller/src/joint_trajectory_controller.cpp)); the parameter no longer exists there and the extra YAML key is inert, so this change is effectively Humble-targeted and Jazzy-safe.

Tolerance interaction (favorable): the JTC wraps `state_error_.position` before both the PID command and `check_state_tolerance_per_joint`, so the yaw `goal: 0.1` tolerance is evaluated on the shortest-arc error too — no spurious `GOAL_TOLERANCE_VIOLATED`, and peak commanded yaw velocity drops (error magnitude shrinks from up to 2π to ≤π).

A follow-up in moveit_pro will address the upstream representation splice itself; this parameter is correct configuration for a continuous yaw joint independent of that fix.

## Verification

Validated live against the reproduction stack (MuJoCo hangar_sim, objective `ML Move Boxes to Loading Zone`), with an automated spin detector (>150° net yaw within a 4 s window while base XY translation <0.4 m; validated 11/11 against historical ground-truth recordings before use):

- **11 reset-controlled full objective runs + 3 human-driven UI runs: 0 spins.** Pre-fix baseline: ~1 in 3 runs spun (0.67¹¹ ≈ 1.2% false-pass probability).
- Runs that completed all 7 picks terminated with objective SUCCESS in ~7.5 min; per-run joint-state recordings (~50 Hz, all 9 joints) confirm zero fast-yaw (>60°/s) travel in every run, vs. 260–340° per spin at baseline.
- Planner-side cross-check: all `pro_rrt` continuous-joint wrap decisions in the session logs are short-path corrections (e.g. raw yaw `init=−3.798`, IK goal `+2.249`, wrapped goal `−4.034` — a 13° move), including runs where raw yaw sat well outside [−π,π], the exact regime that previously spun.
- Both initialization paths exercised (fresh launch and `reset_keyframe`-controlled).

Per-run CSVs, yaw/XY plots, and the campaign ledger are preserved in the investigation worktree and can be attached on request.

## Notes

- **Backport requested**: the bug is present in 9.4.x (all reproductions predate 10.0 work); this repo has no `backport` label, so flagging it here for the release owners.
- Real-hardware carry-forward (sim-only config today): `angle_wraparound` prevents the extra full turn but not same-direction cumulative winding — cable-wrap management on a physical base without a slip ring remains a separate concern; the setting is correct whether the base driver reports wrapped or accumulated yaw.
