### PR TITLE
Fix: factory_sim bin picking fails when brackets settle near the workspace boundary

### DIFF
--- a/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
@@ -10,12 +10,16 @@
       name="Drop bracket part on jig via an intermediate waypoint"
     >
       <!--The drop pose is just above two tapered posts representing a tooling jib that match alignment holes in the bracket part. The part is then released and settles onto those jig posts.-->
+      <!--The target is expressed for the attached part's own frame (ik_frame below), not tool0:
+          the pick may grasp the part at any sampled yaw, and the attached body carries the true
+          part-to-gripper transform, so planning for the part frame places the alignment holes on
+          the posts regardless of which grasp yaw was chosen.-->
       <Action
         ID="CreatePoseStamped"
         reference_frame="jig_post1"
         pose_stamped="{drop_pose}"
-        orientation_xyzw="1.000; 0.000; 0.000; 0.000"
-        position_xyz="0.012;-0.01;0.16"
+        orientation_xyzw="0.000; 0.000; 1.000; 0.000"
+        position_xyz="0.137;-0.08;0.055"
       />
       <Action
         ID="VisualizePose"
@@ -59,7 +63,7 @@
       <Action
         ID="SetupMTCPlanToPose"
         acceleration_scale_factor="0.5"
-        ik_frame="tool0"
+        ik_frame="{part_name}"
         keep_orientation="false"
         keep_orientation_link_names="tool0"
         keep_orientation_tolerance="0.100000"

--- a/src/factory_sim/objectives/pick_and_place_brackets_from_left_bin.xml
+++ b/src/factory_sim/objectives/pick_and_place_brackets_from_left_bin.xml
@@ -31,69 +31,103 @@
         tool_2_return_site="inspection_tool_holder_site"
         tool_names="suction_gripper;inspector"
       />
+      <Action
+        ID="Script"
+        code="halt_picking := false"
+        name="Picking continues until a part cannot be picked"
+      />
       <Decorator
-        ID="Repeat"
+        ID="RepeatUnlessFailureWithinTick"
         num_cycles="3"
         name="Pick a fixed number of brackets"
       >
-        <Control
-          ID="Sequence"
-          name="This is the main sequence of detecting and picking the bracket parts, putting them on the jig, and them putting them in the right bin"
+        <Decorator
+          ID="Precondition"
+          if="halt_picking == false"
+          else="SUCCESS"
+          name="Skip remaining cycles once a part is unpickable"
         >
-          <SubTree ID="Indicate Jig Empty" _collapsed="true" />
-          <SubTree
-            ID="Look for Bracket Part Subtree"
-            _collapsed="true"
-            registered_pose="{registered_pose}"
-          />
-          <SubTree
-            ID="Vacuum Pick Bracket Part Subtree"
-            _collapsed="true"
-            bracket_part_pose="{registered_pose}"
-            part_name="single_bracket_part"
-          />
-          <SubTree
-            ID="Drop Bracket Part on Jig Subtree"
-            _collapsed="true"
-            part_name="single_bracket_part"
-          />
-          <!--This jig apparatus and waiting is here just to motivate the use case and explain why the arm moves to a waiting pose, instead of dropping the part on the jig and then picking it right back up again-->
-          <SubTree
-            ID="Move to Waypoint"
-            _collapsed="true"
-            acceleration_scale_factor="1.0"
-            controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
-            controller_names="joint_trajectory_admittance_controller"
-            joint_group_name="manipulator"
-            keep_orientation="false"
-            keep_orientation_tolerance="0.05"
-            link_padding="0.01"
-            seed="0"
-            velocity_scale_factor="1.0"
-            waypoint_name="Home"
-            name="Send arm to waiting pose"
-          />
-          <Action
-            ID="LogMessage"
-            log_level="info"
-            message="Waiting for a few seconds to simulate a operation being done to the bracket"
-          />
-          <SubTree ID="Visualize Bins and Jig" _collapsed="true" />
-          <SubTree ID="Indicate Jig Working" _collapsed="true" />
-          <Action ID="WaitForDuration" delay_duration="2" />
-          <SubTree ID="Indicate Part Ready" _collapsed="true" />
-          <SubTree
-            ID="Pick Bracket Part from Jig Subtree"
-            _collapsed="true"
-            part_name="single_bracket_part"
-          />
-          <SubTree ID="Indicate Jig Empty" _collapsed="true" />
-          <SubTree
-            ID="Drop Bracket Part in Right Bin Subtree"
-            _collapsed="true"
-            part_name="single_bracket_part"
-          />
-        </Control>
+          <Control
+            ID="IfThenElse"
+            name="Detect and pick the next bracket; if the pick cannot be planned, report it and stop picking"
+          >
+            <Control
+              ID="Sequence"
+              name="Detect the next bracket and pick it with the vacuum gripper"
+            >
+              <SubTree ID="Indicate Jig Empty" _collapsed="true" />
+              <SubTree
+                ID="Look for Bracket Part Subtree"
+                _collapsed="true"
+                registered_pose="{registered_pose}"
+              />
+              <SubTree
+                ID="Vacuum Pick Bracket Part Subtree"
+                _collapsed="true"
+                bracket_part_pose="{registered_pose}"
+                part_name="single_bracket_part"
+              />
+            </Control>
+            <Control
+              ID="Sequence"
+              name="Place the bracket on the jig, then transfer it to the right bin"
+            >
+              <SubTree
+                ID="Drop Bracket Part on Jig Subtree"
+                _collapsed="true"
+                part_name="single_bracket_part"
+              />
+              <!--This jig apparatus and waiting is here just to motivate the use case and explain why the arm moves to a waiting pose, instead of dropping the part on the jig and then picking it right back up again-->
+              <SubTree
+                ID="Move to Waypoint"
+                _collapsed="true"
+                acceleration_scale_factor="1.0"
+                controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+                controller_names="joint_trajectory_admittance_controller"
+                joint_group_name="manipulator"
+                keep_orientation="false"
+                keep_orientation_tolerance="0.05"
+                link_padding="0.01"
+                seed="0"
+                velocity_scale_factor="1.0"
+                waypoint_name="Home"
+                name="Send arm to waiting pose"
+              />
+              <Action
+                ID="LogMessage"
+                log_level="info"
+                message="Waiting for a few seconds to simulate a operation being done to the bracket"
+              />
+              <SubTree ID="Visualize Bins and Jig" _collapsed="true" />
+              <SubTree ID="Indicate Jig Working" _collapsed="true" />
+              <Action ID="WaitForDuration" delay_duration="2" />
+              <SubTree ID="Indicate Part Ready" _collapsed="true" />
+              <SubTree
+                ID="Pick Bracket Part from Jig Subtree"
+                _collapsed="true"
+                part_name="single_bracket_part"
+              />
+              <SubTree ID="Indicate Jig Empty" _collapsed="true" />
+              <SubTree
+                ID="Drop Bracket Part in Right Bin Subtree"
+                _collapsed="true"
+                part_name="single_bracket_part"
+              />
+            </Control>
+            <Control
+              ID="Sequence"
+              name="Report the unpickable part and stop picking"
+            >
+              <SubTree ID="Deactivate Vacuum" _collapsed="true" />
+              <Action
+                ID="LogMessage"
+                log_level="info"
+                message="Could not detect the next bracket or plan a pick for it at any sampled grasp yaw; see the preceding log messages for the failing Behavior. A part that cannot be picked may have settled outside the reachable workspace. Skipping the remaining bracket picks."
+              />
+              <Action ID="Script" code="halt_picking := true" />
+            </Control>
+          </Control>
+        </Decorator>
       </Decorator>
       <SubTree ID="Visualize Bins and Jig" _collapsed="true" />
       <!--Stow vacuum gripper-->

--- a/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
@@ -14,14 +14,60 @@
         translation_xyz=".125;-0.07;0.01"
         name="Create pick pose for the bracket part"
       />
+      <!--A suction grasp on the flat bracket face is yaw-free about the face normal, so
+          approach candidates are sampled at 45-degree yaw increments about the pick pose
+          z-axis. The parts settle near the edge of the robot's reachable workspace, where
+          only some yaws have IK solutions; the batch IK stage below picks any that plans.-->
+      <Action ID="ResetPoseStampedVector" vector="{approach_candidates}" />
       <Action
         ID="TransformPose"
         input_pose="{pick_pose}"
-        output_pose="{approach_pose}"
+        output_pose="{yaw_pick_pose}"
+        translation_xyz="0;0;0"
+        quaternion_xyzw="0;0;0;1"
+        name="Copy pick pose as the yaw-0 candidate"
+      />
+      <Action
+        ID="TransformPose"
+        input_pose="{yaw_pick_pose}"
+        output_pose="{approach_candidate}"
         translation_xyz="0;0;0.15"
         quaternion_xyzw="-0.0; -1.0; -0.0; -0.0"
         name="Create approach pose before straight pick"
       />
+      <Action
+        ID="PushBackVector"
+        input_vector="{approach_candidates}"
+        element="{approach_candidate}"
+        output_vector="{approach_candidates}"
+      />
+      <Decorator ID="RepeatUnlessFailureWithinTick" num_cycles="7">
+        <Control
+          ID="Sequence"
+          name="Rotate the pick yaw 45 degrees and add the approach candidate"
+        >
+          <Action
+            ID="TransformPose"
+            input_pose="{yaw_pick_pose}"
+            output_pose="{yaw_pick_pose}"
+            translation_xyz="0;0;0"
+            quaternion_xyzw="0;0;0.3826834;0.9238795"
+          />
+          <Action
+            ID="TransformPose"
+            input_pose="{yaw_pick_pose}"
+            output_pose="{approach_candidate}"
+            translation_xyz="0;0;0.15"
+            quaternion_xyzw="-0.0; -1.0; -0.0; -0.0"
+          />
+          <Action
+            ID="PushBackVector"
+            input_vector="{approach_candidates}"
+            element="{approach_candidate}"
+            output_vector="{approach_candidates}"
+          />
+        </Control>
+      </Decorator>
       <Action
         ID="InitializeMTCTask"
         task="{mtc_task}"
@@ -53,20 +99,29 @@
         task="{mtc_task}"
       />
       <Action
-        ID="SetupMTCPlanToPose"
+        ID="SetupMTCConnectWithProRRT"
         acceleration_scale_factor="1.000000"
-        ik_frame="tool0"
         keep_orientation="false"
         keep_orientation_link_names="tool0"
         keep_orientation_tolerance="0.100000"
         link_padding="0.0100000"
         max_iterations="5000"
-        monitored_stage="current state"
         planning_group_name="manipulator"
-        target_pose="{approach_pose}"
+        seed="0"
         task="{mtc_task}"
         trajectory_sampling_rate="100"
         velocity_scale_factor="1.000000"
+      />
+      <Action
+        ID="SetupMTCBatchPoseIK"
+        end_effector_group="fanuc_ee"
+        end_effector_link="tool0"
+        ik_group="manipulator"
+        ik_timeout_s="0.05"
+        max_ik_solutions="1"
+        monitored_stage="current state"
+        target_poses="{approach_candidates}"
+        task="{mtc_task}"
       />
       <Action
         ID="SetupMTCMoveAlongFrameAxis"


### PR DESCRIPTION
[written by AI]

Fixes PickNikRobotics/moveit_pro#20020

## Problem

The left bin in `factory_sim` deliberately straddles the LR Mate 200iD's reachable workspace (measured boundary ≈0.70–0.75 m planar at pick height, orientation-dependent). Brackets settle with arbitrary yaw aligned to the rotated bin, which swings the hardcoded pick offset toward the bin's far side. `Pick and Place Brackets from Left Bin` inherits the settled yaw exactly, so depending on where the physics settles each launch, the first pick either has no IK solution (`pose IK (0/1)` in `pick_part`) or plans but fails the 55 mm approach push (`Cartesian Motion: failed to move full distance`). Machine load shifts the settle, which is why the failure reproduces 100% on some machines and intermittently on others.

## Approach

A suction grasp on the flat bracket face is yaw-free about the face normal, so:

- `vacuum_pick_bracket_part_subtree.xml` — keeps the same pick point but builds 8 approach candidates at 45° yaw increments about the part's settled face normal (respecting settled pitch/roll), and replaces the single-pose `SetupMTCPlanToPose` with `SetupMTCConnectWithProRRT` + `SetupMTCBatchPoseIK`, letting MTC plan through whichever yaw solves. This converts most of the bin's far side from unpickable to pickable (86% of the bin interior is reachable tool-down at some yaw vs. only 10% at every yaw).
- `drop_bracket_part_on_jig_subtree.xml` — the jig drop target is re-expressed for the attached part's own frame (`ik_frame="{part_name}"`) instead of `tool0`. The attached body carries the true part-to-gripper transform (the MuJoCo weld freezes the grasp-time relative orientation), so the alignment holes land on the jig posts regardless of which grasp yaw was chosen. The part-frame pose was derived by composing the nominal grasp transform out of the previous tool0 numbers.
- `pick_and_place_brackets_from_left_bin.xml` — if no sampled yaw plans, the objective deactivates the vacuum, logs INFO ("Could not plan a pick … skipping the remaining bracket picks"), and ends cleanly instead of aborting with `PLANNING_FAILED`. This matches the sim's teaching purpose (reachable vs. unreachable areas). Also migrates the deprecated `Repeat` decorator to `RepeatUnlessFailureWithinTick`.

The bins intentionally stay where they are — reachable and unreachable regions are the point of this sim.

## Manual verification

- Stock scene, fresh launch ×2: full 3-cycle objective SUCCEEDED.
- Staged worst case (bracket at 90° yaw, pick point at r=0.716 — beyond the measured r=0.711 failure pose from the reproduction): pick succeeded at a non-zero sampled yaw and the compensated jig drop was confirmed by the fixed-pose jig re-pick succeeding.
- Staged unpickable case (pick point r≈0.82, beyond all yaws): INFO logged, remaining picks skipped, objective ended SUCCEEDED.
- Reproduction evidence, an IK reachability study of the bin (calibrated 3/3 against the live `pose_ik` behavior), and the full run ledger are attached to the linked issue.

## Open question for reviewers

On an unpickable part this gives up on all remaining picks rather than re-detecting, because registration would find the same far bracket again (the ICP guess pose biases to the bin's far side). If retry-per-remaining-part is preferred, it is a small policy change in the top-level tree.

## Release notes

- Bug Fix: Fixed `factory_sim`'s `Pick and Place Brackets from Left Bin` objective intermittently failing with a planning failure by sampling vacuum-grasp yaws at the pick point, compensating the jig placement for the chosen grasp, and skipping parts that settle outside the robot's reachable workspace with an informative log message instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)