### PR TITLE
Fix: Make robot_state_publisher the sole owner of the ridgeback_base_link transform in hangar_sim

### DIFF
--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -21,7 +21,10 @@ hardware:
           path: "config/moveit/joint_limits.yaml"
       - mujoco_model: "description/hangar_scene.xml"
       - mujoco_viewer: false  # set to true locally to open the MuJoCo viewer window
-      # Set to false when use_fuse:=true so fuse is the sole odom -> ridgeback_base_link publisher.
+      # Publishes /odom messages for Nav2. The odom -> ridgeback_base_link TF edge is NOT
+      # published by MuJoCo (odom_publish_tf is false in the ros2_control xacro);
+      # robot_state_publisher owns the live transform to ridgeback_base_link via
+      # the virtual-rail joint chain, so this can stay true with fuse enabled.
       # Rebuild hangar_sim after changing this value.
       - publish_odom: true
 

--- a/src/hangar_sim/config/fuse/fuse.yaml
+++ b/src/hangar_sim/config/fuse/fuse.yaml
@@ -87,7 +87,11 @@ state_estimator:
       base_link_output_frame_id: 'ridgeback_base_link'
       odom_frame_id: 'odom'
       map_frame_id: 'map'
+      # robot_state_publisher owns the live TF to ridgeback_base_link via the
+      # virtual-rail joint chain; fuse must not publish a competing parent.
+      # Its estimate stays available on odom_filtered. On real hardware, feed
+      # the estimate into the virtual-rail joint states instead of TF.
       world_frame_id: 'odom'
-      publish_tf: true
+      publish_tf: false
       publish_frequency: 10.0
       predict_to_current_time: true

--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -23,9 +23,22 @@
           <param name="publish_odom">${publish_odom}</param>
           <param name="odom_child_frame">ridgeback_base_link</param>
           <param name="odom_rate">150</param>
-          <param name="odom_zero_z">true</param>
+          <!-- Zero z/roll/pitch in /odom for this planar base. The previous tag here,
+               odom_zero_z, is not a recognized odom publisher parameter and was silently
+               ignored; odom_planar is the real one. -->
+          <param name="odom_planar">true</param>
+          <!-- robot_state_publisher owns the live TF to ridgeback_base_link via the
+               virtual-rail joint chain (driven by MuJoCo's own joint states), so the
+               odom publisher must not broadcast a competing odom -> ridgeback_base_link
+               edge. /odom messages keep flowing for Nav2. -->
+          <param name="odom_publish_tf">false</param>
           <param name="odom_frame">odom</param>
           <param name="publish_mj_world_tf">false</param>
+          <!-- Stop the lidar TF fill-in chain at the robot's base instead of walking to
+               the MJCF worldbody. Without this, MuJoCo broadcasts
+               base_platform -> ridgeback_base_link, a second parent for a frame that
+               robot_state_publisher already publishes. -->
+          <param name="base_link_name">ridgeback_base_link</param>
           <param name="mujoco_viewer">${mujoco_viewer}</param>
           <param name="mujoco_keyframe">default</param>
       </hardware>

--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -19,7 +19,9 @@
   <xacro:arg name="initial_positions_file" default="$(find picknik_ur_base_config)/config/initial_positions.yaml"/>
   <xacro:arg name="mujoco_model" default="description/bar_scene.xml"/>
   <xacro:arg name="mujoco_viewer" default="false" />
-  <!-- Set to false when use_fuse:=true so fuse is the sole odom → ridgeback_base_link publisher. -->
+  <!-- Publishes /odom messages for Nav2. The odom → ridgeback_base_link TF edge is never
+       broadcast by MuJoCo (odom_publish_tf is false in the ros2_control macro), so this can
+       stay true regardless of use_fuse. -->
   <xacro:arg name="publish_odom" default="true"/>
 
   <!-- Import UR and environment macros -->
@@ -76,7 +78,11 @@
     <axis xyz="1 0 0"/>
     <parent link="world" />
     <child link="virtual_rail_link_1" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+    <!-- z matches the MJCF base_platform_rotation anchor (pos 0 0 -0.048), which is tuned
+         so the wheels contact the floor (the sim base has no z DOF). Without this offset
+         the robot_state_publisher chain renders the robot 48 mm above where the physics
+         (and every sensor frame) actually put it. -->
+    <origin xyz="0 0 -0.048" rpy="0 0 0" />
     <limit effort="1000.0" lower="-25.0" upper="25.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>

--- a/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
+++ b/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
@@ -804,11 +804,18 @@ static_tf_world_to_map = Node(
     arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "map"],
 )
 
-# Static transform: map to odometry frame
+# Static map->odom TF fallback: only used when neither SLAM nor AMCL is publishing it
 static_tf_map_to_odom = Node(
     package="tf2_ros",
     executable="static_transform_publisher",
     arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "map", "odom"],
+)
+
+# Static transform anchoring MoveIt's planning root under the odometry frame
+static_tf_odom_to_world = Node(
+    package="tf2_ros",
+    executable="static_transform_publisher",
+    arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "odom", "world"],
 )
 ```
 
@@ -821,15 +828,17 @@ mj_world (MuJoCo simulation root)
   │
   ├─ [static] → map
   │    │
-  │    └─ [static] → odom
+  │    └─ [beluga_amcl | static fallback] → odom
   │         │
-  │         └─ [robot_state_publisher] → ridgeback_base_link
-  │              (via virtual joint chain)
+  │         └─ [static] → world
+  │              │
+  │              └─ [robot_state_publisher] → ridgeback_base_link
+  │                   (via world → virtual_rail_link_1 → virtual_rail_link_2 chain)
   │
   └─ [Other scene elements]
 ```
 
-In production deployments with active localization, the static `map` to `odom` transform would be replaced with a dynamic transform published by the localization system (e.g., AMCL), representing the estimated pose correction between odometry and the global map frame.
+With `localization:=True` (the default), beluga_amcl publishes the dynamic `map` → `odom` correction and the static fallback is suppressed; its correction shifts the entire robot subtree (everything under `odom`), which is exactly the REP-105 localization semantics.
 
 ---
 
@@ -864,14 +873,22 @@ The `enable_odom_tf: false` parameter prevents the mecanum drive controllers fro
 | Transform | Publishing Node | Mechanism |
 |-----------|----------------|-----------|
 | `mj_world` → `map` | `static_transform_publisher` | Launch file configuration |
-| `map` → `odom` | `static_transform_publisher` | Launch file configuration (simulation only) |
-| `odom` → `ridgeback_base_link` | `robot_state_publisher` | URDF virtual joint chain with joint state feedback |
+| `map` → `odom` | `beluga_amcl` (or `static_transform_publisher` fallback) | Localization when `localization:=True`; static identity otherwise |
+| `odom` → `world` | `static_transform_publisher` | Launch file configuration (anchors the URDF root under the odometry frame) |
+| `world` → … → `ridgeback_base_link` | `robot_state_publisher` | URDF virtual joint chain with joint state feedback |
+| `ridgeback_base_link` → lidar mounts | MuJoCo hardware plugin | Lidar fill-in chain, stopped at the base by the `base_link_name` hardware parameter |
+
+`robot_state_publisher` is the **sole owner** of the live transform into `ridgeback_base_link`. Every other subsystem that knows the base pose expresses it as data, not as a competing TF parent:
+
+- The MuJoCo odom publisher emits `/odom` messages for Nav2 but not TF (`odom_publish_tf: false`).
+- The MuJoCo lidar fill-in chain stops at `ridgeback_base_link` (`base_link_name` hardware parameter) instead of broadcasting the ground-truth body chain (`base_platform` → `ridgeback_base_link`) up to the MJCF worldbody.
+- fuse keeps `publish_tf: false`; its estimate stays on `odom_filtered`. On real hardware the estimate feeds the virtual-rail joint states (odometry-to-joint-state bridge) rather than TF.
 
 ### Transform Source Analysis
 
-The `robot_state_publisher` node computes and publishes the `odom` to `ridgeback_base_link` transform based on:
+The `robot_state_publisher` node computes and publishes the transform into `ridgeback_base_link` based on:
 1. The URDF virtual joint chain definition (`world` → `virtual_rail_link_1` → `virtual_rail_link_2` → `ridgeback_base_link`)
-2. Current joint state values received on `/joint_states` (populated by the odometry bridge)
+2. Current joint state values received on `/joint_states` — in simulation these come straight from the MuJoCo virtual-rail joints via `joint_state_broadcaster` (ground truth); on real hardware they come from an odometry-to-joint-state bridge fed by the state estimator
 
 If the mecanum drive controllers were configured with `enable_odom_tf: true`, they would publish the same transform based on wheel odometry integration. This would result in multiple publishers for the same transform, violating the ROS 2 transform system's requirement for unique transform publishers.
 
@@ -881,10 +898,10 @@ Enabling odometry transform publication on the controllers would produce the fol
 
 **Multiple Transform Publishers**
 ```
-Transform odom → ridgeback_base_link published by:
-1. robot_state_publisher (from virtual joint states)
-2. platform_velocity_controller (from wheel odometry)
-3. platform_velocity_controller_nav2 (from wheel odometry)
+Transforms into ridgeback_base_link published by:
+1. robot_state_publisher (world → … → ridgeback_base_link, from virtual joint states)
+2. platform_velocity_controller (odom → ridgeback_base_link, from wheel odometry)
+3. platform_velocity_controller_nav2 (odom → ridgeback_base_link, from wheel odometry)
 ```
 
 **System-Level Effects**
@@ -927,7 +944,7 @@ In real-world systems with active localization:
 - Remove the static `map` → `odom` transform publisher
 - Configure the localization system (AMCL, Cartographer, etc.) to publish the dynamic `map` → `odom` transform
 - Maintain `enable_odom_tf: false` on platform controllers
-- The `odom` → `base_link` transform continues to be published by `robot_state_publisher` via virtual joints
+- The `world` → … → `ridgeback_base_link` chain continues to be published by `robot_state_publisher` via virtual joints; `odom` → `world` stays a static link. On hardware, the state estimate feeds the virtual-rail joint states (odometry-to-joint-state bridge) rather than TF
 - Localization system consumes odometry messages to estimate drift and publish correction transforms
 
 ---
@@ -1029,7 +1046,7 @@ For implementing whole body planning on mobile manipulator platforms:
 | Mobile base unresponsive during whole body planning | Trajectory controller not activated | Query controller manager state: `ros2 control list_controllers` | Verify controller activates when executing trajectories; check action server connection |
 | Base motion in incorrect direction | Frame transformation error | Verify yaw joint in `/joint_states`; check `body_frame_yaw_joint` parameter | Confirm `odometry_joint_state_publisher.py` is running; verify parameter configuration |
 | Nav2 commands not executed | Incorrect controller active state | Check controller manager state; verify command topic remapping | Activate `platform_velocity_controller_nav2`; verify `/cmd_vel` remapping |
-| Virtual joints absent from state | Odometry bridge failure | Monitor `/joint_states` for virtual joint messages; check node status | Restart `odometry_joint_state_publisher.py`; verify `/odom` topic publication |
+| Virtual joints absent from state | Joint state source failure | Monitor `/joint_states` for virtual joint messages; check node status | In simulation the virtual-rail joints come from MuJoCo via `joint_state_broadcaster` — check `ros2 control list_controllers`. On hardware, restart the odometry-to-joint-state bridge and verify odometry publication |
 | Planning failures for whole body group | Incorrect planning group configuration | Examine SRDF planning group definition; verify joint names | Use `manipulator` group for whole body; confirm SRDF includes virtual joints |
 | TF_REPEATED_DATA warnings | Multiple transform publishers | Execute `ros2 run tf2_tools view_frames`; identify duplicate publishers | Set `enable_odom_tf: false` in both platform controllers; verify single source per transform |
 | Discontinuous position in visualization | Transform tree inconsistency | Monitor `/tf` for conflicting transforms; check timing | Verify transform publication sources; ensure consistent timestamp sources |

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -28,7 +28,6 @@
 
 import os
 
-import yaml
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
@@ -36,10 +35,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
-    LogInfo,
-    OpaqueFunction,
     SetEnvironmentVariable,
-    Shutdown,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -53,52 +49,6 @@ from launch_ros.actions import PushRosNamespace
 from launch_ros.descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
 from nav2_common.launch import RewrittenYaml, ReplaceString
-
-
-def _check_fuse_publish_odom(context, *args, **kwargs):
-    """Fail fast if use_fuse:=true but MuJoCo is still configured to publish odom TF.
-
-    When fuse is enabled it is the sole authority on odom → ridgeback_base_link.
-    MuJoCo must not also publish that edge or consumers will see jittery, interleaved updates.
-    Set 'publish_odom: "false"' in config.yaml under hardware.robot_description.urdf_params.
-    """
-    if LaunchConfiguration("use_fuse").perform(context).lower() != "true":
-        return []
-
-    config_path = os.path.join(
-        get_package_share_directory("hangar_sim"), "config", "config.yaml"
-    )
-    with open(config_path) as f:
-        robot_config = yaml.safe_load(f)
-
-    urdf_params = (
-        robot_config.get("hardware", {})
-        .get("robot_description", {})
-        .get("urdf_params", [])
-    )
-    publish_odom = True  # MuJoCo default
-    for param in urdf_params:
-        if isinstance(param, dict) and "publish_odom" in param:
-            publish_odom = str(param["publish_odom"]).lower() not in (
-                "false",
-                "0",
-                "no",
-            )
-            break
-
-    if publish_odom:
-        return [
-            LogInfo(
-                msg=(
-                    "use_fuse:=true but MuJoCo is still configured to publish"
-                    " odom -> ridgeback_base_link. When fuse is enabled, fuse must be the sole"
-                    " publisher of that TF edge. Set 'publish_odom: false' in config.yaml under"
-                    " hardware.robot_description.urdf_params, then rebuild hangar_sim."
-                )
-            ),
-            Shutdown(reason="publish_odom must be false when use_fuse:=true"),
-        ]
-    return []
 
 
 def generate_launch_description():
@@ -344,15 +294,21 @@ def generate_launch_description():
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "map", "odom"],
     )
 
-    # Static TF connecting MoveIt's planning root ('world') to the simulation root ('mj_world').
-    # The UI (pose-utils.ts) hardcodes 'world' as the reference frame for all user-clicked poses,
-    # so this link is required for nav2 goals to be transformable to 'map'.
-    static_tf_mj_world_to_world = Node(
+    # Static TF anchoring MoveIt's planning root ('world') under the odometry frame.
+    # robot_state_publisher owns the only live chain into ridgeback_base_link
+    # (world -> virtual_rail_... -> ridgeback_base_link), so 'odom' must sit above
+    # 'world' for REP-105 semantics: AMCL's live map->odom correction then shifts the
+    # whole robot subtree, and its own odom->base lookups resolve through this link.
+    # (Previously this was mj_world->world, and the 'odom' frame only existed because
+    # MuJoCo broadcast a competing odom->ridgeback_base_link TF — removed in this
+    # change.) The UI (pose-utils.ts) hardcodes 'world' for user-clicked poses, so
+    # this link also keeps nav2 goals transformable to 'map'.
+    static_tf_odom_to_world = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
-        name="static_tf_mj_world_to_world",
+        name="static_tf_odom_to_world",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "world"],
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "odom", "world"],
     )
 
     # QoS relay to bridge BEST_EFFORT odom and IMU to RELIABLE for fuse
@@ -423,7 +379,7 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
 
-    # Declare the launch options — all args must be declared before the OpaqueFunction runs.
+    # Declare the launch options.
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)
@@ -436,7 +392,6 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
     ld.add_action(declare_use_fuse_cmd)
-    ld.add_action(OpaqueFunction(function=_check_fuse_publish_odom))
 
     # Add the actions to launch all of the navigation nodes
     ld.add_action(bringup_cmd_group)
@@ -447,7 +402,7 @@ def generate_launch_description():
     # ld.add_action(rviz_cmd)
 
     ld.add_action(static_tf_world_to_map)
-    ld.add_action(static_tf_mj_world_to_world)
+    ld.add_action(static_tf_odom_to_world)
     ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
     ld.add_action(laser_filter_front_node)

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -34,8 +34,11 @@ from pathlib import Path
 import pytest
 import rclpy
 import tf2_ros
+from tf2_msgs.msg import TFMessage
+from nav_msgs.msg import Odometry
 import yaml
 from rclpy.time import Time
+from rclpy.qos import qos_profile_sensor_data
 from control_msgs.action import GripperCommand
 from controller_manager_msgs.srv import ListControllers
 from moveit_pro_test_utils.objective_test_fixture import (
@@ -320,6 +323,89 @@ def _expected_end_state_by_id(
     waypoint_joints = resource.get_waypoint_target(JOINT_CHECK_WAYPOINT)
     arm_target = {joint: waypoint_joints[joint] for joint in MANIPULATOR_ARM_JOINTS}
     return {objective_id: EndStateSpec(joints=JointTarget(positions=arm_target))}
+
+
+BASE_LINK_FRAME = "ridgeback_base_link"
+# Phase 1: how long to wait for the FIRST transform into the base link (and the
+# first /odom message) before declaring the stack broken. Generous on purpose:
+# it only bounds startup latency on a loaded CI runner, not the assertion.
+TF_FIRST_SIGHTING_TIMEOUT_S = 60.0
+# Phase 2: once the frame has been seen, how long to keep sampling to catch
+# additional (conflicting) parents. Competing publishers broadcast at 10-120 Hz,
+# so a second parent would appear hundreds of times within this window.
+TF_PARENT_SAMPLE_DURATION_S = 4.0
+
+
+def test_base_link_has_single_tf_parent(
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """The live transform into ridgeback_base_link must have exactly one publisher.
+
+    Regression guard for the three-parent TF conflict (MuJoCo lidar fill-in
+    chain, MuJoCo odom TF, and robot_state_publisher all claiming the frame),
+    which made the robot oscillate below base_link in the web UI.
+    robot_state_publisher owns the edge via the virtual-rail chain; a second
+    parent appearing here means a MuJoCo TF publisher was re-enabled (check
+    base_link_name / odom_publish_tf in the ros2_control xacro) or fuse's
+    publish_tf was turned back on.
+    """
+    node = execute_objective_resource.node
+    parents: set[str] = set()
+    odom_z_samples: list[float] = []
+
+    # Watching /tf only is correct while rotational_yaw_joint (the edge into
+    # ridgeback_base_link) is a moving joint; if it ever becomes fixed the edge
+    # moves to /tf_static and this test must follow it there.
+    def collect(msg: TFMessage) -> None:
+        for transform in msg.transforms:
+            if transform.child_frame_id == BASE_LINK_FRAME:
+                parents.add(transform.header.frame_id)
+
+    def collect_odom(msg: Odometry) -> None:
+        odom_z_samples.append(msg.pose.pose.position.z)
+
+    subscription = node.create_subscription(TFMessage, "/tf", collect, 100)
+    # Piggyback an odom_planar check: odom_zero_z was a silently-ignored
+    # parameter for months, so pin the real one's effect (z zeroed in /odom)
+    # rather than trusting the spelling.
+    odom_subscription = node.create_subscription(
+        Odometry, "/odom", collect_odom, qos_profile_sensor_data
+    )
+    # Phase 1: wait for the first sighting so slow stack bring-up on a loaded
+    # CI runner cannot masquerade as "wrong publishers" (or eat into the
+    # sampling window below).
+    first_sighting_deadline = time.monotonic() + TF_FIRST_SIGHTING_TIMEOUT_S
+    while time.monotonic() < first_sighting_deadline and not (
+        parents and odom_z_samples
+    ):
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    # Distinguish "frame never seen" (a startup failure or renamed frame) from
+    # "wrong publishers" so failures read correctly.
+    assert parents, (
+        f"No transform into {BASE_LINK_FRAME} observed on /tf within "
+        f"{TF_FIRST_SIGHTING_TIMEOUT_S:.1f}s — robot_state_publisher may not "
+        f"be up, or the frame was renamed."
+    )
+
+    # Phase 2: the frame is live; sample long enough that any competing
+    # publisher (10-120 Hz) would land in `parents`.
+    sample_deadline = time.monotonic() + TF_PARENT_SAMPLE_DURATION_S
+    while time.monotonic() < sample_deadline:
+        rclpy.spin_once(node, timeout_sec=0.1)
+    node.destroy_subscription(subscription)
+    node.destroy_subscription(odom_subscription)
+    assert parents == {"virtual_rail_link_2"}, (
+        f"Expected robot_state_publisher's virtual_rail_link_2 as the sole TF "
+        f"parent of {BASE_LINK_FRAME}, saw parents: {sorted(parents)}"
+    )
+    assert (
+        odom_z_samples
+    ), "No /odom messages observed; MuJoCo odom publisher may be off."
+    assert all(abs(z) < 1e-6 for z in odom_z_samples), (
+        f"odom_planar should zero /odom pose z for this planar base; "
+        f"saw max |z| = {max(abs(z) for z in odom_z_samples):.4f}"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[written by AI]

Fixes the remaining half of PickNikRobotics/moveit_pro#18174. Part of epic PickNikRobotics/moveit_pro#17431.

needs: moveit_pro/#20258

**Depends on PickNikRobotics/moveit_pro#20258** (adds the `base_link_name` hardware parameter). Against a moveit_pro image without it, the new xacro param is silently ignored, the lidar-chain half of the conflict remains, and the new single-parent integration test fails — the `needs:` token above makes CI run against that PR's image. Do not merge until #20258 is merged and a fresh moveit_pro `main` image is published, or the first post-merge `main` CI run here will use an image without the parameter.

## Motivation

`ridgeback_base_link` had **three concurrent TF parents** in hangar_sim: the MuJoCo lidar fill-in chain (`base_platform →`, 2×60 Hz), robot_state_publisher (`virtual_rail_link_2 →`, 20 Hz), and the MuJoCo odom TF (`odom →`, 150 Hz; fuse when enabled). tf2 and the web UI keep last-writer-wins, so the frame flipped between poses disagreeing by 48 mm at rest (a real model mismatch) and up to 61 mm in motion — the robot visibly oscillated below `base_link` whenever the UI's fixed frame sat at or below it. #18174 de-duplicated only the odom edge, and only in the opt-in fuse mode.

## Brief description

Makes robot_state_publisher the **sole owner** of the live transform into `ridgeback_base_link`. Its virtual-rail chain is the one publisher that cannot be turned off per-edge (the joints are required for whole-body planning), and in sim it is already ground truth — the base's x/y/yaw are literal MuJoCo joints streamed through `joint_state_broadcaster`. Every other subsystem now expresses the base pose as data, not TF:

- **xacro**: `base_link_name: ridgeback_base_link` stops the MuJoCo lidar fill-in chain at the base (lidar mounts hang off it as plain children); `odom_publish_tf: false` keeps `/odom` messages flowing for Nav2 but drops the competing TF edge; the dead `odom_zero_z` tag (never a recognized parameter — silently ignored) is replaced by the real `odom_planar`.
- **launch**: the `mj_world → world` static becomes `odom → world`. The `odom` frame previously existed only because MuJoCo broadcast the competing edge; anchoring `world` under `odom` gives REP-105 semantics — beluga_amcl's live `map → odom` correction shifts the whole robot subtree, and its own `odom → base` lookups resolve through the static. The #18174 launch guard is removed: it enforced the old ownership model and, when fuse was on, forced `publish_odom: false`, which also killed the `/odom` **messages** Nav2 reads (`odom_topic: /odom`).
- **fuse**: `publish_tf: false`. Nothing consumes `odom_filtered` today; the estimate stays on the topic. On hardware, the estimator feeds the virtual-rail joint states (odometry-to-joint-state bridge) rather than TF — ownership of the edge never moves.
- **URDF**: the virtual-rail origin gets `z = -0.048`, matching the MJCF `base_platform_rotation` anchor (the sim base has no z DOF; that offset is what puts the wheels in floor contact). Previously the RSP chain rendered the robot 48 mm above where the physics and every sensor frame actually put it.
- **test**: new integration test asserts `ridgeback_base_link` has exactly one TF parent (`virtual_rail_link_2`), so a re-enabled competing publisher fails CI instead of reappearing as UI jitter.
- **docs**: transform-allocation table, frame-hierarchy diagram, and production-deployment notes in `NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md` updated to the new tree.

Known out-of-scope: `phoebe_sim.urdf.xacro` uses the same dead `odom_zero_z` tag (vendored dependency); the architecture doc's executive-summary data-flow diagram still shows the historical odometry bridge.

## How it was tested

Live on a running hangar_sim stack (dev container, moveit_pro built from the paired branch):

- `/tf` attribution over 4 s windows: exactly one parent for `ridgeback_base_link` (`virtual_rail_link_2`, ~20 Hz, co-published edges identify robot_state_publisher) — at rest **and** during motion. Before the change: three parents at ~150 flips/s.
- `Solution - Move Forward 2m` objective SUCCEEDED (whole-body pipeline: MoveIt → JTC → chained mecanum controller); base x: −0.08 → 1.65 with z pinned at −0.048 throughout.
- beluga_amcl bootstraps and publishes `map → odom` live on the new topology; `odom → ridgeback_base_link` resolves (z = −0.048, matching physics); local costmap publishes; `/scan_front` at 10 Hz; **zero** TF warnings (`message filter`, `TF_OLD_DATA`, `TF_REPEATED_DATA`) in the backend log.
- Launch file and integration test pass `ast.parse`; `colcon build` of `hangar_sim` succeeds.

## Release notes

- Bug Fix: Fixed the robot model oscillating in the web UI 3D view in `hangar_sim` when the fixed frame was `base_link` or below, caused by multiple simulation publishers competing over the mobile base's transform.


---

Agent checks (this repo has no PR template; statuses mirror the moveit_pro convention): `code-reviewer` run (cross-repo dependency called out above; stale comments, doc sweeps, and a regression test applied from its findings) · `documentation-bot` run (3 stale-corrections in NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md applied) · `platform-architect-bot` run (CI ordering finding addressed by the `needs:` token + merge-order note; stale xacro comment fixed; /odom planar assertion added to the integration test) · `roboticist-bot` run (no required changes; −0.048 z verified kinematically safe: offset sits above every IK chain, waypoints are joint-space) · `test-runner`: hangar_sim builds; launch file and test pass syntax checks; the integration test runs in CI against the paired image; full TF behavior live-verified on a running stack (see "How it was tested").
