### PR TITLE
remove unused controller_names and trajectory_monitoring ports

### DIFF
--- a/src/dual_arm_sim/objectives/sort_blocks.xml
+++ b/src/dual_arm_sim/objectives/sort_blocks.xml
@@ -34,8 +34,6 @@
                   ID="InitializeMTCTask"
                   task="{mtc_task}"
                   timeout="-1.000000"
-                  trajectory_monitoring="false"
-                  controller_names="right_joint_trajectory_admittance_controller"
                   task_id="right_grasp_task"
                 />
                 <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
@@ -86,8 +84,6 @@
                   ID="InitializeMTCTask"
                   task="{mtc_task}"
                   timeout="-1.000000"
-                  trajectory_monitoring="false"
-                  controller_names="right_joint_trajectory_admittance_controller"
                   task_id="right_place_task"
                 />
                 <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
@@ -167,8 +163,6 @@
                   ID="InitializeMTCTask"
                   task="{mtc_task}"
                   timeout="-1.000000"
-                  trajectory_monitoring="false"
-                  controller_names="left_joint_trajectory_admittance_controller"
                   task_id="left_grasp_task"
                 />
                 <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
@@ -219,8 +213,6 @@
                   ID="InitializeMTCTask"
                   task="{mtc_task}"
                   timeout="-1.000000"
-                  trajectory_monitoring="false"
-                  controller_names="left_joint_trajectory_admittance_controller"
                   task_id="left_place_task"
                 />
                 <Action

--- a/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
@@ -34,8 +34,6 @@
       <Action
         ID="InitializeMTCTask"
         task="{mtc_task}"
-        trajectory_monitoring="false"
-        controller_names="joint_trajectory_admittance_controller"
         task_id="drop_task"
         timeout="-1.000000"
       />

--- a/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
@@ -38,8 +38,6 @@
       <Action
         ID="InitializeMTCTask"
         task="{mtc_task}"
-        trajectory_monitoring="false"
-        controller_names="joint_trajectory_admittance_controller"
         task_id="drop_task"
         timeout="-1.000000"
       />

--- a/src/factory_sim/objectives/inspect_convex_bowl.xml
+++ b/src/factory_sim/objectives/inspect_convex_bowl.xml
@@ -55,12 +55,7 @@
         />
       </Control>
       <Control ID="Sequence">
-        <Action
-          ID="InitializeMTCTask"
-          task="{mtc_task}"
-          trajectory_monitoring="false"
-          controller_names="joint_trajectory_admittance_controller"
-        />
+        <Action ID="InitializeMTCTask" task="{mtc_task}" />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
         <Action
           ID="SetupMTCPlanToPose"

--- a/src/factory_sim/objectives/pick_bracket_part_from_jig_subtree.xml
+++ b/src/factory_sim/objectives/pick_bracket_part_from_jig_subtree.xml
@@ -35,10 +35,8 @@
         />
         <Action
           ID="InitializeMTCTask"
-          controller_names="joint_trajectory_admittance_controller"
           task_id="jig_approach"
           task="{mtc_task}"
-          trajectory_monitoring="false"
           timeout="-1.000000"
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
@@ -101,10 +99,8 @@
       <Control ID="Sequence" name="Retract straight off of jig ">
         <Action
           ID="InitializeMTCTask"
-          controller_names="joint_trajectory_admittance_controller"
           task_id="jig_retract"
           task="{mtc_task}"
-          trajectory_monitoring="false"
           timeout="-1.000000"
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/factory_sim/objectives/pick_up_tool_from_holder.xml
+++ b/src/factory_sim/objectives/pick_up_tool_from_holder.xml
@@ -18,13 +18,7 @@
         position_xyz="0;0;-0.1"
         pose_stamped="{approach_pose}"
       />
-      <Action
-        ID="InitializeMTCTask"
-        task_id="pick_up_tool"
-        controller_names="joint_trajectory_admittance_controller"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task_id="pick_up_tool" task="{mtc_task}" />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
         ID="SetupMTCSetCollisionRule"

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -12,13 +12,7 @@
         position_xyz="0;0;-0.15"
         pose_stamped="{approach_pose}"
       />
-      <Action
-        ID="InitializeMTCTask"
-        task_id="pick_up_tool"
-        controller_names="joint_trajectory_admittance_controller"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task_id="pick_up_tool" task="{mtc_task}" />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Decorator
         ID="Precondition"

--- a/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_orientation_samples.xml
@@ -69,9 +69,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="move_to_pose"
-          controller_names="{controller_names}"
           task="{mtc_task}"
-          trajectory_monitoring="false"
           timeout="-1.000000"
         />
         <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
+++ b/src/factory_sim/objectives/plan_and_execute_with_world_vertical_orientation.xml
@@ -18,10 +18,8 @@
       />
       <Action
         ID="InitializeMTCTask"
-        controller_names="{controller_names}"
         task="{mtc_task}"
         task_id="move_to_pose"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/factory_sim/objectives/plan_path_along_surface.xml
+++ b/src/factory_sim/objectives/plan_path_along_surface.xml
@@ -116,8 +116,6 @@
         <Action
           ID="InitializeMTCTask"
           task="{mtc_task}"
-          trajectory_monitoring="false"
-          controller_names="joint_trajectory_admittance_controller"
           task_id="planning_task"
           timeout="-1.000000"
         />

--- a/src/factory_sim/objectives/retract.xml
+++ b/src/factory_sim/objectives/retract.xml
@@ -6,13 +6,7 @@
     distance="0.1"
   >
     <Control ID="Sequence" name="TopLevelSequence">
-      <Action
-        ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller"
-        task_id="retract"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task_id="retract" task="{mtc_task}" />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
         ID="SetupMTCMoveAlongFrameAxis"

--- a/src/factory_sim/objectives/vacuum_drop_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/vacuum_drop_bracket_part_subtree.xml
@@ -17,8 +17,6 @@
       <Action
         ID="InitializeMTCTask"
         task="{mtc_task}"
-        trajectory_monitoring="false"
-        controller_names="joint_trajectory_admittance_controller"
         task_id="drop_task"
         timeout="-1.000000"
       />

--- a/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
+++ b/src/factory_sim/objectives/vacuum_pick_bracket_part_subtree.xml
@@ -71,8 +71,6 @@
       <Action
         ID="InitializeMTCTask"
         task="{mtc_task}"
-        trajectory_monitoring="false"
-        controller_names="joint_trajectory_admittance_controller"
         task_id="pick_part"
         timeout="-1.000000"
       />

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -278,10 +278,8 @@
                   </Decorator>
                   <Action
                     ID="InitializeMTCTask"
-                    controller_names="joint_trajectory_controller"
                     task="{task}"
                     task_id=""
-                    trajectory_monitoring="false"
                     timeout="-1.000000"
                   />
                   <Action ID="SetupMTCCurrentState" task="{task}" />

--- a/src/hangar_sim/objectives/move_to_a_stampedpose.xml
+++ b/src/hangar_sim/objectives/move_to_a_stampedpose.xml
@@ -9,9 +9,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="move_to_pose"
-          controller_names="{controller_names}"
           task="{move_to_pose_task}"
-          trajectory_monitoring="false"
         />
         <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />
         <Action

--- a/src/hangar_sim/objectives/move_to_pose_no_preview.xml
+++ b/src/hangar_sim/objectives/move_to_pose_no_preview.xml
@@ -13,7 +13,6 @@
       <Action
         ID="InitializeMTCTask"
         task_id="move_to_pose"
-        controller_names="joint_trajectory_controller"
         task="{move_to_pose_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />

--- a/src/lab_sim/objectives/add_poses_to_mtc_task.xml
+++ b/src/lab_sim/objectives/add_poses_to_mtc_task.xml
@@ -7,12 +7,7 @@
     _favorite="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
-      <Action
-        ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task="{mtc_task}" />
       <!--Start the MTC task from the robot's current pose-->
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <!--Use a script with a pose counter so we can give a unique name to each marker (allowing multiple poses to be visualized)-->
@@ -59,10 +54,6 @@
         <Metadata subcategory="Motion - Task Planning" />
         <Metadata runnable="false" />
       </MetadataFields>
-      <inout_port
-        name="controller_names"
-        default="/joint_trajectory_admittance_controller;/robotiq_gripper_controller"
-      />
       <inout_port name="ik_frame" default="grasp_link" />
       <inout_port name="mtc_task" default="{mtc_task}" />
       <inout_port name="planning_group_name" default="manipulator" />

--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -81,7 +81,6 @@
           <Action
             ID="InitializeMTCTask"
             task_id="move_to_pre_pick"
-            controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
             task="{pre_pick_task}"
           />
           <Action ID="SetupMTCCurrentState" task="{pre_pick_task}" />
@@ -147,7 +146,6 @@
           <Action
             ID="InitializeMTCTask"
             task_id="move_to_pre_place"
-            controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
             task="{pre_place_task}"
           />
           <Action ID="SetupMTCCurrentState" task="{pre_place_task}" />

--- a/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
+++ b/src/lab_sim/objectives/get_collision_free_grasp_subtree.xml
@@ -61,8 +61,6 @@
             ID="InitializeMTCTask"
             task_id="move_to_pose"
             task="{move_to_pose_task}"
-            trajectory_monitoring="false"
-            controller_names="/joint_trajectory_admittance_controller"
           />
           <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />
           <Action

--- a/src/lab_sim/objectives/grasp_planning.xml
+++ b/src/lab_sim/objectives/grasp_planning.xml
@@ -62,9 +62,7 @@
         <Action
           ID="InitializeMTCTask"
           task_id="pick_object"
-          controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
           task="{pick_object_task}"
-          trajectory_monitoring="false"
           timeout="-1.000000"
         />
         <Action ID="SetupMTCCurrentState" task="{pick_object_task}" />

--- a/src/lab_sim/objectives/move_along_square.xml
+++ b/src/lab_sim/objectives/move_along_square.xml
@@ -9,11 +9,9 @@
     <Control ID="Sequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller"
         task="{mtc_task}"
         task_id="move_along_axis"
         timeout="-1.000000"
-        trajectory_monitoring="false"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action

--- a/src/lab_sim/objectives/pick_from_pose.xml
+++ b/src/lab_sim/objectives/pick_from_pose.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="pick_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/pick_from_pose_vector.xml
+++ b/src/lab_sim/objectives/pick_from_pose_vector.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="pick_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/pick_from_pose_with_approval.xml
+++ b/src/lab_sim/objectives/pick_from_pose_with_approval.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="pick_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/place_at_pose.xml
+++ b/src/lab_sim/objectives/place_at_pose.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/place_at_pose_vector.xml
+++ b/src/lab_sim/objectives/place_at_pose_vector.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/place_at_pose_with_approval.xml
+++ b/src/lab_sim/objectives/place_at_pose_with_approval.xml
@@ -9,10 +9,8 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{mtc_task}"
         task_id="place_object"
-        trajectory_monitoring="false"
         timeout="-1.000000"
       />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />

--- a/src/lab_sim/objectives/plan_move_to_pose.xml
+++ b/src/lab_sim/objectives/plan_move_to_pose.xml
@@ -10,7 +10,6 @@
       <Action
         ID="InitializeMTCTask"
         task_id="move_to_pose"
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
         task="{move_to_pose_task}"
       />
       <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}" />

--- a/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
+++ b/src/lab_sim/objectives/stitch_multiple_point_clouds_together.xml
@@ -65,7 +65,6 @@
         <Control ID="Sequence">
           <Action
             ID="InitializeMTCTask"
-            controller_names="joint_trajectory_admittance_controller"
             task="{mtc_task}"
             task_id="reach_test"
           />
@@ -100,12 +99,7 @@
       >
         <Control ID="Sequence">
           <!--Move to inspection point-->
-          <Action
-            ID="InitializeMTCTask"
-            controller_names="joint_trajectory_admittance_controller"
-            task="{move_task}"
-            task_id="inspect"
-          />
+          <Action ID="InitializeMTCTask" task="{move_task}" task_id="inspect" />
           <Action ID="SetupMTCCurrentState" task="{move_task}" />
           <Action
             ID="SetupMTCPlanToPose"
@@ -185,7 +179,6 @@
       <!--Demonstrate SetupMTCFromSolution for repeatable inspection routine-->
       <Action
         ID="InitializeMTCTask"
-        controller_names="joint_trajectory_admittance_controller"
         task="{replay_task}"
         task_id="repeat_inspection"
       />

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/compliant_grasp_rafti_vfc.xml
@@ -176,13 +176,7 @@
           </Control>
         </Control>
       </Control>
-      <Action
-        ID="InitializeMTCTask"
-        task_id=""
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task_id="" task="{mtc_task}" />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
         ID="SetupMTCPlanToPose"
@@ -213,13 +207,7 @@
         quaternion_xyzw="0.0;1.0;0.0;0.0"
         output_pose="{goal_pose}"
       />
-      <Action
-        ID="InitializeMTCTask"
-        task_id=""
-        controller_names="joint_trajectory_admittance_controller;robotiq_gripper_controller"
-        task="{mtc_task}"
-        trajectory_monitoring="false"
-      />
+      <Action ID="InitializeMTCTask" task_id="" task="{mtc_task}" />
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <Action
         ID="SetupMTCMoveAlongFrameAxis"


### PR DESCRIPTION
[written by AI]

Removes the `controller_names` and `trajectory_monitoring` attributes from `InitializeMTCTask` in the example Objectives, since those ports are removed in the paired MoveIt Pro PR. Without this, the Objectives fail to load against that PR's backend image.

Paired with PickNikRobotics/moveit_pro#20323.

needs: moveit_pro/#20323
