### PR TITLE
Fix: Nav objectives discard click-time pose stamps

### DIFF
--- a/src/hangar_sim/objectives/navigate_to_clicked_point.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point.xml
@@ -29,7 +29,7 @@
         ID="ComputePathToPoseAction"
         action_name="/compute_path_to_pose"
         goal="{goal}"
-        ignore_stamp_time="true"
+        ignore_stamp_time="false"
         path="{path}"
         planning_time="{planning_time}"
         start="{start}"

--- a/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
@@ -32,6 +32,7 @@
         ID="NavigateToPoseAction"
         action_name="/navigate_to_pose"
         behavior_tree_path="/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"
+        ignore_stamp_time="false"
         pose_stamped="{goal}"
       />
       <Action


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#20320

## Problem

`Navigate to Clicked Point` (and its replanning variant) zero the goal pose's timestamp before sending it to Nav2: `ComputePathToPoseAction` is invoked with `ignore_stamp_time="true"` and `NavigateToPoseAction` relies on the same port's `true` default. A zero stamp means "resolve with the latest transform", so a goal clicked in a moving frame (e.g. `base_link` with the fixed-frame selector from moveit_pro#20259) re-anchors to wherever the robot is at lookup time instead of where it was when the user clicked.

moveit_pro#20320 makes the backend stamp `GetPoseFromUser` responses with receipt time — but that stamp is discarded as long as these objectives zero it again.

## Approach

Set `ignore_stamp_time="false"` on both nav actions so the receipt-time stamp survives to Nav2, which resolves the goal's frame as of the click. Safe with or without moveit_pro#20320: before it, the stamp is zero anyway (identical behavior); after it, the stamp is fresh (tens of ms old) so no transform-tolerance risk.

The `needs:` token stacks this PR's integration tests on moveit_pro#20320's image so the combined behavior is what CI exercises.
