### PR TITLE
chore(kitchen_sim): Remove unused L2G ONNX model

### DIFF
--- a/src/kitchen_sim/CMakeLists.txt
+++ b/src/kitchen_sim/CMakeLists.txt
@@ -7,7 +7,6 @@ install(
     config
     description
     launch
-    models
     objectives
     waypoints
   DESTINATION

--- a/src/kitchen_sim/models/l2g.onnx
+++ b/src/kitchen_sim/models/l2g.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc1fd4a7cf185225ba29940da16cf052cc9801a4883aecffd82845627e0965b5
-size 15618125


### PR DESCRIPTION
[written by AI]

## Problem

`src/kitchen_sim/models/l2g.onnx` is an orphaned L2G weight. No kitchen_sim objective references `GetGraspPoseFromPointCloud` or `l2g.onnx` — verified by grep across the whole package (objectives, config, launch, CMake). It was the only file in `kitchen_sim/models/`.

Beyond being dead weight, L2G's upstream ([`antoalli/L2G`](https://github.com/antoalli/L2G)) ships **no license**, so redistributing this ONNX under kitchen_sim's BSD-3-Clause has no grant behind it. Removing the unused copy is the zero-risk first step of the ML-weight licensing cleanup (PickNikRobotics/moveit_pro#20353, epic PickNikRobotics/moveit_pro#20347).

## Change

- `git rm src/kitchen_sim/models/l2g.onnx`
- Drop `models` from the `install(DIRECTORY …)` list in `CMakeLists.txt` — it was the only file in that dir, so leaving the install rule would break the build (git drops the now-empty dir, and `install(DIRECTORY models …)` fails on a missing source dir).

## Why the SAM2/CLIPSeg objectives are unaffected

kitchen_sim's segmentation/grasp objectives reference `models/sam2_decoder.onnx`, `models/clip.onnx`, etc., but resolve them via the `model_package` port (`moveit_pro_sam2`, `moveit_pro_clipseg`) — i.e. against those dependency packages' share dirs, not kitchen_sim's. kitchen_sim's own `models/` dir only ever held l2g.onnx.

## Release notes

None
