### PR TITLE
Migrate Behaviors from `shared_resources_` to `getBehaviorContext()`

### DIFF
--- a/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
+++ b/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
@@ -66,7 +66,7 @@ BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
   // Initialize the robot model loader if this is the first time this Behavior has been run.
   if (robot_model_loader_ == nullptr)
   {
-    robot_model_loader_ = std::make_unique<robot_model_loader::RobotModelLoader>(shared_resources_->node);
+    robot_model_loader_ = std::make_unique<robot_model_loader::RobotModelLoader>(getBehaviorContext()->node);
   }
 
   // Get the robot model from the robot model loader.

--- a/src/example_behaviors/src/example_create_string_msg.cpp
+++ b/src/example_behaviors/src/example_create_string_msg.cpp
@@ -34,8 +34,8 @@ BT::NodeStatus ExampleCreateStringMsg::tick()
   if (const auto error = moveit_pro::behaviors::maybe_error(expected_string); error)
   {
     // If the port was set incorrectly, we will log an error message to the UI and the node will return FAILURE
-    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required values from input data ports." +
-                                                                 error.value());
+    getBehaviorContext()->logger->publishFailureMessage(name(), "Failed to get required values from input data ports." +
+                                                                    error.value());
     return BT::NodeStatus::FAILURE;
   }
 

--- a/src/example_behaviors/src/example_delayed_message.cpp
+++ b/src/example_behaviors/src/example_delayed_message.cpp
@@ -34,8 +34,8 @@ BT::NodeStatus ExampleDelayedMessage::onStart()
   if (const auto error = moveit_pro::behaviors::maybe_error(maybe_duration); error)
   {
     // If the port was set incorrectly, we will log an error message to the UI and the node will return FAILURE
-    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required values from input data ports." +
-                                                                 error.value());
+    getBehaviorContext()->logger->publishFailureMessage(name(), "Failed to get required values from input data ports." +
+                                                                    error.value());
     return BT::NodeStatus::FAILURE;
   }
 
@@ -47,7 +47,7 @@ BT::NodeStatus ExampleDelayedMessage::onStart()
   {
     // Log the "Hello, world!" message.
     // Setting the third argument to false ensures the message will be shown immediately
-    shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+    getBehaviorContext()->logger->publishInfoMessage(name(), "Hello, world!");
     return BT::NodeStatus::SUCCESS;
   }
 
@@ -62,7 +62,7 @@ BT::NodeStatus ExampleDelayedMessage::onRunning()
   {
     // Log the "Hello, world!" message.
     // Setting the third argument to false ensures the message will be shown immediately
-    shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+    getBehaviorContext()->logger->publishInfoMessage(name(), "Hello, world!");
     return BT::NodeStatus::SUCCESS;
   }
   else

--- a/src/example_behaviors/src/example_fibonacci_action_client.cpp
+++ b/src/example_behaviors/src/example_fibonacci_action_client.cpp
@@ -66,7 +66,7 @@ ExampleFibonacciActionClient::processResult(const std::shared_ptr<Fibonacci::Res
   std::cout << stream.str() << std::endl;
 
   // Publish the result to the UI
-  shared_resources_->logger->publishInfoMessage(name(), "Result: " + stream.str());
+  getBehaviorContext()->logger->publishInfoMessage(name(), "Result: " + stream.str());
 
   setOutput<std::vector<int>>("result", result->sequence);
 
@@ -83,7 +83,7 @@ void ExampleFibonacciActionClient::processFeedback(const std::shared_ptr<const F
   std::cout << stream.str() << std::endl;
 
   // Publish the feedback to the UI
-  shared_resources_->logger->publishInfoMessage(name(), "Feedback: " + stream.str());
+  getBehaviorContext()->logger->publishInfoMessage(name(), "Feedback: " + stream.str());
 
   setOutput<std::vector<int>>("feedback", feedback->sequence);
 }

--- a/src/example_behaviors/src/example_hello_world.cpp
+++ b/src/example_behaviors/src/example_hello_world.cpp
@@ -23,7 +23,7 @@ BT::NodeStatus ExampleHelloWorld::tick()
 {
   // Do ExampleHelloWorld's useful work.
   // Setting the third argument to false ensures the message will be shown immediately
-  shared_resources_->logger->publishInfoMessage(name(), "Hello, world!");
+  getBehaviorContext()->logger->publishInfoMessage(name(), "Hello, world!");
 
   return BT::NodeStatus::SUCCESS;
 }

--- a/src/example_behaviors/src/example_publish_color_rgba.cpp
+++ b/src/example_behaviors/src/example_publish_color_rgba.cpp
@@ -6,7 +6,7 @@ ExamplePublishColorRGBA::ExamplePublishColorRGBA(
     const std::string& name, const BT::NodeConfiguration& config,
     const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
   : moveit_pro::behaviors::SharedResourcesNode<BT::SyncActionNode>(name, config, shared_resources)
-  , publisher_{ shared_resources_->node->create_publisher<std_msgs::msg::ColorRGBA>("/my_topic", rclcpp::QoS(1)) }
+  , publisher_{ getBehaviorContext()->node->create_publisher<std_msgs::msg::ColorRGBA>("/my_topic", rclcpp::QoS(1)) }
 {
 }
 

--- a/src/lab_sim_behaviors/src/compute_tray_place_positions_using_apriltags.cpp
+++ b/src/lab_sim_behaviors/src/compute_tray_place_positions_using_apriltags.cpp
@@ -106,8 +106,8 @@ BT::NodeStatus ComputeTrayPlacePositionsUsingAprilTags::tick()
 
   if (!ports.has_value())
   {
-    shared_resources_->logger->publishFailureMessage(name(), "Failed to get required values from input data ports: " +
-                                                                 ports.error());
+    getBehaviorContext()->logger->publishFailureMessage(
+        name(), "Failed to get required values from input data ports: " + ports.error());
     return BT::NodeStatus::FAILURE;
   }
 
@@ -128,7 +128,7 @@ BT::NodeStatus ComputeTrayPlacePositionsUsingAprilTags::tick()
 
   if (tray_it == detections_array.detections.end())
   {
-    shared_resources_->logger->publishFailureMessage(
+    getBehaviorContext()->logger->publishFailureMessage(
         name(), fmt::format("Tray AprilTag with ID {} not found in detections.", tray_apriltag_id));
     return BT::NodeStatus::FAILURE;
   }
@@ -168,14 +168,14 @@ BT::NodeStatus ComputeTrayPlacePositionsUsingAprilTags::tick()
   }
 
   // Look up camera_frame -> "world" transform
-  if (!shared_resources_->transform_buffer_ptr->canTransform("world", camera_frame, tf2::TimePointZero))
+  if (!getBehaviorContext()->transform_buffer_ptr->canTransform("world", camera_frame, tf2::TimePointZero))
   {
-    shared_resources_->logger->publishFailureMessage(name(), fmt::format("Cannot transform between '{}' and 'world'.",
-                                                                         camera_frame));
+    getBehaviorContext()->logger->publishFailureMessage(
+        name(), fmt::format("Cannot transform between '{}' and 'world'.", camera_frame));
     return BT::NodeStatus::FAILURE;
   }
   const geometry_msgs::msg::TransformStamped camera_to_world_tf =
-      shared_resources_->transform_buffer_ptr->lookupTransform("world", camera_frame, tf2::TimePointZero);
+      getBehaviorContext()->transform_buffer_ptr->lookupTransform("world", camera_frame, tf2::TimePointZero);
   const Eigen::Isometry3d camera_to_world = tf2::transformToEigen(camera_to_world_tf);
 
   // Transform all positions to world frame with gripper-down orientation (x=1, y=0, z=0, w=0)
@@ -201,14 +201,14 @@ BT::NodeStatus ComputeTrayPlacePositionsUsingAprilTags::tick()
   const auto maybe_image = getInput<sensor_msgs::msg::Image>(kPortIDInputImage);
   if (!maybe_image.has_value())
   {
-    shared_resources_->logger->publishInfoMessage(name(), "No input_image provided; skipping visualization.");
+    getBehaviorContext()->logger->publishInfoMessage(name(), "No input_image provided; skipping visualization.");
   }
   else
   {
     try
     {
       const auto viz_topic = getInput<std::string>(kPortIDVisualizationTopic).value();
-      ros_publisher_interface_->init(viz_topic, shared_resources_);
+      ros_publisher_interface_->init(viz_topic, getBehaviorContext());
 
       const double fx = camera_info.k[0];
       const double fy = camera_info.k[4];
@@ -260,8 +260,8 @@ BT::NodeStatus ComputeTrayPlacePositionsUsingAprilTags::tick()
     }
     catch (const cv_bridge::Exception& e)
     {
-      shared_resources_->logger->publishFailureMessage(name(), fmt::format("cv_bridge error during visualization: {}",
-                                                                           e.what()));
+      getBehaviorContext()->logger->publishFailureMessage(
+          name(), fmt::format("cv_bridge error during visualization: {}", e.what()));
     }
   }
 


### PR DESCRIPTION
[written by AI]

## Problem

MoveIt Pro 10.0 (PickNikRobotics/moveit_pro#20288) removes `protected` across the C++ API and privatizes `SharedResourcesNode::shared_resources_` behind the public `getBehaviorContext()` accessor. Behaviors in this workspace that dereference `shared_resources_->` no longer compile against the 10.0 base image — `lab_sim_behaviors` fails first (`compute_tray_place_positions_using_apriltags.cpp:109: 'shared_resources_' was not declared in this scope`).

## Change

Mechanical migration of every `shared_resources_` member reference to the `getBehaviorContext()` accessor across `example_behaviors` and `lab_sim_behaviors` (7 files, 16 call sites). `#include <.../shared_resources_node.hpp>` lines are unchanged — the base class and header keep their names; only the member access moved behind an accessor. This is the migration documented in the moveit_pro 10.0 user-workspace migration guide.

Validation rides on the paired moveit_pro PR: the `needs:` token below pins `example_ws / integration` to that PR's backend image (which defines `getBehaviorContext()`), not the released `main` image. Merge order is moveit_pro first, then this PR.

needs: moveit_pro/#20288
