### PR TITLE
Fix: Validate hangar_sim surface path against the aircraft and abort stuck goals

### DIFF
--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -249,7 +249,14 @@ joint_trajectory_controller:
         angle_wraparound: true
     constraints:
       stopped_velocity_tolerance: 0.0
-      goal_time: 0.0
+      # A zero goal_time disables the goal-time check entirely: a goal whose
+      # joints sit outside their goal tolerance after the last trajectory
+      # point neither succeeds nor aborts, so the controller waits forever
+      # and callers hang (moveit_pro#20427). A finite tolerance converts
+      # that hang into a GOAL_TOLERANCE_VIOLATED abort that names the
+      # offending joint. 20 s is generous headroom for post-trajectory
+      # convergence.
+      goal_time: 20.0
       shoulder_pan_joint:
         goal: 0.05
       shoulder_lift_joint:

--- a/src/hangar_sim/config/moveit/picknik_ur.srdf
+++ b/src/hangar_sim/config/moveit/picknik_ur.srdf
@@ -59,10 +59,6 @@
     <disable_collisions link1="base_link_inertia" link2="collision_Cube_013" reason="Never"/>
     <disable_collisions link1="base_link_inertia" link2="collision_Cube_014" reason="Never"/>
     <disable_collisions link1="base_link_inertia" link2="collision_Cube_015" reason="Never"/>
-    <disable_collisions link1="base_link_inertia" link2="collision_Plane_005" reason="Never"/>
-    <disable_collisions link1="base_link_inertia" link2="collision_Plane_006" reason="Never"/>
-    <disable_collisions link1="base_link_inertia" link2="collision_Plane_007" reason="Never"/>
-    <disable_collisions link1="base_link_inertia" link2="collision_Plane_008" reason="Never"/>
     <disable_collisions link1="base_link_inertia" link2="collision_SM_Box_A7_73" reason="Never"/>
     <disable_collisions link1="base_link_inertia" link2="collision_SM_Box_A8" reason="Never"/>
     <disable_collisions link1="base_link_inertia" link2="collision_SM_Box_C7_77" reason="Never"/>
@@ -119,10 +115,6 @@
     <disable_collisions link1="chassis_link" link2="collision_Cube_013" reason="Never"/>
     <disable_collisions link1="chassis_link" link2="collision_Cube_014" reason="Never"/>
     <disable_collisions link1="chassis_link" link2="collision_Cube_015" reason="Never"/>
-    <disable_collisions link1="chassis_link" link2="collision_Plane_005" reason="Never"/>
-    <disable_collisions link1="chassis_link" link2="collision_Plane_006" reason="Never"/>
-    <disable_collisions link1="chassis_link" link2="collision_Plane_007" reason="Never"/>
-    <disable_collisions link1="chassis_link" link2="collision_Plane_008" reason="Never"/>
     <disable_collisions link1="chassis_link" link2="collision_SM_Box_A7_73" reason="Never"/>
     <disable_collisions link1="chassis_link" link2="collision_SM_Box_A8" reason="Never"/>
     <disable_collisions link1="chassis_link" link2="collision_SM_Floor_376" reason="Adjacent"/>
@@ -1373,7 +1365,6 @@
     <disable_collisions link1="collision_Plane" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane" link2="wrist_1_link" reason="Never"/>
     <disable_collisions link1="collision_Plane_001" link2="collision_Plane_002" reason="Never"/>
     <disable_collisions link1="collision_Plane_001" link2="collision_Plane_003" reason="Never"/>
     <disable_collisions link1="collision_Plane_001" link2="collision_Plane_004" reason="Never"/>
@@ -1471,7 +1462,6 @@
     <disable_collisions link1="collision_Plane_002" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_002" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_002" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_002" link2="collision_vacuum_base" reason="Never"/>
     <disable_collisions link1="collision_Plane_003" link2="collision_Plane_004" reason="Never"/>
     <disable_collisions link1="collision_Plane_003" link2="collision_Plane_005" reason="Never"/>
     <disable_collisions link1="collision_Plane_003" link2="collision_Plane_006" reason="Never"/>
@@ -1565,7 +1555,6 @@
     <disable_collisions link1="collision_Plane_004" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_004" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_004" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_004" link2="collision_vacuum_suction_cups" reason="Never"/>
     <disable_collisions link1="collision_Plane_005" link2="collision_Plane_006" reason="Never"/>
     <disable_collisions link1="collision_Plane_005" link2="collision_Plane_007" reason="Never"/>
     <disable_collisions link1="collision_Plane_005" link2="collision_Plane_008" reason="Never"/>
@@ -1611,24 +1600,6 @@
     <disable_collisions link1="collision_Plane_005" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_005" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_005" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="collision_vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="collision_vacuum_suction_cups" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="forearm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="forearm_pinch_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="front_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="front_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="ham_assem_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="rear_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="rear_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="riser_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="shoulder_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="top_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="upper_arm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="wrist_1_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="wrist_2_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="wrist_3_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_005" link2="wrist_3_pinch_link" reason="Never"/>
     <disable_collisions link1="collision_Plane_006" link2="collision_Plane_007" reason="Never"/>
     <disable_collisions link1="collision_Plane_006" link2="collision_Plane_008" reason="Never"/>
     <disable_collisions link1="collision_Plane_006" link2="collision_Plane_009" reason="Default"/>
@@ -1673,24 +1644,6 @@
     <disable_collisions link1="collision_Plane_006" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_006" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_006" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="collision_vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="collision_vacuum_suction_cups" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="forearm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="forearm_pinch_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="front_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="front_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="ham_assem_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="rear_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="rear_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="riser_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="shoulder_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="top_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="upper_arm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="wrist_1_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="wrist_2_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="wrist_3_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_006" link2="wrist_3_pinch_link" reason="Never"/>
     <disable_collisions link1="collision_Plane_007" link2="collision_Plane_008" reason="Never"/>
     <disable_collisions link1="collision_Plane_007" link2="collision_Plane_009" reason="Never"/>
     <disable_collisions link1="collision_Plane_007" link2="collision_Plane_010" reason="Never"/>
@@ -1734,24 +1687,6 @@
     <disable_collisions link1="collision_Plane_007" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_007" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_007" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="collision_vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="collision_vacuum_suction_cups" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="forearm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="forearm_pinch_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="front_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="front_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="ham_assem_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="rear_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="rear_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="riser_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="shoulder_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="top_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="upper_arm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="wrist_1_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="wrist_2_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="wrist_3_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_007" link2="wrist_3_pinch_link" reason="Never"/>
     <disable_collisions link1="collision_Plane_008" link2="collision_Plane_009" reason="Never"/>
     <disable_collisions link1="collision_Plane_008" link2="collision_Plane_010" reason="Never"/>
     <disable_collisions link1="collision_Plane_008" link2="collision_Plane_011" reason="Never"/>
@@ -1794,24 +1729,6 @@
     <disable_collisions link1="collision_Plane_008" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_008" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_008" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="collision_vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="collision_vacuum_suction_cups" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="forearm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="forearm_pinch_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="front_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="front_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="ham_assem_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="rear_left_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="rear_right_wheel_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="riser_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="shoulder_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="top_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="upper_arm_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="wrist_1_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="wrist_2_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="wrist_3_link" reason="Never"/>
-    <disable_collisions link1="collision_Plane_008" link2="wrist_3_pinch_link" reason="Never"/>
     <disable_collisions link1="collision_Plane_009" link2="collision_Plane_010" reason="Never"/>
     <disable_collisions link1="collision_Plane_009" link2="collision_Plane_011" reason="Never"/>
     <disable_collisions link1="collision_Plane_009" link2="collision_Plane_012" reason="Never"/>
@@ -1893,8 +1810,6 @@
     <disable_collisions link1="collision_Plane_010" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_010" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_010" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_010" link2="collision_vacuum_base" reason="Never"/>
-    <disable_collisions link1="collision_Plane_010" link2="collision_vacuum_suction_cups" reason="Never"/>
     <disable_collisions link1="collision_Plane_011" link2="collision_Plane_012" reason="Default"/>
     <disable_collisions link1="collision_Plane_011" link2="collision_SM_Box_A7_73" reason="Never"/>
     <disable_collisions link1="collision_Plane_011" link2="collision_SM_Box_A8" reason="Never"/>
@@ -1934,7 +1849,6 @@
     <disable_collisions link1="collision_Plane_011" link2="collision_supports_013" reason="Never"/>
     <disable_collisions link1="collision_Plane_011" link2="collision_supports_014" reason="Never"/>
     <disable_collisions link1="collision_Plane_011" link2="collision_supports_015" reason="Never"/>
-    <disable_collisions link1="collision_Plane_011" link2="collision_vacuum_base" reason="Never"/>
     <disable_collisions link1="collision_Plane_012" link2="collision_SM_Box_A7_73" reason="Never"/>
     <disable_collisions link1="collision_Plane_012" link2="collision_SM_Box_A8" reason="Never"/>
     <disable_collisions link1="collision_Plane_012" link2="collision_SM_Box_C7_77" reason="Never"/>

--- a/src/hangar_sim/objectives/plan_path_along_surface.xml
+++ b/src/hangar_sim/objectives/plan_path_along_surface.xml
@@ -74,8 +74,8 @@
         input_cloud="{point_cloud}"
         slice_distance_from_plane="0.100000"
         slice_plane="{centroid}"
-        contour_crop_angle_span="3.2"
-        contour_crop_angle_start="1.58"
+        contour_crop_angle_span="2.25"
+        contour_crop_angle_start="2.4"
       />
       <Action
         ID="VisualizePath"
@@ -96,7 +96,20 @@
         planning_group_name="manipulator"
         position_only="false"
         trajectory_timing="[{mode: time_optimal}]"
-        tip_offset="0;0;0.1;0;0;0"
+        tip_offset="0;0;0.2;0;0;0"
+        debug_solution="{debug_solution}"
+      />
+      <Action
+        ID="GetCurrentPlanningScene"
+        planning_scene_msg="{planning_scene}"
+      />
+      <Action
+        ID="ValidateTrajectory"
+        cartesian_space_step="0.020000"
+        joint_space_step="0.100000"
+        joint_trajectory_msg="{joint_trajectory_msg}"
+        planning_group_name="manipulator"
+        planning_scene_msg="{planning_scene}"
         debug_solution="{debug_solution}"
       />
       <Action


### PR DESCRIPTION
[written by AI]

Fixes the `Plan Path Along Surface` CI hang tracked in PickNikRobotics/moveit_pro#20427 (~70% of hangar_sim integration runs).

## Problem

The objective plans a whole-body (arm + mecanum base) Cartesian path along the perceived fuselage contour with no trajectory validation, and the untuned contour window routes the path's tail into the aircraft. The aircraft's 13 convex collision meshes have always existed as URDF links fixed to `world`, but auto-generated SRDF `disable_collisions` entries (from the original `Add hangar_sim` commit) exempted the tail pieces from checking against every robot link — and `constraints.goal_time: 0.0` makes the upstream JTC's goal-tolerance abort branch unreachable, so when MuJoCo contact stops the base short of the commanded terminal, the controller waits forever. The test fixture reports that silent hang as "did not return within 90.0s", and the abandoned goal pollutes the next test (rosbag forensics, phase timelines, and live reproduction on the moveit_pro issue).

## Approach

Three minimal changes, each independently defensible:

1. **`plan_path_along_surface.xml`**: retune the path so it is actually feasible — `tip_offset` 0.1→0.2 and contour crop window (start 2.4, span 2.25) so the arc clears the wing box and the coarse nose hull — and add `GetCurrentPlanningScene` + `ValidateTrajectory` before `ExecuteTrajectory` (the exact pattern `plan_path_along_surface_3_passes.xml` and `cartesian_path_with_collision_checking.xml` already use). The bare abort on validation failure (no `WaitForMTCSolutionApproval` fallback) is deliberate: in headless CI an approval prompt blocks forever, and the intent of this fix is a fast, diagnosable failure.
2. **`picknik_ur.srdf`**: remove the 86 auto-generated `disable_collisions` entries between `collision_Plane*` and robot links. They made collision checking blind to the aircraft's tail pieces for every group and objective. The re-enabled pieces sit at y≈29–33, far outside any current objective's workspace, so nothing legitimate is newly rejected (verified: the stricter validation still passes `3 Passes`).
3. **`picknik_ur.ros2_control.yaml`**: `constraints.goal_time` 0.0→20.0, converting any future terminal non-convergence into a `GOAL_TOLERANCE_VIOLATED` abort that names the offending joint instead of an unbounded silent hang. Worst-case surface-path abort lands ~T+84s, inside the CI fixture's 90s cap.

## Validation (live, main-based stack, moveit_pro overlay @ post-#20258 main)

- Tuned objective: 3/3 SUCCEEDED (~40s each, 9–11 waypoints planned).
- Untuned probe (original crop/tip values): aborts at plan time in ~30s with `ValidateTrajectory Error: Trajectory collides at 82.7% feasible. Colliding objects: collision_Plane_009 - collision_vacuum_suction_cups` — proving validation now covers the aircraft via its URDF links, no scene setup needed.
- `Plan Path Along Surface 3 Passes`: SUCCEEDED under the stricter SRDF (goal_time + SRDF regression probe).

## Follow-ups (not in this PR)

- moveit_pro docs: `src/docs/docs/tutorials/motion_planning.mdx` needs its single-pass Behavior list updated to mention validation, and the 3-passes "extends" bullet reworded (validation is no longer unique to it).
- `objective_test_fixture.py` (moveit_pro): cancel the objective on timeout so an abandoned goal can't pollute subsequent tests.
- Optional: a regression test asserting the validation-abort failure mode itself, guarding against the SRDF exemptions creeping back.
- Contour-crop angle tuning remains brittle by design (window is anchored to the perceived hull's angular start); documented in moveit_pro#20427.

## Claude agent checks

- [x] code-reviewer (v1 + v2 re-review — no P0/P1; P2 naming fix applied in v1, P2 notes addressed in this description)
- [x] roboticist-bot (Required Change resolved by the SRDF root fix; TF/ACM/goal_time semantics verified)
- [x] documentation-bot (2 stale-corrections identified → moveit_pro docs follow-up above)
- [x] test-runner — SKIPPED: no buildable code in diff (XML/YAML/SRDF config); validated live per the matrix above; CI integration suite exercises the changed objective automatically