### PR TITLE
Add Run pi0.5 Policy objective wiring ExecutePolicyPi05Torch

### DIFF
--- a/src/lab_sim/objectives/run_pi05_policy.xml
+++ b/src/lab_sim/objectives/run_pi05_policy.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Run pi0.5 Policy">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Run pi0.5 Policy"
+    _description="Runs the in-process libtorch pi0.5 vision-language-action policy on the lab_sim arm. Wiring demo: runnable end-to-end once a matching-dims checkpoint (real lab_sim joint count, not the base checkpoint's 32-dim placeholder) is exported -- see moveit_pro PR that adds ExecutePolicyPi05Torch."
+    _favorite="false"
+  >
+    <Control ID="Sequence">
+      <!-- Move to a known start pose so the policy's first observation is reproducible. -->
+      <SubTree
+        ID="Move to Waypoint"
+        _collapsed="true"
+        waypoint_name="Look at Table"
+      />
+      <Action
+        ID="ExecutePolicyPi05Torch"
+        prefix_pt_path="/models/pi05/pi05_prefix.pt"
+        expert_pt_path="/models/pi05/pi05_expert.pt"
+        tokenizer_path=""
+        stats_path="/models/pi05/pi05_stats.json"
+        prompt="pick up the block"
+        joint_group_name="manipulator"
+        total_action_steps="200"
+        committed_action_steps="32"
+        dt="0.05"
+        num_interpolation_points="100"
+        goal_path_tolerance="0.05"
+        policy_tracking_weight="300.0"
+        policy_uses_real_time_chunking="false"
+        guidance_horizon="0"
+        controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        absolute_force_torque_threshold="45;45;45;10;10;10"
+        policy_call_timeout="30.0"
+        image_names="observation.images.base_0_rgb;observation.images.left_wrist_0_rgb;observation.images.right_wrist_0_rgb"
+        image_topics="/scene_camera/color;/wrist_camera/color;/wrist_camera/color"
+        joint_states_topic="/joint_states"
+        policy_service_name="unused"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Run pi0.5 Policy">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - ML (GPU Recommended)" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -295,6 +295,7 @@ skip_objectives = {
     # rate even with the 0.003 s scene timestep and CPU pinning. See PR #615.
     "Push Button With a Trajectory",
     "Record Square Trajectory",
+    "Run pi0.5 Policy",  # Wiring demo only: needs an external ~15 GB libtorch checkpoint export not present in CI.
     "Scan Scene - Multiple Point Clouds",
     "Stack Objects with ICP",  # Skipped because there is no primary ui to switch to in ci
     "Stitch Multiple Point Clouds Together",


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#20521

Adds a `lab_sim` Objective, `Run pi0.5 Policy` (`src/lab_sim/objectives/run_pi05_policy.xml`), wiring the new `ExecutePolicyPi05Torch` behavior from moveit_pro PR #20521 (in-process libtorch pi0.5 VLA policy inference).

## What it wires

- Moves to the `Look at Table` waypoint, then runs `ExecutePolicyPi05Torch` arm-only (`manipulator` joint group; gripper ports left unset) against lab_sim's two cameras (`/scene_camera/color`, `/wrist_camera/color`, the latter doubled to fill the checkpoint's third expected camera slot).
- Model artifact ports (`prefix_pt_path`, `expert_pt_path`, `stats_path`) point at placeholder paths under `/models/pi05/` — no such checkpoint ships in this repo or in CI.

## Known limitation: wiring demo, not runnable as-is

The pi0.5 base checkpoint's exported metadata declares `state_dim: 32` (the base checkpoint has no fine-tune dataset, so the exporter falls back to `PI05Config.max_state_dim`'s default). `ExecutePolicyPi05Torch` requires an exact match between the real robot state size and `metadata.state_dim`; lab_sim's manipulator has far fewer than 32 joints, so this objective will fail its first observation with the base checkpoint.

This is not a padding bug to fix: reading LeRobot's actual pi0.5 pipeline (`lerobot/policies/pi05/processor_pi05.py`'s `Pi05PrepareStateTokenizerProcessorStep` and the shared `NormalizerProcessorStep`), state is discretized and embedded as *text* tokens in the prompt at its real (unpadded) length — `max_state_dim` is stored on that processor step but never read in its `__call__`. Only the flow-matching *action* expert has a hard-sized `Linear` projection that requires numeric padding to `max_action_dim`, and `ExecutePolicyPi05Torch` already implements that (unpadding the response chunk, per the moveit_pro PR). A properly fine-tuned checkpoint for lab_sim would report its own real joint count as `state_dim` in its exported metadata, and this objective would run against it unmodified — no code change needed on either side.

Runnable end-to-end once a matching-dims checkpoint is exported and its artifact paths are substituted in. Added to `skip_objectives` in `objectives_integration_test.py` so the "run all objectives" CI sweep doesn't try to execute it without real checkpoint files.
