### PR TITLE
Fix: Navigate to Clicked Point objectives abort with TF extrapolation error

### DIFF
--- a/src/hangar_sim/objectives/navigate_to_clicked_point.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point.xml
@@ -29,7 +29,7 @@
         ID="ComputePathToPoseAction"
         action_name="/compute_path_to_pose"
         goal="{goal}"
-        ignore_stamp_time="false"
+        ignore_stamp_time="true"
         path="{path}"
         planning_time="{planning_time}"
         start="{start}"

--- a/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
+++ b/src/hangar_sim/objectives/navigate_to_clicked_point_with_replanning.xml
@@ -32,7 +32,7 @@
         ID="NavigateToPoseAction"
         action_name="/navigate_to_pose"
         behavior_tree_path="/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"
-        ignore_stamp_time="false"
+        ignore_stamp_time="true"
         pose_stamped="{goal}"
       />
       <Action


### PR DESCRIPTION
[written by AI]

## Problem

On `hangar_sim`, the **Navigate to Clicked Point** and **Navigate to Clicked Point with Replanning** objectives fail: the robot drives a short distance, does a recovery backup/spin, then aborts. The backend log shows:

```
Extrapolation Error ... Lookup would require extrapolation into the past
Could not transform the start or goal pose in the costmap frame
[compute_path_to_pose] [ActionServer] Aborting handle.
```

Addresses PickNikRobotics/moveit_pro#20481.

## Root cause

Both objectives overrode the nav2 action behaviors' `ignore_stamp_time` port to `false`. With `false`, nav2 must transform the clicked goal pose into the costmap (`map`) frame **at the goal's exact click-time stamp**. During (re)planning that stamp keeps being reused while the TF buffer rolls forward; once it ages past `transform_tolerance` it falls off the back of the buffer, so the lookup fails with "extrapolation into the past" and the objective aborts. Under load the window is wide enough to fail on essentially every run.

Setting `ignore_stamp_time="true"` (the behavior's own default) zeroes the goal stamp so nav2 resolves it against latest-available TF (`TimePointZero`) instead of a fixed past time.

## Why this only affects the navigation objectives

`ignore_stamp_time` is a port on the nav2 action behaviors specifically (`ComputePathToPoseAction`, `NavigateToPoseAction`). They are the only behaviors that take a timestamped goal pose and transform it into the global costmap frame at that stamp, so they are the only ones exposed to the aging-stamp failure. Non-navigation objectives don't use these behaviors and never carried the override — this is why the two clicked-point objectives were the *only* files in the workspace with `ignore_stamp_time="false"`, and the complete fix is these two lines.

## Verification

Reproduced and fixed against a live `hangar_sim` backend driven through the web UI:

- **Before:** both objectives abort on click with the extrapolation error above.
- **After:** both objectives succeed and the robot reaches the goal — confirmed across multiple manual runs, with zero extrapolation errors in the backend log.

## Release notes

`Bug Fix:` Fixed the `Navigate to Clicked Point` and `Navigate to Clicked Point with Replanning` objectives on `hangar_sim` aborting with a costmap transform error instead of navigating to the clicked goal.
