### PR TITLE
Distribute factory_sim SAM 2.1 models under Apache-2.0 with Meta attribution

### DIFF
--- a/src/factory_sim/README.md
+++ b/src/factory_sim/README.md
@@ -3,3 +3,15 @@
 A MoveIt Pro configuration for a Fanuc LR Mate 200iD.
 
 For detailed documentation see: [MoveIt Pro Documentation](https://docs.picknik.ai/)
+
+## Model licensing and provenance
+
+The ONNX model files in [`models/`](models/) are exports of Meta's SAM 2.1 model and are distributed under the [Apache License 2.0](models/LICENSE), with upstream attribution in [`models/NOTICE`](models/NOTICE). If you redistribute the models or derivative works, include the license text and the NOTICE file with them. All other files in this package are governed by the package's [BSD 3-Clause License](LICENSE).
+
+The models were exported by PickNik in December 2025 from Meta's SAM 2.1 `sam2.1_hiera_large` checkpoint ([facebookresearch/sam2](https://github.com/facebookresearch/sam2)) using `torch.onnx.export` (PyTorch 2.6.0, per the ONNX producer metadata), split into three graphs (image encoder, prompt encoder, decoder) so image embeddings can be cached across prompts. No training or fine-tuning was performed. The export scripts and the exact checkpoint revision were not preserved.
+
+| File | SHA-256 |
+| --- | --- |
+| `sam2.1_hiera_l_image_encoder.onnx` | `cbdbe1e1ad3b616985d0f9c071a5948f8f8342d8e55e98857159405678b70cec` |
+| `sam2.1_prompt_encoder.onnx` | `eb2130a99f74bb2f6a430c0f1fe6af291b45ead4bf0beee715330c3def901206` |
+| `sam2.1_decoder.onnx` | `e11609a8d694f2186f5974cf0d86e1588dbbb126088c4a7849adbc546b284e3a` |

--- a/src/factory_sim/models/LICENSE
+++ b/src/factory_sim/models/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/factory_sim/models/NOTICE
+++ b/src/factory_sim/models/NOTICE
@@ -1,0 +1,7 @@
+SAM 2
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This directory contains ONNX exports of the SAM 2.1 model weights, licensed
+under the Apache License, Version 2.0 (see the LICENSE file in this
+directory). If you redistribute the models or derivative works, retain this
+NOTICE and the LICENSE file.

--- a/src/factory_sim/package.xml
+++ b/src/factory_sim/package.xml
@@ -10,6 +10,7 @@
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
 
   <license>BSD-3-Clause</license>
+  <license file="models/LICENSE">Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
[written by AI]

## Summary

- add `models/LICENSE` (Apache License 2.0, byte-identical to Meta's upstream [facebookresearch/sam2 LICENSE](https://github.com/facebookresearch/sam2/blob/main/LICENSE)) and `models/NOTICE` (Meta attribution) for the three SAM 2.1 ONNX exports in `factory_sim` (Apache 2.0 §4 requires carrying the license text and attribution; the package previously carried only PickNik's BSD-3-Clause LICENSE)
- add a second `<license file="models/LICENSE">Apache-2.0</license>` tag to `factory_sim`'s `package.xml`; PickNik code stays BSD-3-Clause
- document provenance in the README: checkpoint (`sam2.1_hiera_large`), export method (`torch.onnx.export`, PyTorch 2.6.0 per ONNX producer metadata, December 2025), the three-graph split rationale, and SHA-256 checksums pinned to the Git LFS oids

No CMake change: `factory_sim` already installs the whole `models/` directory, so the LICENSE and NOTICE ride along with the models.

## Validation

- `pre-commit run` on all changed files — passed
- `package.xml` parses; second license tag follows REP-149 format 3 (same pattern as the merged PickNikRobotics/moveit_pro_sam3#1)
- verified the checksums in the README match the Git LFS SHA-256 oids of the three models at HEAD
- verified `models/LICENSE` and `models/NOTICE` are stored as regular git files (no LFS filter applies)

## Notes

The export scripts and exact checkpoint revision were not preserved; the README states what the artifacts and git history establish.

Partially addresses PickNikRobotics/moveit_pro#20351 — the `moveit_pro_sam2` repo models are covered by the companion PR PickNikRobotics/moveit_pro_sam2#2; together they complete the issue.
