### PR TITLE
Fix: Air-pick in hangar_sim ML Move Boxes — zero the vacuum grasp TCP offset

### DIFF
--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -206,11 +206,32 @@
             >
               <Decorator ID="Inverter">
                 <Control ID="Sequence">
+                  <!--
+                    `grasp_link` sits exactly at the suction-cup tip plane
+                    (vacuum_urdf.xacro places it at the collision-mesh tip), so
+                    the end-effector-to-TCP offset must be zero: the generated
+                    grasp puts the TCP on the box face, and any positive z here
+                    holds the cup tips that far above the surface. The previous
+                    0.045 offset likely compensated for a low box-top bias in
+                    the pre-SAM3 perception chain; SAM3 reads the top surface
+                    to within a few millimeters, so with 0.045 the cups hovered
+                    45 mm above the box and the vacuum never sealed.
+
+                    Assumptions this zero offset leans on: SAM3's small bias
+                    reads the top HIGH (an under-read would command the cups
+                    into the surface — the approach is a fixed-distance
+                    Cartesian move with no force feedback, absorbed only by
+                    cup compliance in sim), and gripper-box contact stays
+                    collision-legal because the box lives in the octomap,
+                    which SetupMTCSetCollisionRule allows against the gripper.
+                    The reference_frame on this pose is inert — the value is
+                    consumed as a relative end-effector-to-TCP transform.
+                  -->
                   <Action
                     ID="CreatePoseStamped"
                     reference_frame="world"
                     pose_stamped="{ee_to_tcp}"
-                    position_xyz="0;0;0.045"
+                    position_xyz="0;0;0"
                     orientation_xyzw="0;0;0;1"
                   />
                   <Action


### PR DESCRIPTION
[written by AI]

### Problem

`ML Move Boxes to Loading Zone` on Jazzy performs an "air pick": the vacuum gripper hovers a few centimeters above each box, the gripper action reports success without a seal (zero `Activating weld constraint` lines), and the objective loops without ever moving a box.

### Root cause (measured, not inferred)

- `grasp_link` sits **exactly at the suction-cup tip plane**: the cup collision mesh tops out at z = 0.158968 in `vacuum_base` frame and `vacuum_urdf.xacro` places `grasp_link` at z = 0.159.
- `GenerateVacuumGraspPoses` composes each grasp so the **TCP lands on the box face** and the end effector sits `ee_to_tcp` behind it (`grasp_utils.cpp`, `... * tform_flip_around_x * tform_tcp_to_eef`).
- Therefore `ee_to_tcp = 0;0;0.045` commands the cup tips 45 mm above the box — outside the 20 mm `margin`/`gap` on the cup collision geom, so MuJoCo never reports contact and the suction weld never activates.
- Live measurement at hover: cup tips at z ≈ 0.297–0.306 vs box top 0.2499 (gap ≈ 47 mm); the commanded TCP z matched the SAM3-perceived box top (0.2525 vs 0.253) exactly — the pipeline was doing precisely what the offset told it to.

The 0.045 came from #732, which was tuned three days before the SAM3 perception migration (`c4fcf9ef`). SAM3 reads the box top to within +3–9 mm of MuJoCo ground truth, so the offset most likely compensated a low box-top bias in the old CLIPSeg+SAM2 chain and became a pure hover once that bias disappeared.

### Fix

Set `ee_to_tcp` to zero and document the geometry and its assumptions in the objective XML.

### Validation

With this change, `ML Move Boxes to Loading Zone` completes end-to-end on hangar_sim (Jazzy): **7/7 boxes seal** (`Activating weld constraint box_N_suction` for every box including the tilted shelf box), each is released at the place pose (−4.5, 8.4, 0.5), and the objective returns `SUCCEEDED` — verified on both moveit_pro `main` and the PR moveit_pro#20581 branch, with valid 46 Hz joint-state recordings showing zero pirouettes. Requires the JTC terminal-velocity workaround PR (sibling to this one) to execute the approach sub-trajectory.

Note: this objective is CI-skipped (ML perception cannot run headless), so these manual runs are the only end-to-end coverage.

## Release notes

- Bug Fix: Fixed the `ML Move Boxes to Loading Zone` objective in `hangar_sim` picking above the boxes so the vacuum gripper never attached; the gripper now contacts and moves every box.
