### PR TITLE
Fix: Hangar_sim JTC rejects goals with sub-epsilon terminal velocities (workaround pending moveit_pro#20766)

### DIFF
--- a/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
+++ b/src/hangar_sim/config/control/picknik_ur.ros2_control.yaml
@@ -211,6 +211,20 @@ joint_trajectory_controller:
     action_monitor_rate: 20.0
     allow_partial_joints_goal: true
     open_loop_control: false # this is closed loop
+    # Workaround for PickNikRobotics/moveit_pro#20766: trajectory generation
+    # leaves sub-epsilon terminal-velocity residuals that Jazzy's JTC rejects
+    # by default — measured ~1e-4 on `linear_x_joint` from the MTC Cartesian
+    # approach in "ML Move Boxes to Loading Zone", and ~4e-7 from joint
+    # interpolation in "Point-to-Point Trajectory" (previously skipped in
+    # test/objectives_integration_test.py for exactly this rejection).
+    # CAUTION: this flag is binary and controller-wide — it disables the
+    # endpoint-still-moving check for every magnitude on every joint,
+    # including the mecanum base, where a genuinely nonzero terminal velocity
+    # means the base is still translating at trajectory end and then snaps to
+    # a position hold. Acceptable for this sim config; re-evaluate before
+    # copying to real hardware. Remove when moveit_pro#20766 clamps the
+    # residuals at trajectory generation.
+    allow_nonzero_velocity_at_trajectory_end: true
     gains:
       shoulder_pan_joint:
         p: 10.0

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -121,14 +121,6 @@ skip_objectives = {
     # the next objectives plan from a self-colliding start. Skipping removes the
     # timeout flake and its downstream sim-state pollution.
     "Solution - Draw Picknik",
-    # "Point-to-Point Trajectory" interpolates to the "Arm Forward" waypoint on
-    # joint_trajectory_controller, which also owns the mecanum linear_x_joint
-    # (config/control/picknik_ur.ros2_control.yaml). The interpolated terminal
-    # velocity carries a floating-point residual (~3.8e-7) that the controller's
-    # nonzero-terminal-velocity validation intermittently rejects ("Velocity of
-    # last trajectory point of joint linear_x_joint is not zero"). Real
-    # controller/interpolation bug, not a test issue -- skip pending that fix.
-    "Point-to-Point Trajectory",
 }
 
 # Action servers the hangar_sim tree types need before any objective runs.


### PR DESCRIPTION
[written by AI]

### Problem

Jazzy's `joint_trajectory_controller` defaults `allow_nonzero_velocity_at_trajectory_end` to `false`, and trajectory generation leaves sub-epsilon terminal-velocity residuals, so JTC rejects otherwise-valid goals in `hangar_sim`:

- ~1e-4 on `linear_x_joint` from the MTC Cartesian approach in `ML Move Boxes to Loading Zone` (deterministic — blocks every pick).
- ~4e-7 from joint interpolation in `Point-to-Point Trajectory` (intermittent — the reason that objective was skipped in `objectives_integration_test.py`).

### Change

- Set `allow_nonzero_velocity_at_trajectory_end: true` on the hangar_sim JTC, with a comment stating the blast radius plainly: the flag is binary and controller-wide, disabling the endpoint-still-moving check for every magnitude on every joint including the mecanum base. Acceptable for this sim config; flagged for re-evaluation before copying to real hardware.
- Un-skip `Point-to-Point Trajectory` in the integration test — its documented skip cause is exactly this rejection. Validated live: the objective now returns `SUCCEEDED`.

This is a workaround. The real fix is PickNikRobotics/moveit_pro#20766: clamp sub-epsilon terminal velocities at trajectory generation so every consumer receives a well-formed trajectory; this parameter should be removed when that lands.

### Validation

- `Point-to-Point Trajectory`: `SUCCEEDED` on a live hangar_sim stack with this parameter active.
- `ML Move Boxes to Loading Zone`: with this parameter plus the sibling grasp-offset PR, completes 7/7 picks and returns `SUCCEEDED` on both moveit_pro `main` and the moveit_pro#20581 branch.

## Release notes

- Bug Fix: Fixed `hangar_sim` motion goals being rejected by the trajectory controller due to floating-point residual terminal velocities, which blocked `ML Move Boxes to Loading Zone` and intermittently `Point-to-Point Trajectory`.
