### PR TITLE
Fix: Migrate hangar_sim nav2 config to Jazzy and isolate localization

### DIFF
--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -31,9 +31,12 @@ if(BUILD_TESTING)
   # artifact ships them back too. Default would be ~/.ros/log/, which lives
   # on the doomed container filesystem and never gets uploaded -- making
   # post-mortem of objective failures impossible.
+  # 900 s: the suite runs ~7 min on the CI runner, and the surface-following
+  # objectives carry 180 s execute budgets (EXECUTE_TIMEOUT_OVERRIDES_S in the
+  # test) — two worst-case executions alone could exceed the previous 600 s.
   ament_add_pytest_test(
           objectives_integration_test test/objectives_integration_test.py
-          TIMEOUT 600
+          TIMEOUT 900
           ENV MOVEIT_CONFIG_PACKAGE=hangar_sim
               MOVEIT_HOST_USER_WORKSPACE=${CMAKE_SOURCE_DIR}
               ROS_LOG_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_results/${PROJECT_NAME}/ros_logs)

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -207,6 +207,22 @@ def generate_launch_description():
                 remappings=remappings,
                 output="screen",
             ),
+            # Localization (map_server, AMCL, scan merger) runs in its own container so a
+            # crash in any navigation node cannot take localization down with it. The
+            # map -> odom transform AMCL publishes is what connects the MuJoCo scene
+            # frames (cameras under mj_world -> map) to MoveIt's planning frame
+            # (world under odom); if this container dies, every point-cloud-to-world
+            # transform in the product breaks, not just navigation.
+            Node(
+                condition=IfCondition(use_composition),
+                name="localization_container",
+                package="rclcpp_components",
+                executable="component_container_isolated",
+                parameters=[configured_params, {"autostart": autostart}],
+                arguments=["--ros-args", "--log-level", log_level],
+                remappings=remappings,
+                output="screen",
+            ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     os.path.join(launch_dir, "slam_launch.py")
@@ -231,7 +247,7 @@ def generate_launch_description():
                     "use_sim_time": use_sim_time,
                     "autostart": autostart,
                     "params_file": params_file,
-                    "container_name": "nav2_container",
+                    "container_name": "localization_container",
                     "localization": localization,
                 }.items(),
             ),

--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -66,54 +66,12 @@ bt_navigator:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
     # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_assisted_teleop_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_drive_on_heading_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_truncate_path_local_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_path_expiring_timer_condition
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_goal_updated_controller_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-      - nav2_controller_cancel_bt_node
-      - nav2_path_longer_on_approach_bt_node
-      - nav2_wait_cancel_bt_node
-      - nav2_spin_cancel_bt_node
-      - nav2_back_up_cancel_bt_node
-      - nav2_assisted_teleop_cancel_bt_node
-      - nav2_drive_on_heading_cancel_bt_node
-      - nav2_is_battery_charging_condition_bt_node
+    #
+    # Do NOT list the stock nav2 BT plugin libraries in `plugin_lib_names` here. Since
+    # Jazzy, bt_navigator always loads the default nav2 set implicitly and the parameter
+    # is additive, so re-listing them double-registers every node and configure fails
+    # with "ID [ComputePathToPose] already registered". Only custom user libraries
+    # belong in `plugin_lib_names`.
 
 bt_navigator_navigate_through_poses_rclcpp_node:
   ros__parameters:
@@ -385,7 +343,7 @@ planner_server:
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
+      plugin: "nav2_navfn_planner::NavfnPlanner"
       tolerance: 0.5
       use_astar: false
       allow_unknown: true
@@ -407,15 +365,15 @@ behavior_server:
     cycle_frequency: 10.0
     behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
     spin:
-      plugin: "nav2_behaviors/Spin"
+      plugin: "nav2_behaviors::Spin"
     backup:
-      plugin: "nav2_behaviors/BackUp"
+      plugin: "nav2_behaviors::BackUp"
     drive_on_heading:
-      plugin: "nav2_behaviors/DriveOnHeading"
+      plugin: "nav2_behaviors::DriveOnHeading"
     wait:
-      plugin: "nav2_behaviors/Wait"
+      plugin: "nav2_behaviors::Wait"
     assisted_teleop:
-      plugin: "nav2_behaviors/AssistedTeleop"
+      plugin: "nav2_behaviors::AssistedTeleop"
     global_frame: odom
     robot_base_frame: ridgeback_base_link
     transform_tolerance: 0.1

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -42,6 +42,7 @@ from rclpy.qos import qos_profile_sensor_data
 from control_msgs.action import GripperCommand
 from controller_manager_msgs.srv import ListControllers
 from moveit_pro_test_utils.objective_test_fixture import (
+    DEFAULT_OBJECTIVE_WAIT_S,
     EndStateSpec,
     ExecuteObjectiveResource,
     JointTarget,
@@ -121,6 +122,17 @@ skip_objectives = {
     # the next objectives plan from a self-colliding start. Skipping removes the
     # timeout flake and its downstream sim-state pollution.
     "Solution - Draw Picknik",
+}
+
+# Execute-timeout overrides for objectives that legitimately exceed the 90 s
+# default on the CI runner. The surface-following objectives run the full
+# wrist-snap -> raster-generation -> Cartesian-plan pipeline; on the shared CI
+# runner the single-pass variant needs >90 s and the 3-pass variant passed with
+# only ~20 s of headroom. (Before the nav2 TF fix these objectives failed fast
+# at the point-cloud transform ~30 s in, so the default budget never bound.)
+EXECUTE_TIMEOUT_OVERRIDES_S = {
+    "Plan Path Along Surface": 180.0,
+    "Plan Path Along Surface 3 Passes": 180.0,
 }
 
 # Action servers the hangar_sim tree types need before any objective runs.
@@ -421,6 +433,9 @@ def test_all_objectives(
             objective_id,
             should_cancel,
             execute_objective_resource,
+            objective_wait_time=EXECUTE_TIMEOUT_OVERRIDES_S.get(
+                objective_id, DEFAULT_OBJECTIVE_WAIT_S
+            ),
             expected_end_state_by_id=expected_end_state_by_id,
         )
     except AssertionError as e:


### PR DESCRIPTION
[written by AI]

`src/hangar_sim/params/nav2_params.yaml` still used ROS 2 pre-Jazzy pluginlib class names (`pkg/Class`) for `planner_server`'s `GridBased` plugin and all five `behavior_server` plugins. `nav2_navfn_planner` and `nav2_behaviors` renamed their pluginlib class names to `pkg::Class` on Jazzy, so bringup of both servers fails with these old-style names. Fixing the names then exposed two more Jazzy incompatibilities in the same config, both fixed here.

## Changes

1. **Jazzy `::` plugin names** — `planner_server.GridBased`: `nav2_navfn_planner/NavfnPlanner` -> `nav2_navfn_planner::NavfnPlanner`; `behavior_server` `spin`/`backup`/`drive_on_heading`/`wait`/`assisted_teleop` -> `nav2_behaviors::{Spin,BackUp,DriveOnHeading,Wait,AssistedTeleop}`. All 6 verified byte-exact against the upstream `navigation2` `jazzy` pluginlib exports. The slash-form names elsewhere in the workspace (`laser_filters`, MoveIt `sensors_3d.yaml`) are correct as-is — those packages never adopted `::`.
2. **Drop the stock `plugin_lib_names` list from `bt_navigator`** — since Jazzy, `bt_navigator` loads every default nav2 BT plugin library implicitly and the parameter is additive, so re-listing the defaults double-registers every node and configure fails with `ID [ComputePathToPose] already registered` (verified locally in the CI image).
3. **Run localization in its own component container** — `map_server`, AMCL, and the scan merger move from the shared `nav2_container` to a new `localization_container` (`robot_drivers_to_persist_sim.launch.py`, `localization_launch.py` include). AMCL's `map -> odom` transform is what connects the MuJoCo scene frames (cameras under `mj_world -> map`) to MoveIt's planning frame (`world` under `odom`), so localization must not share fate with navigation: a crash in any navigation node previously killed AMCL and the merger with it, breaking every point-cloud-to-world transform in the product, not just navigation.
4. **180 s execute budget for the two surface-following objectives** (`EXECUTE_TIMEOUT_OVERRIDES_S` in the integration test, plus a 600 -> 900 s suite ceiling in `CMakeLists.txt`). With TF fixed these objectives run their full wrist-snap -> raster -> Cartesian-plan pipeline for the first time in CI; the single-pass variant needs more than the 90 s default on the CI runner (the 3-pass variant passed at 68.9 s with little headroom). Before this PR the default budget never bound because the objectives failed fast at the point-cloud transform.

## Why the CI failures happened (root cause of the earlier red runs)

With the plugin names fixed, nav bringup reached `bt_navigator`'s configure step for the first time in this test environment. On the current Jazzy image that step aborts the whole `nav2_container`:

- The image pins and holds `ros-jazzy-behaviortree-cpp=4.7.2-6noble` (PickNik apt farm, moveit_pro `Dockerfile`), while the nav2 1.3.11 binaries installed from the image's pinned ROS snapshot (2026-04-13) are built against behaviortree-cpp **4.9.0**. BT.CPP ships an unversioned soname, so the loader silently binds the 4.9-compiled nav2 BT plugins to the 4.7.2 library.
- gdb on the CI image shows the crash: `bt_navigator on_configure -> BehaviorTreeEngine -> BT_RegisterNodesFromPlugin(libnav2_compute_path_to_pose_action_bt_node.so) -> SIGFPE` at a `div` instruction with a hash value as dividend — an `unordered_map` bucket-count read as 0 through the mismatched `BT::BehaviorTreeFactory` layout. GraphicsMagick's process-wide signal handler (installed by `map_server`'s image loading) then aborts the container.
- The container crash killed AMCL and the scan merger, so `/scan_merged` never flowed, AMCL never published `map -> odom`, and the TF tree stayed split in two (`world`/`odom` vs `map`/`mj_world`/cameras) from bringup onward. The 4 failing objectives (`Plan Path Along Surface` x2, `Take Scene/Wrist Camera Snapshot`) are exactly the ones that transform camera clouds into `world` — hence `Tf has two or more unconnected trees`. Main is green only because the old plugin names aborted the lifecycle bringup *before* `bt_navigator` ever configured.

Change 3 restores localization (and CI green) on the current image. The BT.CPP ABI mismatch itself is a moveit_pro image bug that needs its own fix — `bt_navigator` still crashes the navigation container until the image ships a coherent BT.CPP/nav2 pair, so nav goals remain unavailable on hangar_sim in the meantime.

Verification (local, exact CI image `picknikciuser/moveit-studio:main-jazzy-amd64-cuda13.2-cudnn9`):
- Reproduced the 4 CI failures byte-identically before the fix (69 tests: 4 failed / 51 skipped).
- A `/tf` monitor proved the camera transforms streamed at 60 Hz all session while `map -> odom` and `/scan_merged` had zero traffic — killing the earlier CPU-starvation and TF-cache hypotheses.
- With behaviortree-cpp 4.9.0 temporarily installed (coherent ABI), the SIGFPE disappears and change 2's duplicate-registration failure surfaces, confirming both layers independently.
- Full suite with this PR on the pinned 4.7.2 image: 18 passed / 51 skipped / 0 failed.
- First CI run of the fix (before change 4): `take_snap`, `wrist_snap`, and `Plan Path Along Surface 3 Passes` all pass; per-test timings for every other test are byte-identical to the pre-fix runs, and `Plan Path Along Surface` hit the 90 s execute-timeout on both attempts while doing legitimate surface planning — hence the budget increase, not a code change.

**Do not backport**: the `::` form is Jazzy-and-newer. On Humble-based release lines the slash form is the correct one, and applying this change there would break bringup in the mirror image of #20767.

Fixes PickNikRobotics/moveit_pro#20767
