### PR TITLE
Fix: Migrate suction margin/gap for MuJoCo 3.9 contact semantics

### DIFF
--- a/src/factory_sim/description/inspection_tool.xml
+++ b/src/factory_sim/description/inspection_tool.xml
@@ -21,7 +21,7 @@
           type="cylinder"
           size="0.01 0.015"
           pos="0 0 0.015"
-          margin="0.01"
+          margin="0"
           gap="0.01"
           rgba="0 0 1 1"
         />

--- a/src/factory_sim/description/suction_tool.xml
+++ b/src/factory_sim/description/suction_tool.xml
@@ -21,7 +21,7 @@
           type="cylinder"
           size="0.01 0.03"
           pos="0 0 0.03"
-          margin="0.01"
+          margin="0"
           gap="0.01"
           rgba=".1 .1 .1 1"
         />
@@ -30,7 +30,7 @@
             class="collision"
             type="cylinder"
             size="0.01 0.005"
-            margin="0.01"
+            margin="0"
             gap="0.01"
           />
           <site name="suction_cup_tool_tip" />

--- a/src/hangar_sim/description/vacuum.xml
+++ b/src/hangar_sim/description/vacuum.xml
@@ -36,7 +36,7 @@
         type="mesh"
         name="collision_vacuum_suction_cups geom"
         mesh="collision_vacuum_suction_cups"
-        margin="0.02"
+        margin="0"
         gap="0.02"
       />
       <site name="suction_cup" type="box" size="0.1 0.1 0.1" />

--- a/src/picknik_accessories/mujoco_assets/lrmate200id/lrmate200id.xml
+++ b/src/picknik_accessories/mujoco_assets/lrmate200id/lrmate200id.xml
@@ -90,7 +90,7 @@
                     type="box"
                     size="0.01 0.01 0.001"
                     pos="0 0 -0.001"
-                    margin="0.02"
+                    margin="0"
                     gap="0.02"
                   />
                   <site


### PR DESCRIPTION
## Motivation

MuJoCo 3.9 redesigned the contact `margin` and `gap` geom attributes, and every suction site here still uses the pre-3.9 idiom. PickNikRobotics/moveit_pro#22404 takes the bundled runtime to 3.13.0, past that change.

## Brief description

Detection moved from `dist < margin` to `dist < margin + gap`, and force from `dist < margin - gap` to `dist < margin`. All five sites use `margin == gap`, the idiom for sensing a part without pushing it away, which under the new semantics generates force from a full margin out.

Applies the upstream migration `margin_new = margin_old - gap_old`, zero at every site, with `gap` unchanged. `factory_sim`'s `override="enable"` forces every margin to `o_margin`, so its edits are inert there; kept for consistency.

## Merge order

- [ ] PickNikRobotics/moveit_pro#22404 merged first

Correct only against the 3.13.0 runtime that PR brings in. Under the 3.6 shipping today this reads as detection at `0`, so cups stop sensing parts until they interpenetrate.

## How it was tested

Separation sweep against a multi-geom target, stepping 10 µm, reading the outermost separation that registers a contact and the outermost that registers a force-generating one. Single-geom pairs skip MuJoCo's midphase, so the target carries five geoms.

| runtime | margin | gap | detection | force |
| --- | --- | --- | --- | --- |
| 3.6.0, shipping today | 10 mm | 10 mm | 9.99 mm | penetration only |
| 3.13.0, this PR | 0 | 10 mm | 9.99 mm | penetration only |
| 3.13.0, unmigrated | 10 mm | 10 mm | 19.99 mm | 9.99 mm |
| 3.6.0, shipping today | 20 mm | 20 mm | 19.99 mm | penetration only |
| 3.13.0, this PR | 0 | 20 mm | 19.99 mm | penetration only |
| 3.13.0, unmigrated | 20 mm | 20 mm | 39.99 mm | 19.99 mm |

3.13.0 with these edits reproduces 3.6.0 exactly at both site sizes. Without them the cup generates force from a full margin out, which is the suction cup pushing the part away before it touches.

Every scene in the affected packages that loads standalone compiles on 3.13.0: `factory_sim/description/scene.xml` (179 geoms), `hangar_sim/description/hangar_scene.xml` (306), and `hangar_sim/description/ur5e_ridgeback.xml` (76). `hangar_sim/description/hangar.xml` is an include fragment and does not load standalone on 3.6.0 either. All five migrated geoms compile to `margin = 0` with `gap` intact, detection at `gap` and force at contact.

The 3.10 pairing also needed a `body_margin` workaround alongside these edits: MuJoCo 3.9 and 3.10 compute `body_margin` without gap, culling multi-geom bodies at the midphase before the leaves that would detect them, which is the shape every site here migrates to. Measured on 3.10 these geoms give `body_margin = 0` and detection collapses to contact. Upstream folded gap into `body_margin` in 3.11.0, so on 3.13 every migrated body reports `body_margin = margin + gap` and no workaround is needed.

## Release notes

None. The user-facing migration guidance ships with PickNikRobotics/moveit_pro#22404.
