### PR TITLE
Rename cartesian_planning references to path_ik

### DIFF
--- a/src/example_behaviors/CMakeLists.txt
+++ b/src/example_behaviors/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(moveit_pro_package REQUIRED)
 find_package(example_interfaces REQUIRED)
 moveit_pro_package()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS cartesian_planning moveit_pro_behavior
+set(THIS_PACKAGE_INCLUDE_DEPENDS path_ik moveit_pro_behavior
   moveit_pro_behavior_interface pluginlib moveit_studio_vision
   moveit_studio_vision_msgs PCL pcl_conversions pcl_ros example_interfaces)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
+++ b/src/example_behaviors/include/example_behaviors/example_convert_mtc_solution_to_joint_trajectory.hpp
@@ -5,13 +5,13 @@
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 #include <Eigen/Core>
-#include <cartesian_planning/trajectory_utils.hpp>
 #include <moveit/robot_model_loader/robot_model_loader.hpp>
 #include <moveit_msgs/msg/robot_trajectory.hpp>
 #include <moveit_pro_behavior_interface/behavior_context.hpp>
 #include <moveit_pro_behavior_interface/check_for_error.hpp>
 #include <moveit_pro_behavior_interface/shared_resources_node.hpp>
 #include <moveit_task_constructor_msgs/msg/solution.hpp>
+#include <path_ik/trajectory_utils.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 namespace example_behaviors

--- a/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
+++ b/src/example_behaviors/src/example_convert_mtc_solution_to_joint_trajectory.cpp
@@ -91,8 +91,8 @@ BT::NodeStatus ExampleConvertMtcSolutionToJointTrajectory::tick()
 
   // Use trajectory_utils.hpp to create a trajectory
   auto trajectory_result =
-      cartesian_planning::createTrajectoryFromWaypoints(*joint_model_group, waypoints, velocity_scaling_factor.value(),
-                                                        acceleration_scaling_factor.value(), sampling_rate.value());
+      path_ik::createTrajectoryFromWaypoints(*joint_model_group, waypoints, velocity_scaling_factor.value(),
+                                             acceleration_scaling_factor.value(), sampling_rate.value());
 
   if (!trajectory_result)
   {


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#20818

Paired with PickNikRobotics/moveit_pro#20818, which renames `cartesian_planning` to `path_ik` in 10.0.0. Updates the three references in `example_behaviors` to match. The package is dormant (checked-in `COLCON_IGNORE`, not built by CI), so this just keeps its sources accurate for whoever revives it.
