### PR TITLE
Adopt UnpackRobotStateMessage in lab_sim/factory_sim objectives

### DIFF
--- a/src/factory_sim/objectives/inspect_convex_bowl.xml
+++ b/src/factory_sim/objectives/inspect_convex_bowl.xml
@@ -24,10 +24,10 @@
           waypoint_name="View Convex"
         />
         <Action
-          ID="UnpackRobotJointStateMessage"
+          ID="UnpackRobotStateMessage"
           joint_state="{joint_state}"
           multi_dof_joint_state="{multi_dof_joint_state}"
-          robot_joint_state="{target_joint_state}"
+          robot_state="{target_joint_state}"
         />
         <Action
           ID="GetCurrentPlanningScene"

--- a/src/lab_sim/objectives/computelinkposefromwaypoint.xml
+++ b/src/lab_sim/objectives/computelinkposefromwaypoint.xml
@@ -14,10 +14,10 @@
         waypoint_name="MPC Pose Tracking"
       />
       <Action
-        ID="UnpackRobotJointStateMessage"
+        ID="UnpackRobotStateMessage"
         joint_state="{joint_state}"
         multi_dof_joint_state="{multi_dof_joint_state}"
-        robot_joint_state="{target_joint_state}"
+        robot_state="{target_joint_state}"
       />
       <Action
         ID="GetCurrentPlanningScene"

--- a/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
+++ b/src/lab_sim/objectives/constrained_pick_and_place_subtree.xml
@@ -24,10 +24,10 @@
           waypoint_name="{pick}"
         />
         <Action
-          ID="UnpackRobotJointStateMessage"
+          ID="UnpackRobotStateMessage"
           joint_state="{pick_joint_state_msg}"
           multi_dof_joint_state="{pick_multi_dof}"
-          robot_joint_state="{pick_joint_state}"
+          robot_state="{pick_joint_state}"
         />
         <Action
           ID="ComputeLinkPoseForwardKinematics"
@@ -53,10 +53,10 @@
           waypoint_name="{place}"
         />
         <Action
-          ID="UnpackRobotJointStateMessage"
+          ID="UnpackRobotStateMessage"
           joint_state="{place_joint_state_msg}"
           multi_dof_joint_state="{place_multi_dof}"
-          robot_joint_state="{place_joint_state}"
+          robot_state="{place_joint_state}"
         />
         <Action
           ID="ComputeLinkPoseForwardKinematics"


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#20889

## Problem

moveit_pro PR PickNikRobotics/moveit_pro#20889 retires the `moveit_studio_agent_msgs/RobotJointState` message and its auto-generated converter Behavior `UnpackRobotJointStateMessage`, replacing them with the standard `moveit_msgs/RobotState` and `UnpackRobotStateMessage`. The message port on the converter also renames `robot_joint_state` → `robot_state`.

Objectives in `lab_sim` and `factory_sim` still referenced the retired `UnpackRobotJointStateMessage`, so they failed to register against a moveit_pro build that includes #20889:

```
Error registering Objective ... constrained_pick_and_place_subtree.xml: Node not recognized: UnpackRobotJointStateMessage
Error registering Objective ... computelinkposefromwaypoint.xml:      Node not recognized: UnpackRobotJointStateMessage
```

That broke the `Move Flasks to Burners` objective, which includes the `Constrained Pick and Place Subtree`.

## Change

Rename the converter Behavior and its message port in the affected objectives:

- `UnpackRobotJointStateMessage` → `UnpackRobotStateMessage`
- port `robot_joint_state="..."` → `robot_state="..."`

The field ports (`joint_state`, `multi_dof_joint_state`) are unchanged, since `moveit_msgs/RobotState` is a superset of the retired message.

Files:
- `lab_sim/objectives/constrained_pick_and_place_subtree.xml`
- `lab_sim/objectives/computelinkposefromwaypoint.xml`
- `factory_sim/objectives/inspect_convex_bowl.xml`

## Dependency

The `needs: moveit_pro/#20889` line above ties this PR's CI to that moveit_pro run.

**Depends on PickNikRobotics/moveit_pro#20889.** `UnpackRobotStateMessage` only exists once #20889 is merged (and shipped in the base image this repo builds against), so CI here will fail until that lands. Merge after #20889.