### PR TITLE
Migrate example configs to MoveIt Pro 10.0 hardware schema

### DIFF
--- a/src/dual_arm_sim/config/config.yaml
+++ b/src/dual_arm_sim/config/config.yaml
@@ -7,11 +7,6 @@
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware using the same configuration.
-  # [Required]
-  simulated: True
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -35,9 +30,6 @@ hardware:
       - mujoco_keyframe: "default"
       - mujoco_model: "description/mujoco/scene.xml"
       - mujoco_viewer: false
-    simulated_hardware_launch_file:
-      package: "moveit_studio_agent"
-      path: "launch/blank.launch.py"
 
 # Configuration files for MoveIt.
 # For more information, refer to https://moveit.picknik.ai/main/doc/how_to_guides/moveit_configuration/moveit_configuration_tutorial.html

--- a/src/factory_sim/config/config.yaml
+++ b/src/factory_sim/config/config.yaml
@@ -7,16 +7,6 @@
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware by changing a single parameter with config inheritance.
-  # [Required]
-  simulated: true
-  # If simulated is false, launch the following file:
-  # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "moveit_studio_agent"
-    path: "launch/blank.launch.py"
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True

--- a/src/grinding_sim/config/config.yaml
+++ b/src/grinding_sim/config/config.yaml
@@ -7,16 +7,6 @@
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware by changing a single parameter with config inheritance.
-  # [Required]
-  simulated: true
-  # If simulated is false, launch the following file:
-  # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "moveit_studio_agent"
-    path: "launch/blank.launch.py"
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True

--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -28,10 +28,9 @@ hardware:
       # Rebuild hangar_sim after changing this value.
       - publish_odom: true
 
-  # Specify any additional launch files for running the robot in simulation mode.
-  # Used when hardware.simulated is True.
+  # Additional launch file included with the persistent driver process (Nav2 sim drivers).
   # [Optional, defaults to a blank launch file if not specified]
-  simulated_robot_driver_persist_launch_file:
+  additional_driver_launch_file:
     package: "hangar_sim"
     path: "launch/sim/robot_drivers_to_persist_sim.launch.py"
 

--- a/src/kitchen_sim/config/config.yaml
+++ b/src/kitchen_sim/config/config.yaml
@@ -8,11 +8,6 @@ based_on_package: "franka_base_config"
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware using the same configuration.
-  # [Required]
-  simulated: True
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -36,9 +31,6 @@ hardware:
       - mujoco_keyframe: "default"
       - mujoco_model: "description/mujoco/scene.xml"
       - mujoco_viewer: false
-    simulated_hardware_launch_file:
-      package: "moveit_studio_agent"
-      path: "launch/blank.launch.py"
 
 # Configuration for loading behaviors and objectives.
 # [Required]

--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/config/config.yaml
@@ -5,11 +5,6 @@
 ###############################################################
 
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware using the same configuration.
-  # [Required]
-  simulated: True
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -19,21 +14,12 @@ hardware:
   # [Optional, default=True]
   launch_robot_state_publisher: True
 
-  # Specify additional launch files for running the robot with real hardware.
+  # Additional launch file included with the persistent driver process. This base
+  # config ships the simulated drivers; a real-hardware child overrides this key.
   # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "kinova_gen3_base_config"
-    path: "launch/robot_drivers_to_persist.launch.py"
-
-  # Specify any additional launch files for running the robot in simulation mode.
-  # Used when hardware.simulated is True.
-  # [Optional, defaults to a blank launch file if not specified]
-  simulated_robot_driver_persist_launch_file:
+  additional_driver_launch_file:
     package: "kinova_gen3_base_config"
     path: "launch/sim/robot_drivers_to_persist_sim.launch.py"
-  simulated_hardware_launch_file:
-    package: "moveit_studio_agent"
-    path: "launch/blank.launch.py"
 
   # These Params are pasted to the XACRO to create the URDF
   robot_description:

--- a/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_site_config/config/config.yaml
@@ -6,7 +6,11 @@
 based_on_package: "kinova_gen3_base_config"
 
 hardware:
-  simulated: False
+  # Real-hardware drivers. Overrides the base config's simulated default
+  # (additional_driver_launch_file is always included).
+  additional_driver_launch_file:
+    package: "kinova_gen3_base_config"
+    path: "launch/robot_drivers_to_persist.launch.py"
   robot_description:
     urdf:
       package: "kinova_gen3_site_config"

--- a/src/moveit_pro_kinova_configs/kinova_sim/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/config/config.yaml
@@ -7,11 +7,6 @@
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware using the same configuration.
-  # [Required]
-  simulated: True
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -21,21 +16,6 @@ hardware:
   # [Optional, default=True]
   launch_robot_state_publisher: True
 
-  # Specify additional launch files for running the robot with real hardware.
-  # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "kinova_sim"
-    path: "launch/robot_drivers_to_persist.launch.py"
-
-  # Specify any additional launch files for running the robot in simulation mode.
-  # Used when hardware.simulated is True.
-  # [Optional, defaults to a blank launch file if not specified]
-#  simulated_robot_driver_persist_launch_file:
-#    package: "kinova_sim"
-#    path: "launch/sim/robot_drivers_to_persist_sim.launch.py"
-#  simulated_hardware_launch_file:
-#    package: "moveit_studio_agent"
-#    path: "launch/blank.launch.py"
 
   # Parameters used to configure the robot description through XACRO.
   # A URDF and SRDF are both required.
@@ -56,7 +36,7 @@ hardware:
       - dof: "7"
       - vision: "false"
       - gripper: "robotiq_2f_85"
-      - use_fake_hardware: "%>> hardware.simulated"
+      - use_fake_hardware: "true"
       - fake_sensor_commands: "false"
       - external_camera: "true"
       - wrist_realsense: "true"

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/config/config.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/config/config.yaml
@@ -10,11 +10,10 @@ based_on_package: kinova_sim
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Launched by the main agent when `simulated: True`. Hosts the AprilTag
-  # detectors and the fuse state estimator so /odom_filtered is published in
-  # dev — not just in prod / e2e where `runtime.launch.xml` runs
-  # standalone.
-  simulated_hardware_launch_file:
+  # Included with the main agent process. Hosts the AprilTag detectors and the
+  # fuse state estimator so /odom_filtered is published in dev — not just in
+  # prod / e2e where `agent_bridge.launch.xml` runs standalone.
+  additional_agent_launch_file:
     package: "space_satellite_sim"
     path: "launch/simulated_extras.launch.xml"
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/launch/simulated_extras.launch.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/launch/simulated_extras.launch.xml
@@ -1,6 +1,6 @@
 <launch>
-  <!--Sim-only extras launched by the agent via the
-      `hardware.simulated_hardware_launch_file` key in config.yaml. The agent's
+  <!--Extras launched with the agent via the
+      `hardware.additional_agent_launch_file` key in config.yaml. The agent's
       `agent_launch_setup` function picks this up in both dev
       (`agent_robot.app`) and prod / e2e (`runtime.launch.xml`), so a
       single config key drives both paths.-->

--- a/src/moveit_pro_ur_configs/mock_sim/config/config.yaml
+++ b/src/moveit_pro_ur_configs/mock_sim/config/config.yaml
@@ -1,8 +1,6 @@
 based_on_package: "picknik_ur_base_config"
 
 hardware:
-  simulated: True
-
   # Update robot description for machine tending world.
   robot_description:
     urdf:

--- a/src/moveit_pro_ur_configs/multi_arm_sim/config/config.yaml
+++ b/src/moveit_pro_ur_configs/multi_arm_sim/config/config.yaml
@@ -2,11 +2,6 @@
 # [Required]
 hardware:
 
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware by changing a single parameter with config inheritance.
-  # [Required]
-  simulated: true
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -16,16 +11,9 @@ hardware:
   # [Optional, default=True]
   launch_robot_state_publisher: True
 
-  # Specify additional launch files for running the robot with real hardware.
+  # Additional launch file included with the persistent driver process.
   # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "picknik_ur_base_config"
-    path: "launch/robot_drivers_to_persist.launch.py"
-
-  # Specify any additional launch files for running the robot in simulation mode.
-  # Used when hardware.simulated is True.
-  # [Optional, defaults to a blank launch file if not specified]
-  simulated_robot_driver_persist_launch_file:
+  additional_driver_launch_file:
     package: "picknik_ur_base_config"
     path: "launch/sim/robot_drivers_to_persist_sim.launch.py"
 

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/config/config.yaml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/config/config.yaml
@@ -7,11 +7,6 @@
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:
-  # Set simulated to false if you are using this as a configuration for real hardware.
-  # This allows users to switch between mock and real hardware by changing a single parameter with config inheritance.
-  # [Required]
-  simulated: true
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -21,21 +16,14 @@ hardware:
   # [Optional, default=True]
   launch_robot_state_publisher: True
 
-  # Specify additional launch files for running the robot with real hardware.
+  # Additional launch file included with the persistent driver process (the process
+  # that stays up across Agent restarts and runs in `--only-drivers` mode). Always
+  # included. This base config ships the simulated drivers; override this key in a
+  # real-hardware config to point at your driver bringup instead.
   # [Optional, defaults to a blank launch file if not specified]
-  robot_driver_persist_launch_file:
-    package: "picknik_ur_base_config"
-    path: "launch/robot_drivers_to_persist.launch.py"
-
-  # Specify any additional launch files for running the robot in simulation mode.
-  # Used when hardware.simulated is True.
-  # [Optional, defaults to a blank launch file if not specified]
-  simulated_robot_driver_persist_launch_file:
+  additional_driver_launch_file:
     package: "picknik_ur_base_config"
     path: "launch/sim/robot_drivers_to_persist_sim.launch.py"
-  simulated_hardware_launch_file:
-    package: "moveit_studio_agent"
-    path: "launch/blank.launch.py"
 
   # Parameters used to configure the robot description through XACRO.
   # A URDF and SRDF are both required.


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#20990

## Motivation

Pairs with PickNikRobotics/moveit_pro#20990, the MoveIt Pro 10.0 breaking change that removes the `simulated`, `robot_driver_persist_launch_file`, `simulated_robot_driver_persist_launch_file`, and `simulated_hardware_launch_file` keys from the `config.yaml` `hardware` section. Every example config must migrate or it fails to load under the new schema.

## Brief description

Migrates all 13 robot configs to the two consolidated, always-included keys — `additional_driver_launch_file` and `additional_agent_launch_file`:

- Sim configs: rename the sim driver/agent keys; drop `simulated` and any blank-default key.
- Switch case: `kinova_gen3_base_config` defaults `additional_driver_launch_file` to the sim driver (keeps the sim examples working); the real-hardware child `kinova_gen3_site_config` overrides it to the real driver.
- `kinova_sim`: replaces a `%>> hardware.simulated` template reference in `urdf_params` with the literal `use_fake_hardware: "true"` (the removed key can no longer be referenced), and drops its dormant real driver.
- Updates a stale doc-comment in `space_satellite_sim`'s launch XML.
- Bumps the `phoebe_ws` submodule to its migrated commit (PickNikRobotics/phoebe_ws#33).

## How it was tested

Brought up `lab_sim` and `kinova_sim` from these migrated configs against the paired moveit_pro branch in an isolated dev stack; both reached `You can start planning now!` with the new keys resolving correctly. A repo-wide grep confirms no removed key or `hardware.simulated` reference remains.

## Merge order

Merge PickNikRobotics/phoebe_ws#33 (into `for-example-ws-no-dups`) and PickNikRobotics/moveit_pro#20990 before this PR.
