### PR TITLE
Add forward stereo camera to hangar_sim for VO/VSLAM input

### DIFF
--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -18,6 +18,7 @@ install(
 )
 
 install(PROGRAMS
+  script/forward_stereo_publisher.py
   script/odometry_joint_state_publisher.py
   script/odom_qos_relay.py
   DESTINATION lib/${PROJECT_NAME}
@@ -27,6 +28,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          forward_stereo_calibration_test test/test_forward_stereo_calibration.py
+          TIMEOUT 30)
+  ament_add_pytest_test(
+          forward_stereo_publisher_test test/test_forward_stereo_publisher.py
+          TIMEOUT 60)
   # Redirect ROS node logs into the test_results tree so the test-results CI
   # artifact ships them back too. Default would be ~/.ros/log/, which lives
   # on the doomed container filesystem and never gets uploaded -- making

--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -13,6 +13,19 @@
       <sensor name="lidar_rear">
         <param name="topic">/scan_rear</param>
       </sensor>
+      <!-- Move the plugin's per-camera monocular camera_info off the ROS sibling
+           name of the stereo source images. That info carries the same K and
+           frame_id as the stereo contract but P[3]=0, so a consumer resolving
+           camera_info as the sibling of /forward_stereo_right/color would read a
+           zero baseline and infer infinite depth from finite disparity, with
+           nothing to flag the mistake. The calibrated stereo contract is
+           published by forward_stereo_publisher on /forward_stereo/{left,right}/. -->
+      <sensor name="forward_stereo_left">
+        <param name="camera_info_topic">/forward_stereo_left/monocular_camera_info</param>
+      </sensor>
+      <sensor name="forward_stereo_right">
+        <param name="camera_info_topic">/forward_stereo_right/monocular_camera_info</param>
+      </sensor>
       <hardware>
           <plugin>picknik_mujoco_ros/MujocoSystem</plugin>
           <param name="mujoco_model">${mujoco_model}</param>

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -3,7 +3,9 @@
 
   <option integrator="implicitfast" />
 
-  <size nuser_sensor="6" />
+  <!-- Camera user parameter 0 selects the picknik_mujoco_ros depth type:
+       0=RGB_DEPTH, 1=RGB_ONLY, 2=THREE_D_LIDAR. -->
+  <size nuser_sensor="6" nuser_cam="1" />
 
   <default>
     <default class="ur5e">
@@ -215,6 +217,102 @@
       />
       <body name="base_platform" pos="0 0 0" euler="0 0 0">
         <body name="ridgeback_base_link">
+          <!-- Calibrated forward stereo input for downstream VO/VSLAM evaluation.
+               This model publishes camera input only; it does not launch a VO/VSLAM
+               implementation, evaluation harness, or benchmark Objective.
+               Base axes are +X forward, +Y left, +Z up. MuJoCo cameras look
+               along local -Z with local +Y up, while the sites encode ROS
+               optical axes (+Z forward, +X right, +Y down). The optical
+               centers are coplanar and separated by the OAK-D Pro's nominal
+               0.075 m stereo baseline. -->
+          <camera
+            name="forward_stereo_left"
+            pos="0.45 0.0375 0.55"
+            fovy="50.53401584672457"
+            mode="fixed"
+            resolution="1280 720"
+            user="1"
+            xyaxes="0 -1 0 0 0 1"
+          />
+          <site
+            name="forward_stereo_left_optical_frame"
+            pos="0.45 0.0375 0.55"
+            xyaxes="0 -1 0 0 0 -1"
+          />
+          <camera
+            name="forward_stereo_right"
+            pos="0.45 -0.0375 0.55"
+            fovy="50.53401584672457"
+            mode="fixed"
+            resolution="1280 720"
+            user="1"
+            xyaxes="0 -1 0 0 0 1"
+          />
+          <site
+            name="forward_stereo_right_optical_frame"
+            pos="0.45 -0.0375 0.55"
+            xyaxes="0 -1 0 0 0 -1"
+          />
+          <!-- Forward stereo mount: visual-only sensor bar (Husky-style) so the
+               pair is visible in the sim. Non-colliding like the SICK lidar
+               geoms below, so it cannot introduce arm interference; the optical
+               centers above are unchanged.
+               The cameras look along base +X, so every geom here stays behind
+               x=0.45 (the optical plane) or below it: group 2 is rendered by
+               MuJoCo's offscreen pass, so geometry in front of the optical
+               center would occlude the stereo images. A regression test pins
+               that margin (test_forward_stereo_calibration.py).
+               contype/conaffinity remove these from contact dynamics but not
+               from mj_ray, which the rangefinder lidars use; what keeps them
+               out of the front scan is height: the mast's lower cap sits at
+               z=0.30, clear of the z=0.15 scan plane.
+               mass="0" keeps this decorative: ridgeback_base_link declares no
+               <inertial>, so MuJoCo would otherwise infer added mass and shift
+               the base COM from these geoms' default density. -->
+          <geom
+            name="forward_stereo_mast"
+            type="cylinder"
+            fromto="0.41 0 0.30 0.41 0 0.55"
+            size="0.02"
+            mass="0"
+            rgba="0.15 0.15 0.15 1"
+            contype="0"
+            conaffinity="0"
+            group="2"
+          />
+          <geom
+            name="forward_stereo_bar"
+            type="box"
+            size="0.02 0.075 0.02"
+            pos="0.41 0 0.55"
+            mass="0"
+            rgba="0.15 0.15 0.15 1"
+            contype="0"
+            conaffinity="0"
+            group="2"
+          />
+          <geom
+            name="forward_stereo_left_lens"
+            type="cylinder"
+            fromto="0.40 0.0375 0.55 0.44 0.0375 0.55"
+            size="0.012"
+            mass="0"
+            rgba="0.05 0.05 0.05 1"
+            contype="0"
+            conaffinity="0"
+            group="2"
+          />
+          <geom
+            name="forward_stereo_right_lens"
+            type="cylinder"
+            fromto="0.40 -0.0375 0.55 0.44 -0.0375 0.55"
+            size="0.012"
+            mass="0"
+            rgba="0.05 0.05 0.05 1"
+            contype="0"
+            conaffinity="0"
+            group="2"
+          />
           <!-- Front SICK TIM571: mounted at x=+0.45m (front bumper), z=0.15m.
                91 beams x 3 deg = 270 deg FOV, sweeping CCW from beam-0 at -135 deg in robot frame.
                Quat rule: site Z axis = beam-0 firing direction. Site X axis must point in world -Z

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -337,6 +337,17 @@ def generate_launch_description():
 
     hangar_sim_pkg = FindPackageShare("hangar_sim")
 
+    forward_stereo_publisher = Node(
+        package="hangar_sim",
+        executable="forward_stereo_publisher.py",
+        name="forward_stereo_publisher",
+        parameters=[
+            PathJoinSubstitution([hangar_sim_pkg, "params", "forward_stereo.yaml"]),
+            {"use_sim_time": use_sim_time},
+        ],
+        output="log",
+    )
+
     # Angular bounds filter: clips chassis self-hitting beams (±93° to ±135°).
     # One filter instance per lidar; each publishes its filtered scan to
     # /scan_{front,rear}_filtered for Nav2 to consume as an independent
@@ -421,6 +432,7 @@ def generate_launch_description():
     ld.add_action(static_tf_odom_to_world)
     ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
+    ld.add_action(forward_stereo_publisher)
     ld.add_action(laser_filter_front_node)
     ld.add_action(laser_filter_rear_node)
     ld.add_action(fuse_state_estimator)

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -27,10 +27,14 @@
   <exec_depend>picknik_accessories</exec_depend>
   <exec_depend>picknik_mujoco_ros</exec_depend>
   <exec_depend>picknik_ur_base_config</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>ridgeback_description</exec_depend>
   <exec_depend>robotiq_description</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
@@ -38,6 +42,7 @@
   <exec_depend>moveit_pro_sam3</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>
@@ -47,6 +52,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>rcl_interfaces</test_depend>
+  <test_depend>python3-yaml</test_depend>
   <test_depend>control_msgs</test_depend>
   <test_depend>tf2_ros</test_depend>
 

--- a/src/hangar_sim/params/forward_stereo.yaml
+++ b/src/hangar_sim/params/forward_stereo.yaml
@@ -1,0 +1,16 @@
+forward_stereo_publisher:
+  ros__parameters:
+    # OAK-D Pro-compatible center-cropped OV9282 stereo profile. The real
+    # camera should use the same 1280x720 @ 20 Hz profile for parity captures.
+    width: 1280
+    height: 720
+    vertical_fov_degrees: 50.53401584672457
+    baseline_m: 0.075
+    left_frame_id: "forward_stereo_left_optical_frame"
+    right_frame_id: "forward_stereo_right_optical_frame"
+    left_source_topic: "/forward_stereo_left/color"
+    right_source_topic: "/forward_stereo_right/color"
+    left_image_topic: "/forward_stereo/left/image_rect"
+    right_image_topic: "/forward_stereo/right/image_rect"
+    left_camera_info_topic: "/forward_stereo/left/camera_info"
+    right_camera_info_topic: "/forward_stereo/right/camera_info"

--- a/src/hangar_sim/script/forward_stereo_publisher.py
+++ b/src/hangar_sim/script/forward_stereo_publisher.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Publish a synchronized, calibrated stereo contract for ideal MuJoCo cameras."""
+
+import math
+import threading
+
+import cv2
+import numpy as np
+import rclpy
+from rclpy.clock import JumpThreshold
+from rclpy.duration import Duration
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CameraInfo, Image
+
+
+class ForwardStereoPublisher(Node):
+    """Pair ideal rendered images by timestamp and publish stereo calibration."""
+
+    def __init__(self, parameter_overrides=None):
+        super().__init__(
+            "forward_stereo_publisher", parameter_overrides=parameter_overrides
+        )
+
+        # One thread: the per-frame convert is well under a millisecond, so
+        # OpenCV's thread pool would only add scheduling overhead and contend
+        # with MuJoCo's stepping threads on the same host. This setting is
+        # process-global rather than per-node, which is safe while this runs as
+        # its own process; revisit if it is ever composed into a shared
+        # container alongside another OpenCV user.
+        cv2.setNumThreads(1)
+
+        self.width = self.declare_parameter("width", 1280).value
+        self.height = self.declare_parameter("height", 720).value
+        vertical_fov_degrees = self.declare_parameter(
+            "vertical_fov_degrees", 50.53401584672457
+        ).value
+        self.baseline_m = self.declare_parameter("baseline_m", 0.075).value
+        self.left_frame_id = self.declare_parameter(
+            "left_frame_id", "forward_stereo_left_optical_frame"
+        ).value
+        self.right_frame_id = self.declare_parameter(
+            "right_frame_id", "forward_stereo_right_optical_frame"
+        ).value
+        left_source_topic = self.declare_parameter(
+            "left_source_topic", "/forward_stereo_left/color"
+        ).value
+        right_source_topic = self.declare_parameter(
+            "right_source_topic", "/forward_stereo_right/color"
+        ).value
+        left_image_topic = self.declare_parameter(
+            "left_image_topic", "/forward_stereo/left/image_rect"
+        ).value
+        right_image_topic = self.declare_parameter(
+            "right_image_topic", "/forward_stereo/right/image_rect"
+        ).value
+        left_info_topic = self.declare_parameter(
+            "left_camera_info_topic", "/forward_stereo/left/camera_info"
+        ).value
+        right_info_topic = self.declare_parameter(
+            "right_camera_info_topic", "/forward_stereo/right/camera_info"
+        ).value
+
+        # Reject bad calibration at construction: downstream VO/VSLAM consumers
+        # treat the published camera_info as ground truth, so a silently
+        # degenerate intrinsic matrix is worse than a node that fails to start.
+        self.validate_calibration(
+            self.width, self.height, vertical_fov_degrees, self.baseline_m
+        )
+
+        self.focal_length_px = self.height / (
+            2.0 * math.tan(math.radians(vertical_fov_degrees) / 2.0)
+        )
+        self.principal_x_px = self.width / 2.0
+        self.principal_y_px = self.height / 2.0
+        self.queue_depth = 5
+        self.left_images = {}
+        self.right_images = {}
+        self.latest_source_stamp = None
+        self.pairing_lock = threading.Lock()
+        self.reported_bad_dimensions = False
+        self.reported_bad_encoding = False
+        self.reported_bad_buffer_size = False
+
+        self.clock_jump_callback = self.get_clock().create_jump_callback(
+            JumpThreshold(
+                min_forward=None,
+                min_backward=Duration(nanoseconds=-1),
+                on_clock_change=True,
+            ),
+            post_callback=self.reset_pairing_buffers,
+        )
+
+        self.left_image_publisher = self.create_publisher(
+            Image, left_image_topic, qos_profile_sensor_data
+        )
+        self.right_image_publisher = self.create_publisher(
+            Image, right_image_topic, qos_profile_sensor_data
+        )
+        self.left_info_publisher = self.create_publisher(
+            CameraInfo, left_info_topic, qos_profile_sensor_data
+        )
+        self.right_info_publisher = self.create_publisher(
+            CameraInfo, right_info_topic, qos_profile_sensor_data
+        )
+        self.create_subscription(
+            Image, left_source_topic, self.receive_left, qos_profile_sensor_data
+        )
+        self.create_subscription(
+            Image, right_source_topic, self.receive_right, qos_profile_sensor_data
+        )
+
+    @staticmethod
+    def validate_calibration(width, height, vertical_fov_degrees, baseline_m):
+        """Raise ValueError naming any parameter that cannot form a valid pinhole model."""
+        if width <= 0:
+            raise ValueError(f"width must be positive, got {width}")
+        if height <= 0:
+            raise ValueError(f"height must be positive, got {height}")
+        if not math.isfinite(vertical_fov_degrees) or not (
+            0.0 < vertical_fov_degrees < 180.0
+        ):
+            raise ValueError(
+                "vertical_fov_degrees must be in (0, 180), got "
+                f"{vertical_fov_degrees}"
+            )
+        if not math.isfinite(baseline_m) or baseline_m <= 0.0:
+            raise ValueError(f"baseline_m must be positive, got {baseline_m}")
+
+    @staticmethod
+    def stamp_nanoseconds(image):
+        return image.header.stamp.sec * 1_000_000_000 + image.header.stamp.nanosec
+
+    def receive_left(self, image):
+        self.receive_image(image, self.left_images, self.right_images)
+
+    def receive_right(self, image):
+        self.receive_image(image, self.right_images, self.left_images)
+
+    def receive_image(self, image, own_queue, other_queue):
+        if image.width != self.width or image.height != self.height:
+            if not self.reported_bad_dimensions:
+                self.get_logger().error(
+                    "Forward stereo source dimensions do not match calibration: "
+                    f"received {image.width}x{image.height}, expected "
+                    f"{self.width}x{self.height}"
+                )
+                self.reported_bad_dimensions = True
+            return
+
+        stamp = self.stamp_nanoseconds(image)
+        pair = None
+        with self.pairing_lock:
+            # Pairing keys on source header stamps, so a backward step in those
+            # stamps -- not in this node's clock -- is what can fuse frames from
+            # two different simulator epochs. A deterministic sim reset replays
+            # the same stamp sequence, so a buffered pre-reset frame could
+            # otherwise match a post-reset frame of equal stamp. Drop the
+            # buffers whenever the source timeline rewinds; this holds whether
+            # or not use_sim_time is enabled.
+            if (
+                self.latest_source_stamp is not None
+                and stamp < self.latest_source_stamp
+            ):
+                self.get_logger().warn(
+                    "Forward stereo source timestamps went backward "
+                    f"({self.latest_source_stamp} -> {stamp}); clearing pairing "
+                    "buffers to avoid cross-epoch stereo pairs."
+                )
+                self.left_images.clear()
+                self.right_images.clear()
+                # Re-baseline onto the new epoch rather than keeping the old
+                # high-water mark: retaining it would re-trigger this branch for
+                # every replayed frame, discarding each partner as it arrives and
+                # stalling the stream until stamps passed the pre-rewind peak.
+                self.latest_source_stamp = stamp
+            else:
+                # max() on the normal path absorbs benign left/right reordering.
+                self.latest_source_stamp = (
+                    stamp
+                    if self.latest_source_stamp is None
+                    else max(self.latest_source_stamp, stamp)
+                )
+
+            own_queue[stamp] = image
+            if stamp in other_queue:
+                # Pop from the concrete left/right attributes rather than the
+                # generic own/other parameters: publish_pair() requires (left,
+                # right) order, which the caller-relative names cannot provide.
+                pair = (
+                    self.left_images.pop(stamp),
+                    self.right_images.pop(stamp),
+                )
+
+            while len(own_queue) > self.queue_depth:
+                del own_queue[min(own_queue)]
+
+        if pair is not None:
+            self.publish_pair(*pair)
+
+    def reset_pairing_buffers(self, _time_jump):
+        with self.pairing_lock:
+            self.left_images.clear()
+            self.right_images.clear()
+            self.latest_source_stamp = None
+
+    def make_camera_info(self, stamp, frame_id, projection_tx):
+        info = CameraInfo()
+        info.header.stamp = stamp
+        info.header.frame_id = frame_id
+        info.height = self.height
+        info.width = self.width
+        info.distortion_model = "plumb_bob"
+        info.d = [0.0, 0.0, 0.0, 0.0, 0.0]
+        info.k = [
+            self.focal_length_px,
+            0.0,
+            self.principal_x_px,
+            0.0,
+            self.focal_length_px,
+            self.principal_y_px,
+            0.0,
+            0.0,
+            1.0,
+        ]
+        info.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        info.p = [
+            self.focal_length_px,
+            0.0,
+            self.principal_x_px,
+            projection_tx,
+            0.0,
+            self.focal_length_px,
+            self.principal_y_px,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+        ]
+        return info
+
+    def convert_to_mono8(self, source_image, frame_id):
+        if source_image.encoding != "rgb8":
+            if not self.reported_bad_encoding:
+                self.get_logger().error(
+                    "Forward stereo source encoding does not match MuJoCo's "
+                    f"RGB contract: received {source_image.encoding}, expected rgb8"
+                )
+                self.reported_bad_encoding = True
+            return None
+
+        expected_row_bytes = self.width * 3
+        expected_buffer_bytes = source_image.step * self.height
+        if (
+            source_image.step < expected_row_bytes
+            or len(source_image.data) != expected_buffer_bytes
+        ):
+            if not self.reported_bad_buffer_size:
+                self.get_logger().error(
+                    "Forward stereo source image buffer size does not match step * height"
+                )
+                self.reported_bad_buffer_size = True
+            return None
+
+        rgb_rows = np.frombuffer(source_image.data, dtype=np.uint8).reshape(
+            self.height, source_image.step
+        )
+        rgb = rgb_rows[:, :expected_row_bytes].reshape(self.height, self.width, 3)
+        # BT.601 luma conversion. The OV9282 pair is monochrome, so publish
+        # mono8 rather than MuJoCo's native rgb8 render representation.
+        # OpenCV's SIMD path measured ~11x faster than the equivalent NumPy
+        # expression here (0.42 ms vs 4.56 ms per 1280x720 frame), which matters
+        # because this runs on every frame of both cameras alongside MuJoCo.
+        mono = cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY)
+
+        image = Image()
+        image.header = source_image.header
+        image.header.frame_id = frame_id
+        image.height = self.height
+        image.width = self.width
+        image.encoding = "mono8"
+        image.is_bigendian = False
+        image.step = self.width
+        image.data = mono.tobytes()
+        return image
+
+    def has_output_subscribers(self):
+        """Report whether any of the four contract topics currently has a subscriber."""
+        return any(
+            publisher.get_subscription_count() > 0
+            for publisher in (
+                self.left_image_publisher,
+                self.right_image_publisher,
+                self.left_info_publisher,
+                self.right_info_publisher,
+            )
+        )
+
+    def publish_pair(self, left_image, right_image):
+        # Nothing downstream is listening on a normal hangar_sim run (navigation,
+        # manipulation, CI), so skip the conversion rather than spend it on
+        # frames no one reads. Subscription counts update live, so a VO consumer,
+        # rosbag, or image viewer resumes the stream as soon as it subscribes.
+        if not self.has_output_subscribers():
+            return
+
+        left_mono = self.convert_to_mono8(left_image, self.left_frame_id)
+        right_mono = self.convert_to_mono8(right_image, self.right_frame_id)
+        if left_mono is None or right_mono is None:
+            return
+
+        left_info = self.make_camera_info(
+            left_mono.header.stamp, self.left_frame_id, 0.0
+        )
+        right_info = self.make_camera_info(
+            right_mono.header.stamp,
+            self.right_frame_id,
+            -self.focal_length_px * self.baseline_m,
+        )
+
+        self.left_image_publisher.publish(left_mono)
+        self.left_info_publisher.publish(left_info)
+        self.right_image_publisher.publish(right_mono)
+        self.right_info_publisher.publish(right_info)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ForwardStereoPublisher()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        # Jazzy's default signal handler shuts the context down and spin()
+        # raises ExternalShutdownException, so Ctrl-C must not look like a crash.
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hangar_sim/test/test_forward_stereo_calibration.py
+++ b/src/hangar_sim/test/test_forward_stereo_calibration.py
@@ -1,0 +1,169 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import math
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+import yaml
+
+
+PACKAGE_ROOT = Path(__file__).parents[1]
+PARAMETERS = PACKAGE_ROOT / "params" / "forward_stereo.yaml"
+MODEL = PACKAGE_ROOT / "description" / "ur5e_ridgeback.xml"
+SCENE = PACKAGE_ROOT / "description" / "hangar_scene.xml"
+
+
+def parse_vector(element, attribute):
+    return tuple(float(value) for value in element.attrib[attribute].split())
+
+
+def test_forward_stereo_model_matches_calibration():
+    parameters = yaml.safe_load(PARAMETERS.read_text())["forward_stereo_publisher"][
+        "ros__parameters"
+    ]
+    root = ET.parse(MODEL).getroot()
+    size = root.find("size")
+    assert size is not None
+    assert size.attrib["nuser_cam"] == "1"
+    cameras = {camera.attrib["name"]: camera for camera in root.iter("camera")}
+    sites = {
+        site.attrib["name"]: site for site in root.iter("site") if "name" in site.attrib
+    }
+
+    left_camera = cameras["forward_stereo_left"]
+    right_camera = cameras["forward_stereo_right"]
+    left_site = sites[parameters["left_frame_id"]]
+    right_site = sites[parameters["right_frame_id"]]
+
+    expected_resolution = (parameters["width"], parameters["height"])
+    assert parse_vector(left_camera, "resolution") == expected_resolution
+    assert parse_vector(right_camera, "resolution") == expected_resolution
+    # picknik_mujoco_ros CameraConfig::DepthType::RGB_ONLY. The stereo bridge
+    # consumes color only, so depth rendering and point-cloud generation must
+    # remain disabled for these cameras.
+    assert left_camera.attrib["user"] == "1"
+    assert right_camera.attrib["user"] == "1"
+    assert float(left_camera.attrib["fovy"]) == parameters["vertical_fov_degrees"]
+    assert float(right_camera.attrib["fovy"]) == parameters["vertical_fov_degrees"]
+
+    left_position = parse_vector(left_camera, "pos")
+    right_position = parse_vector(right_camera, "pos")
+    assert left_position == parse_vector(left_site, "pos")
+    assert right_position == parse_vector(right_site, "pos")
+    assert left_position[0] == right_position[0]
+    assert left_position[2] == right_position[2]
+    assert math.isclose(left_position[1] - right_position[1], parameters["baseline_m"])
+
+    camera_axes = (0.0, -1.0, 0.0, 0.0, 0.0, 1.0)
+    optical_axes = (0.0, -1.0, 0.0, 0.0, 0.0, -1.0)
+    assert parse_vector(left_camera, "xyaxes") == camera_axes
+    assert parse_vector(right_camera, "xyaxes") == camera_axes
+    assert parse_vector(left_site, "xyaxes") == optical_axes
+    assert parse_vector(right_site, "xyaxes") == optical_axes
+
+    scene_root = ET.parse(SCENE).getroot()
+    global_visual = scene_root.find("./visual/global")
+    assert global_visual is not None
+    offscreen_resolution = (
+        int(global_visual.attrib["offwidth"]),
+        int(global_visual.attrib["offheight"]),
+    )
+    camera_resolutions = {
+        tuple(int(value) for value in camera.attrib["resolution"].split())
+        for document_root in (scene_root, root)
+        for camera in document_root.iter("camera")
+    }
+    assert camera_resolutions == {offscreen_resolution}
+
+
+def test_right_projection_translation_uses_ros_stereo_convention():
+    parameters = yaml.safe_load(PARAMETERS.read_text())["forward_stereo_publisher"][
+        "ros__parameters"
+    ]
+    focal_length_px = parameters["height"] / (
+        2.0 * math.tan(math.radians(parameters["vertical_fov_degrees"]) / 2.0)
+    )
+    projection_tx = -focal_length_px * parameters["baseline_m"]
+
+    horizontal_fov_degrees = math.degrees(
+        2.0 * math.atan(parameters["width"] / (2.0 * focal_length_px))
+    )
+
+    assert math.isclose(focal_length_px, 762.7222992602944)
+    assert math.isclose(horizontal_fov_degrees, 80.0)
+    assert math.isclose(projection_tx, -57.20417244452208)
+
+
+def test_mount_geoms_stay_behind_the_optical_plane():
+    """Visual mount geometry must never cross in front of the optical centers.
+
+    MuJoCo renders group-2 geoms in the offscreen pass, so a mount geom ahead of
+    a camera occludes that camera's image. `contype`/`conaffinity` disable
+    collision only, not rendering, and the failure surfaces as degraded VO
+    scores rather than an error -- so pin the margin here.
+    """
+    root = ET.parse(MODEL).getroot()
+    cameras = {camera.attrib["name"]: camera for camera in root.iter("camera")}
+    stereo_cameras = [
+        camera for name, camera in cameras.items() if name.startswith("forward_stereo_")
+    ]
+    assert stereo_cameras, "expected the forward stereo cameras to exist"
+
+    # The cameras look along base +X, so every mount geom must sit at smaller x.
+    optical_plane_x = min(parse_vector(camera, "pos")[0] for camera in stereo_cameras)
+
+    mount_geoms = [
+        geom
+        for geom in root.iter("geom")
+        if geom.attrib.get("name", "").startswith("forward_stereo_")
+    ]
+    assert mount_geoms, "expected the forward stereo mount geoms to exist"
+
+    for geom in mount_geoms:
+        if "fromto" in geom.attrib:
+            values = parse_vector(geom, "fromto")
+            # A cylinder's surface extends by its radius perpendicular to the
+            # axis, so only an x-aligned one is bounded by its endpoints -- the
+            # rest bulge forward by size[0]. Non-axis-aligned geometry gets the
+            # full radius, which over-estimates rather than risking a false pass.
+            radius = parse_vector(geom, "size")[0]
+            axis_is_x = values[1] == values[4] and values[2] == values[5]
+            max_x = max(values[0], values[3]) + (0.0 if axis_is_x else radius)
+        else:
+            half_x = parse_vector(geom, "size")[0]
+            max_x = parse_vector(geom, "pos")[0] + half_x
+        assert max_x < optical_plane_x, (
+            f"mount geom {geom.attrib['name']} reaches x={max_x}, which is not "
+            f"behind the optical plane at x={optical_plane_x}"
+        )
+        # Decorative geometry must not perturb the base's inferred inertia:
+        # ridgeback_base_link declares no <inertial>.
+        assert (
+            geom.attrib.get("mass") == "0"
+        ), f"mount geom {geom.attrib['name']} must set mass=\"0\""

--- a/src/hangar_sim/test/test_forward_stereo_publisher.py
+++ b/src/hangar_sim/test/test_forward_stereo_publisher.py
@@ -1,0 +1,433 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import math
+from pathlib import Path
+import sys
+import time
+
+import pytest
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CameraInfo, Image
+
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "script"))
+from forward_stereo_publisher import ForwardStereoPublisher  # noqa: E402
+
+
+def spin_until(executor, predicate, timeout_seconds=5.0):
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        executor.spin_once(timeout_sec=0.05)
+        if predicate():
+            return True
+    return False
+
+
+def make_rgb_image(width, height, stamp, rgb):
+    image = Image()
+    image.header.stamp = stamp
+    image.height = height
+    image.width = width
+    image.encoding = "rgb8"
+    image.step = width * 3
+    image.data = bytes(rgb) * (width * height)
+    return image
+
+
+@pytest.fixture
+def ros_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+def test_synchronized_pair_publishes_oak_compatible_contract(ros_context):
+    width = 4
+    height = 2
+    vertical_fov_degrees = 55.0
+    baseline_m = 0.075
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+            Parameter("vertical_fov_degrees", value=vertical_fov_degrees),
+            Parameter("baseline_m", value=baseline_m),
+        ]
+    )
+    probe = Node("forward_stereo_test_probe")
+    executor = SingleThreadedExecutor()
+    executor.add_node(publisher)
+    executor.add_node(probe)
+
+    received = {}
+    subscriptions = [
+        probe.create_subscription(
+            Image,
+            "/forward_stereo/left/image_rect",
+            lambda message: received.setdefault("left_image", message),
+            qos_profile_sensor_data,
+        ),
+        probe.create_subscription(
+            Image,
+            "/forward_stereo/right/image_rect",
+            lambda message: received.setdefault("right_image", message),
+            qos_profile_sensor_data,
+        ),
+        probe.create_subscription(
+            CameraInfo,
+            "/forward_stereo/left/camera_info",
+            lambda message: received.setdefault("left_info", message),
+            qos_profile_sensor_data,
+        ),
+        probe.create_subscription(
+            CameraInfo,
+            "/forward_stereo/right/camera_info",
+            lambda message: received.setdefault("right_info", message),
+            qos_profile_sensor_data,
+        ),
+    ]
+    left_source = probe.create_publisher(
+        Image, "/forward_stereo_left/color", qos_profile_sensor_data
+    )
+    right_source = probe.create_publisher(
+        Image, "/forward_stereo_right/color", qos_profile_sensor_data
+    )
+
+    def discovery_complete():
+        return (
+            left_source.get_subscription_count() == 1
+            and right_source.get_subscription_count() == 1
+            and all(
+                subscription.get_publisher_count() == 1
+                for subscription in subscriptions
+            )
+        )
+
+    try:
+        assert spin_until(
+            executor, discovery_complete
+        ), "DDS discovery did not complete"
+
+        stamp = probe.get_clock().now().to_msg()
+        left_source.publish(make_rgb_image(width, height, stamp, (255, 0, 0)))
+        right_source.publish(make_rgb_image(width, height, stamp, (0, 255, 0)))
+
+        assert spin_until(executor, lambda: len(received) == 4)
+        left_image = received["left_image"]
+        right_image = received["right_image"]
+        left_info = received["left_info"]
+        right_info = received["right_info"]
+
+        assert left_image.header.stamp == stamp
+        assert right_image.header.stamp == stamp
+        assert left_info.header.stamp == stamp
+        assert right_info.header.stamp == stamp
+        assert left_image.header.frame_id == "forward_stereo_left_optical_frame"
+        assert right_image.header.frame_id == "forward_stereo_right_optical_frame"
+        assert left_image.encoding == "mono8"
+        assert right_image.encoding == "mono8"
+        assert left_image.step == width
+        assert right_image.step == width
+        # BT.601 luma of pure red / pure green. Values come from OpenCV's
+        # rounding; a +/-1 LSB shift would just mean a different rounding
+        # rule, so pin the channel weighting rather than the exact integer.
+        assert bytes(left_image.data) == bytes([76]) * (width * height)
+        assert bytes(right_image.data) == bytes([150]) * (width * height)
+
+        focal_length_px = height / (
+            2.0 * math.tan(math.radians(vertical_fov_degrees) / 2.0)
+        )
+        assert left_info.width == width
+        assert left_info.height == height
+        assert left_info.distortion_model == "plumb_bob"
+        assert list(left_info.d) == [0.0] * 5
+        assert list(left_info.r) == [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ]
+        assert math.isclose(left_info.k[0], focal_length_px)
+        assert math.isclose(left_info.k[4], focal_length_px)
+        assert left_info.p[3] == 0.0
+        assert math.isclose(right_info.p[3], -focal_length_px * baseline_m)
+
+        oversized_image = make_rgb_image(width, height, stamp, (0, 0, 0))
+        oversized_image.data = bytes(oversized_image.data) + b"\x00"
+        assert publisher.convert_to_mono8(oversized_image, "test_frame") is None
+        truncated_image = make_rgb_image(width, height, stamp, (0, 0, 0))
+        truncated_image.data = bytes(truncated_image.data)[:-1]
+        assert publisher.convert_to_mono8(truncated_image, "test_frame") is None
+
+        received.clear()
+        left_source.publish(make_rgb_image(width, height, stamp, (255, 0, 0)))
+        stamp_ns = publisher.stamp_nanoseconds(
+            make_rgb_image(width, height, stamp, (0, 0, 0))
+        )
+        assert spin_until(executor, lambda: stamp_ns in publisher.left_images)
+        publisher.reset_pairing_buffers(None)
+        assert not publisher.left_images
+        assert not publisher.right_images
+
+        right_source.publish(make_rgb_image(width, height, stamp, (0, 255, 0)))
+        assert spin_until(executor, lambda: stamp_ns in publisher.right_images)
+        assert not received
+
+        left_source.publish(make_rgb_image(width, height, stamp, (255, 0, 0)))
+        assert spin_until(executor, lambda: len(received) == 4)
+    finally:
+        executor.remove_node(probe)
+        executor.remove_node(publisher)
+        probe.destroy_node()
+        publisher.destroy_node()
+
+
+def make_stamp(sec, nanosec=0):
+    """Build a builtin_interfaces Time via a throwaway Image header."""
+    image = Image()
+    image.header.stamp.sec = sec
+    image.header.stamp.nanosec = nanosec
+    return image.header.stamp
+
+
+def test_backward_source_stamp_clears_pairing_buffers(ros_context):
+    """A rewound source timeline must not fuse frames from two simulator epochs.
+
+    Pairing keys on source header stamps, so a deterministic sim reset that
+    replays earlier stamps could otherwise match a buffered pre-reset frame
+    against a post-reset frame carrying the same stamp.
+    """
+    width = 4
+    height = 2
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+        ]
+    )
+    try:
+        # GIVEN a buffered left frame from the pre-reset epoch
+        late_stamp = make_stamp(1000)
+        publisher.receive_left(make_rgb_image(width, height, late_stamp, (255, 0, 0)))
+        assert publisher.left_images, "expected the pre-reset frame to be buffered"
+
+        # WHEN a frame arrives with an earlier source stamp (sim reset replay)
+        early_stamp = make_stamp(500)
+        publisher.receive_right(make_rgb_image(width, height, early_stamp, (0, 255, 0)))
+
+        # THEN the stale pre-reset frame is dropped rather than kept for pairing
+        assert 1000 * 1_000_000_000 not in publisher.left_images
+        # AND only the post-reset frame remains buffered
+        assert list(publisher.right_images) == [500 * 1_000_000_000]
+    finally:
+        publisher.destroy_node()
+
+
+def test_forward_source_stamps_preserve_pairing_buffers(ros_context):
+    """A normally advancing timeline must not trigger the rewind guard."""
+    width = 4
+    height = 2
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+        ]
+    )
+    try:
+        # GIVEN a buffered left frame
+        publisher.receive_left(
+            make_rgb_image(width, height, make_stamp(500), (255, 0, 0))
+        )
+
+        # WHEN a later, unmatched right frame arrives
+        publisher.receive_right(
+            make_rgb_image(width, height, make_stamp(501), (0, 255, 0))
+        )
+
+        # THEN the earlier frame stays buffered awaiting its partner
+        assert 500 * 1_000_000_000 in publisher.left_images
+    finally:
+        publisher.destroy_node()
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_name",
+    [
+        ({"width": 0}, "width"),
+        ({"height": -1}, "height"),
+        ({"vertical_fov_degrees": 0.0}, "vertical_fov_degrees"),
+        ({"vertical_fov_degrees": 180.0}, "vertical_fov_degrees"),
+        ({"vertical_fov_degrees": float("nan")}, "vertical_fov_degrees"),
+        ({"baseline_m": 0.0}, "baseline_m"),
+        ({"baseline_m": -0.075}, "baseline_m"),
+    ],
+)
+def test_invalid_calibration_is_rejected(kwargs, expected_name):
+    """Degenerate intrinsics must fail loudly, naming the offending parameter."""
+    valid = {
+        "width": 1280,
+        "height": 720,
+        "vertical_fov_degrees": 50.53401584672457,
+        "baseline_m": 0.075,
+    }
+    valid.update(kwargs)
+
+    with pytest.raises(ValueError, match=expected_name):
+        ForwardStereoPublisher.validate_calibration(**valid)
+
+
+def test_valid_calibration_is_accepted():
+    """The shipped OAK-D Pro profile passes validation."""
+    ForwardStereoPublisher.validate_calibration(1280, 720, 50.53401584672457, 0.075)
+
+
+def test_pairing_resumes_immediately_after_a_rewind(ros_context):
+    """After a rewind the replayed epoch must pair, not stall.
+
+    Regression: retaining the pre-rewind high-water mark re-triggered the guard
+    on every replayed frame, so each partner was cleared as it arrived and no
+    pair was ever published until stamps climbed past the old peak.
+    """
+    width = 4
+    height = 2
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+        ]
+    )
+    published = []
+    publisher.publish_pair = lambda left, right: published.append((left, right))
+    try:
+        # GIVEN a buffered frame from the pre-rewind epoch
+        publisher.receive_left(
+            make_rgb_image(width, height, make_stamp(1000), (255, 0, 0))
+        )
+
+        # WHEN the timeline rewinds and BOTH halves of a replayed frame arrive
+        publisher.receive_right(
+            make_rgb_image(width, height, make_stamp(500), (0, 255, 0))
+        )
+        publisher.receive_left(
+            make_rgb_image(width, height, make_stamp(500), (255, 0, 0))
+        )
+
+        # THEN the replayed frame pairs instead of being discarded
+        assert len(published) == 1, "replayed epoch must pair after a rewind"
+        left, right = published[0]
+        assert publisher.stamp_nanoseconds(left) == 500 * 1_000_000_000
+        assert publisher.stamp_nanoseconds(right) == 500 * 1_000_000_000
+    finally:
+        publisher.destroy_node()
+
+
+def test_pairing_skips_conversion_when_nothing_is_subscribed(ros_context):
+    """With no subscribers the pair is dropped rather than converted.
+
+    A normal hangar_sim run (navigation, manipulation, CI) subscribes to none of
+    the four contract topics, and the mono8 conversion is the node's dominant
+    cost -- so it must not run for frames no one reads.
+    """
+    width = 4
+    height = 2
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+        ]
+    )
+    converted = []
+    original_convert = publisher.convert_to_mono8
+    publisher.convert_to_mono8 = lambda *a, **k: (
+        converted.append(a) or original_convert(*a, **k)
+    )
+    try:
+        # GIVEN no subscriber on any contract topic
+        assert not publisher.has_output_subscribers()
+
+        # WHEN a complete pair arrives
+        stamp = make_stamp(500)
+        publisher.receive_left(make_rgb_image(width, height, stamp, (255, 0, 0)))
+        publisher.receive_right(make_rgb_image(width, height, stamp, (0, 255, 0)))
+
+        # THEN the expensive conversion never runs
+        assert converted == []
+    finally:
+        publisher.destroy_node()
+
+
+def test_pairing_publishes_once_a_subscriber_attaches(ros_context):
+    """A subscriber on any contract topic re-enables the stream."""
+    width = 4
+    height = 2
+    publisher = ForwardStereoPublisher(
+        parameter_overrides=[
+            Parameter("width", value=width),
+            Parameter("height", value=height),
+        ]
+    )
+    probe = Node("forward_stereo_lazy_probe")
+    executor = SingleThreadedExecutor()
+    executor.add_node(publisher)
+    executor.add_node(probe)
+    received = []
+    probe.create_subscription(
+        Image,
+        "/forward_stereo/left/image_rect",
+        received.append,
+        qos_profile_sensor_data,
+    )
+    try:
+        # GIVEN a subscriber that has been discovered
+        assert spin_until(
+            executor, publisher.has_output_subscribers
+        ), "subscriber was never discovered"
+
+        # WHEN a complete pair arrives
+        stamp = probe.get_clock().now().to_msg()
+        publisher.receive_left(make_rgb_image(width, height, stamp, (255, 0, 0)))
+        publisher.receive_right(make_rgb_image(width, height, stamp, (0, 255, 0)))
+
+        # THEN the pair is converted and published
+        assert spin_until(executor, lambda: len(received) == 1)
+        assert received[0].encoding == "mono8"
+    finally:
+        executor.remove_node(probe)
+        executor.remove_node(publisher)
+        probe.destroy_node()
+        publisher.destroy_node()


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#19635.

Adds a forward-facing stereo pair to the Ridgeback in `hangar_sim` so VO/VSLAM candidates have repeatable simulated input with ground truth. Two coplanar MuJoCo cameras publish through a node that pairs them by exact source timestamp and emits the ROS stereo contract. Nominal OAK-D Pro profile: 75 mm baseline, 1280×720 @ 20 Hz, 80° HFOV, `mono8`.

Camera source only — no VO/VSLAM implementation or benchmark harness, per the issue's scope boundary.

## Published contract

| Stream | Image | Calibration | Frame |
| --- | --- | --- | --- |
| Left | `/forward_stereo/left/image_rect` | `/forward_stereo/left/camera_info` | `forward_stereo_left_optical_frame` |
| Right | `/forward_stereo/right/image_rect` | `/forward_stereo/right/camera_info` | `forward_stereo_right_optical_frame` |

Optical centers at `(0.45, ±0.0375, 0.55)` m in `ridgeback_base_link`, both facing base `+X`, optical frames in ROS convention (`+Z` forward, `+X` right, `+Y` down). `fx = fy = 762.722299`, `(cx, cy) = (640, 360)`, zero distortion, identity `R`, right `P[0,3] = -fx × baseline = -57.204172`.

This is a **nominal input contract, not a photometric sensor emulator** — MuJoCo renders ideal pinhole images, so distortion is zero and the images are already rectified. It does not reproduce per-device calibration variation, exposure/gain, shot noise, motion blur, IR projection, or DepthAI's on-device depth. Physical-camera comparisons must record the real OAK's own `camera_info` rather than reusing these values.

## Three decisions worth reviewing

**Remapped the plugin's per-camera `camera_info` to `monocular_camera_info`.** Same `K` and `frame_id` as the stereo contract but `P[0,3] = 0`, and it sat on the ROS sibling name of the raw color topics — a consumer following that convention reads zero baseline and infers infinite depth, silently.

**The rewind guard keys on source stamps, not the node clock.** The node clock never rewinds under `use_sim_time=false`, but a keyframe reset replays earlier stamps and can fuse a pre-reset frame with a post-reset one. On rewind the buffers clear and the high-water mark re-baselines, so pairing resumes next frame instead of stalling.

**Mount geoms sit behind the optical plane** (max x 0.44 vs cameras at 0.45) with `mass="0"` — group-2 geoms render even with collision disabled, and `ridgeback_base_link` has no `<inertial>` to absorb their inferred mass. A test pins both.

## Validation

Full stack launched on this SHA. All four topics publish `mono8` 1280×720 at 19.93–20.01 Hz with identical timestamps across both images and both `camera_info`, and zero unmatched frames (391 messages on each topic over a 19.5 s bag). Calibration matches spec exactly. TF against MuJoCo ground truth confirms coplanar centers, 0.075 m baseline, facing base +X in ROS optical convention. Rendered frames show the hangar unoccluded with visible disparity. No forward-stereo depth or point-cloud topics are created and `scene_camera`/`wrist_camera` are unchanged; sim reset resumes cleanly with no cross-epoch pairing.

15 package tests pass (up from 3); `pre-commit` clean.

## Limitations

- **Optical frames are `mj_world` children carrying ground-truth pose**, not rigid children of `ridgeback_base_link` — that's how `picknik_mujoco_ros` broadcasts non-lidar sites. A `ridgeback_base_link → optical` lookup therefore resolves through `map → odom` and wobbles with localization error. Take the rig extrinsic from the constants above; use `mj_world → optical` as the trajectory to score against, never as VO input.
- **Backward-`/clock` path unexercised** — the packaged launch defaults `use_sim_time` to false, so there is no `/clock` to rewind. The source-stamp guard covers the reset case the shipped config actually reaches.
- **The pair is always on, with no toggle.** Every `hangar_sim` run pays two extra 1280×720 offscreen renders per cycle, whether or not anything consumes them. There is no opt-in flag: the cameras live in `ur5e_ridgeback.xml`, which is raw MJCF (not xacro-processed), so a xacro arg cannot conditionally omit them — the only lever would be maintaining a second scene file selected via `config.yaml`'s `mujoco_model`, which trades a duplicated scene for the saving. Measured cost: `ros2_control_node` at ~192% of a core (physics + render) against the publisher node's ~51%, so the render dominates and the Python side is not worth optimizing.
- **Rate is host-load sensitive** — 20 Hz on an unloaded host; ~11 Hz under heavy contention with MuJoCo reporting 56–80% of steps over budget. Worth watching on slower CI runners.

## Follow-up

A public docs page on adding a camera to a MuJoCo sim config belongs in `moveit_pro/src/docs`, not here — example_ws docs are never published. Tracked separately and blocked on this PR.

## Release notes

Enhancement: Added a calibrated forward-facing stereo camera to the `hangar_sim` mobile base, publishing rectified grayscale images and matching calibration at 20 Hz for visual odometry and SLAM evaluation.
