### PR TITLE
Fix: Rename example_ws objectives to RobotState Behavior names

### DIFF
--- a/src/dual_arm_sim/objectives/sort_blocks.xml
+++ b/src/dual_arm_sim/objectives/sort_blocks.xml
@@ -109,7 +109,7 @@
                   velocity_scale="1.000000"
                 />
                 <Action
-                  ID="SetupMTCPlanToJointState"
+                  ID="SetupMTCPlanToRobotState"
                   acceleration_scale_factor="1.000000"
                   joint_state="{target_joint_state}"
                   keep_orientation_link_names="grasp_link"
@@ -238,7 +238,7 @@
                   velocity_scale="1.000000"
                 />
                 <Action
-                  ID="SetupMTCPlanToJointState"
+                  ID="SetupMTCPlanToRobotState"
                   acceleration_scale_factor="1.000000"
                   joint_state="{target_joint_state}"
                   keep_orientation_link_names="grasp_link"

--- a/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_in_right_bin_subtree.xml
@@ -60,7 +60,7 @@
         task="{mtc_task}"
       />
       <Action
-        ID="SetupMTCPlanToJointState"
+        ID="SetupMTCPlanToRobotState"
         acceleration_scale_factor="1"
         joint_state="{midpoint_move}"
         keep_orientation="false"

--- a/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
+++ b/src/factory_sim/objectives/drop_bracket_part_on_jig_subtree.xml
@@ -44,7 +44,7 @@
       <Action ID="SetupMTCCurrentState" task="{mtc_task}" />
       <!--The arm is moved to this intermediate waypoint to give a more predictable arm motion while avoiding the hanging bowls. Even with a collision object modeled the arm would still make large motions at times which influenced how well the part was aligned to the jig posts.-->
       <Action
-        ID="SetupMTCPlanToJointState"
+        ID="SetupMTCPlanToRobotState"
         acceleration_scale_factor="1"
         joint_state="{midpoint_move}"
         keep_orientation="false"

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -36,7 +36,7 @@
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
-                      ID="RetrieveJointStateParameter"
+                      ID="RetrieveRobotStateParameter"
                       timeout_sec="-1"
                       joint_state="{target_joint_state}"
                     />
@@ -127,7 +127,7 @@
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
-                      ID="RetrieveJointStateParameter"
+                      ID="RetrieveRobotStateParameter"
                       timeout_sec="-1"
                       joint_state="{target_joint_state}"
                     />

--- a/src/lab_sim/objectives/add_waypoints_to_mtc_task.xml
+++ b/src/lab_sim/objectives/add_waypoints_to_mtc_task.xml
@@ -16,9 +16,9 @@
         joint_group_name="{joint_group_name}"
       />
       <Action
-        ID="SetupMTCPlanToJointState"
+        ID="SetupMTCPlanToRobotState"
         joint_state="{target_joint_state}"
-        name="SetupMTCPlanToJointState"
+        name="SetupMTCPlanToRobotState"
         planning_group_name="{joint_group_name}"
         task="{mtc_task}"
       />
@@ -29,9 +29,9 @@
         joint_group_name="{joint_group_name}"
       />
       <Action
-        ID="SetupMTCPlanToJointState"
+        ID="SetupMTCPlanToRobotState"
         joint_state="{target_joint_state}"
-        name="SetupMTCPlanToJointState"
+        name="SetupMTCPlanToRobotState"
         planning_group_name="{joint_group_name}"
         task="{mtc_task}"
       />

--- a/src/lab_sim/objectives/playback_square_trajectory.xml
+++ b/src/lab_sim/objectives/playback_square_trajectory.xml
@@ -13,7 +13,7 @@
         output="{joint_trajectory_msg}"
       />
       <Action
-        ID="GetTrajectoryStateAtTime"
+        ID="GetRobotStateFromTrajectory"
         from_start="true"
         joint_state="{joint_state}"
         joint_trajectory_msg="{joint_trajectory_msg}"

--- a/src/lab_sim/objectives/reset_mujoco_robot.xml
+++ b/src/lab_sim/objectives/reset_mujoco_robot.xml
@@ -18,7 +18,7 @@
         deactivate_controllers="{command_controllers}"
       />
       <Action
-        ID="CreateJointState"
+        ID="CreateRobotState"
         joint_names="linear_rail_joint;shoulder_pan_joint;shoulder_lift_joint;elbow_joint;wrist_1_joint;wrist_2_joint;wrist_3_joint"
         positions="0.0;0.0;-1.57;0.0;0.0;0.0;0.0"
       />

--- a/src/lab_sim/objectives/save_robot_joint_state.xml
+++ b/src/lab_sim/objectives/save_robot_joint_state.xml
@@ -4,7 +4,7 @@
   <BehaviorTree ID="Save Robot Joint State" _description="" _favorite="false">
     <Control ID="Sequence" name="TopLevelSequence">
       <Action ID="GetCurrentPlanningScene" />
-      <Action ID="GetRobotJointState" />
+      <Action ID="GetJointState" />
       <Action
         ID="SaveRobotJointStateToYaml"
         message="{robot_joint_state}"

--- a/src/lab_sim/objectives/stationary_admittance.xml
+++ b/src/lab_sim/objectives/stationary_admittance.xml
@@ -42,7 +42,7 @@
         planning_scene_msg="{planning_scene}"
       />
       <Action
-        ID="GetRobotJointState"
+        ID="GetJointState"
         joint_state="{joint_state}"
         planning_scene="{planning_scene}"
         planning_group_name="manipulator"

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/demo_trajectory_stitching.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/demo_trajectory_stitching.xml
@@ -18,7 +18,7 @@
         planning_scene_msg="{planning_scene}"
       />
       <Action
-        ID="GetRobotJointState"
+        ID="GetJointState"
         planning_group_name="manipulator"
         planning_scene="{planning_scene}"
         joint_state="{start_joint_state}"
@@ -33,27 +33,27 @@
         velocity="{start_velocity}"
       />
       <Action
-        ID="CreateJointState"
+        ID="CreateRobotState"
         joint_state_msg="{start_state}"
         positions="{start_position}"
         joint_names="{joint_names}"
         velocities="{start_velocity}"
       />
       <Action
-        ID="CreateJointState"
+        ID="CreateRobotState"
         positions="0.5;0.51;-3.025;-2.31;0.2;1.159;1.37"
         joint_names="{joint_names}"
         joint_state_msg="{target_state}"
         velocities="0.0;0.0;0.0;0.0;0.0;0.0;0.0"
       />
       <Action
-        ID="GetRobotJointState"
+        ID="GetJointState"
         planning_group_name="manipulator"
         planning_scene="{planning_scene}"
         joint_state="{joint_state}"
       />
       <Action
-        ID="CreateJointState"
+        ID="CreateRobotState"
         positions="-0.5;-0.51;-3.025;-2.31;0.2;1.159;1.37"
         joint_names="{joint_names}"
         joint_state_msg="{stitch_target_state}"
@@ -72,7 +72,7 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
       />
       <Action
-        ID="GetTrajectoryStateAtTime"
+        ID="GetRobotStateFromTrajectory"
         time_from_reference="0.8"
         joint_state="{stitch_state}"
         from_start="true"

--- a/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_site_config/objectives/retreat_to_initial_pose.xml
@@ -23,7 +23,7 @@
         />
       </Decorator>
       <Action
-        ID="SetupMTCCartesianMoveToJointState"
+        ID="SetupMTCCartesianMoveToRobotState"
         joint_state="{pre_approach_robot_state}"
         planning_group_name="manipulator"
         task="{retreat_task}"
@@ -43,7 +43,7 @@
         />
       </Decorator>
       <Action
-        ID="SetupMTCPlanToJointState"
+        ID="SetupMTCPlanToRobotState"
         joint_state="{initial_robot_state}"
         planning_group_name="manipulator"
         task="{retreat_task}"


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#21016

## Problem

moveit_pro#20821 renamed 7 joint-state planning Behaviors to `RobotState` names and kept the old names as deprecation aliases. The `example_ws` objectives still referenced the deprecated aliases, so they render a deprecation flag in the Objective editor.

## Change

Rename every deprecated-alias reference in the shipped objectives to its new name:

| Old (deprecated alias) | New |
| --- | --- |
| `GetRobotJointState` | `GetJointState` |
| `CreateJointState` | `CreateRobotState` |
| `GetTrajectoryStateAtTime` | `GetRobotStateFromTrajectory` |
| `RetrieveJointStateParameter` | `RetrieveRobotStateParameter` |
| `SetupMTCPlanToJointState` | `SetupMTCPlanToRobotState` |
| `SetupMTCInterpolateToJointState` | `SetupMTCInterpolateToRobotState` |
| `SetupMTCCartesianMoveToJointState` | `SetupMTCCartesianMoveToRobotState` |

11 objective XMLs across `dual_arm_sim`, `factory_sim`, `hangar_sim`, `lab_sim`, `moveit_pro_kinova_configs`, and `moveit_pro_ur_configs`, plus a bump of the `phoebe_ws` submodule to pick up the same rename in its `record_admittance_trajectory.xml` (PickNikRobotics/phoebe_ws#34, merged).

This is a pure rename — no port values, structure, or behavior change. The new names resolve to the same Behaviors the aliases pointed at.

## Definition of Done

- `grep` of the 7 deprecated names across the tree (submodule included) returns nothing.
- phoebe_ws submodule points at the merged commit `5bc755f`.
- CI green; affected objectives no longer show a deprecation flag.
