### PR TITLE
Diagnostic: log UDP rcvbuf capacity/overflow for moveit_pro#20603

### DIFF
--- a/src/lab_sim/test/conftest.py
+++ b/src/lab_sim/test/conftest.py
@@ -79,6 +79,62 @@ def pytest_runtest_logreport(report):
     os.write(2, (line + "\n").encode())
 
 
+def _udp_rcvbuf_errors() -> "int | None":
+    """UDP RcvbufErrors from /proc/net/snmp — the socket-receive overflow counter."""
+    try:
+        lines = Path("/proc/net/snmp").read_text().splitlines()
+    except OSError:
+        return None
+    header = values = None
+    for line in lines:
+        if line.startswith("Udp:"):
+            if header is None:
+                header = line.split()[1:]
+            else:
+                values = line.split()[1:]
+                break
+    if not header or not values or "RcvbufErrors" not in header:
+        return None
+    try:
+        return int(values[header.index("RcvbufErrors")])
+    except (ValueError, IndexError):
+        return None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dds_transport_diagnostics():
+    """Log UDP receive-buffer capacity and overflow across the run (issue #20603).
+
+    The MuJoCo cameras publish ~14.7 MB PointCloud2 samples best-effort. If the
+    socket receive buffer is smaller than one sample — e.g. net.core.rmem_max
+    caps CycloneDDS's requested 10 MB — fragments are lost and whole samples are
+    silently dropped, the suspected GetPointCloud-timeout cause. A rising
+    RcvbufErrors count over the run confirms socket-receive overflow; rmem_max
+    shows whether the buffer request could have been honored at all. Written to
+    fd 2 so it survives pytest's fd capture (see module docstring)."""
+
+    def _read(path: str) -> str:
+        try:
+            return Path(path).read_text().strip()
+        except OSError:
+            return "?"
+
+    rmem_max = _read("/proc/sys/net/core/rmem_max")
+    rmem_default = _read("/proc/sys/net/core/rmem_default")
+    before = _udp_rcvbuf_errors()
+    os.write(
+        2,
+        f"[dds-diag] net.core.rmem_max={rmem_max} rmem_default={rmem_default} "
+        f"UDP RcvbufErrors(start)={before}\n".encode(),
+    )
+    try:
+        yield
+    finally:
+        after = _udp_rcvbuf_errors()
+        delta = after - before if after is not None and before is not None else "?"
+        os.write(2, f"[dds-diag] UDP RcvbufErrors(end)={after} delta={delta}\n".encode())
+
+
 @pytest.fixture(scope="session", autouse=True)
 def capture_rosout():
     """Run capture_rosout.py as a subprocess to mirror /rosout to NDJSON.

--- a/src/lab_sim/test/conftest.py
+++ b/src/lab_sim/test/conftest.py
@@ -58,9 +58,28 @@ from pathlib import Path
 import pytest
 
 _started_at: dict[str, float] = {}
+_diag_printed = False
 
 
 def pytest_runtest_logstart(nodeid, location):
+    # Emit the DDS transport-capacity line once, from this hook (fd-2 writes here
+    # survive pytest's fd capture, unlike a fixture body) — see issue #20603.
+    global _diag_printed
+    if not _diag_printed:
+        _diag_printed = True
+
+        def _read(path: str) -> str:
+            try:
+                return Path(path).read_text().strip()
+            except OSError:
+                return "?"
+
+        os.write(
+            2,
+            f"[dds-diag] net.core.rmem_max={_read('/proc/sys/net/core/rmem_max')} "
+            f"rmem_default={_read('/proc/sys/net/core/rmem_default')} "
+            f"UDP RcvbufErrors={_udp_rcvbuf_errors()}\n".encode(),
+        )
     _started_at[nodeid] = time.monotonic()
     os.write(2, f"  START   {nodeid}\n".encode())
 
@@ -72,7 +91,9 @@ def pytest_runtest_logreport(report):
     start = _started_at.get(nodeid)
     elapsed_str = f"{time.monotonic() - start:.1f}s" if start is not None else "n/a"
     outcome = report.outcome.upper()  # PASSED / FAILED / SKIPPED
-    line = f"  {outcome:7s} {nodeid} ({elapsed_str})"
+    # Running RcvbufErrors count so a jump can be correlated with the objective
+    # that failed on a point-cloud timeout (issue #20603).
+    line = f"  {outcome:7s} {nodeid} ({elapsed_str}) RcvbufErrors={_udp_rcvbuf_errors()}"
     if report.failed and report.longrepr:
         reason = str(report.longrepr).splitlines()[-1][:200]
         line += f"\n    └─ {reason}"
@@ -99,40 +120,6 @@ def _udp_rcvbuf_errors() -> "int | None":
         return int(values[header.index("RcvbufErrors")])
     except (ValueError, IndexError):
         return None
-
-
-@pytest.fixture(scope="session", autouse=True)
-def dds_transport_diagnostics():
-    """Log UDP receive-buffer capacity and overflow across the run (issue #20603).
-
-    The MuJoCo cameras publish ~14.7 MB PointCloud2 samples best-effort. If the
-    socket receive buffer is smaller than one sample — e.g. net.core.rmem_max
-    caps CycloneDDS's requested 10 MB — fragments are lost and whole samples are
-    silently dropped, the suspected GetPointCloud-timeout cause. A rising
-    RcvbufErrors count over the run confirms socket-receive overflow; rmem_max
-    shows whether the buffer request could have been honored at all. Written to
-    fd 2 so it survives pytest's fd capture (see module docstring)."""
-
-    def _read(path: str) -> str:
-        try:
-            return Path(path).read_text().strip()
-        except OSError:
-            return "?"
-
-    rmem_max = _read("/proc/sys/net/core/rmem_max")
-    rmem_default = _read("/proc/sys/net/core/rmem_default")
-    before = _udp_rcvbuf_errors()
-    os.write(
-        2,
-        f"[dds-diag] net.core.rmem_max={rmem_max} rmem_default={rmem_default} "
-        f"UDP RcvbufErrors(start)={before}\n".encode(),
-    )
-    try:
-        yield
-    finally:
-        after = _udp_rcvbuf_errors()
-        delta = after - before if after is not None and before is not None else "?"
-        os.write(2, f"[dds-diag] UDP RcvbufErrors(end)={after} delta={delta}\n".encode())
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
[written by AI]

**Diagnostic — DO NOT MERGE.** For PickNikRobotics/moveit_pro#20603.

Adds a session pytest fixture to the lab_sim integration that prints, on fd 2 (survives pytest capture):
- `net.core.rmem_max` / `rmem_default` — whether the runner can honor CycloneDDS's requested 10 MB socket receive buffer.
- UDP `RcvbufErrors` delta across the run — confirms socket-receive overflow.

Local A/B already showed a 208 KB receive buffer drops the ~14.75 MB best-effort point clouds (RcvbufErrors +4,655, rate 3.85 Hz) while 64 MB is clean. This run reveals the runner's actual `rmem_max` (decisive on any run, pass or fail) and whether overflow occurs.
