### PR TITLE
Fix: AprilTag detection silently broken by RELIABLE QoS default on Jazzy

### DIFF
--- a/src/moveit_pro_kinova_configs/space_satellite_sim/config/fuse/fuse.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/config/fuse/fuse.yaml
@@ -82,7 +82,7 @@ state_estimator:
       # this is the frame that all transforms should be parented to for fuse to use as a measurement
       # thus a measurement will be a tf from `estimation_frame` to any frame in `transforms` (see above)
       estimation_frames:
-        ["servicer_camera_optical_frame", "wrist_mounted_camera_optical_frame"]
+        ["servicer_camera_optical_frame", "wrist_camera_optical_frame"]
       position_dimensions: ["x", "y", "z"]
       orientation_dimensions: ["roll", "pitch", "yaw"]
       base_frame: "world"

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/launch/tags_36h11.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/launch/tags_36h11.yaml
@@ -1,6 +1,10 @@
 /**:
     ros__parameters:
         image_transport: raw    # image format
+        # apriltag_ros >= 3.4.0 defaults qos_profile to RELIABLE, which cannot match the
+        # BEST_EFFORT (SensorDataQoS) MuJoCo camera publishers - the detector then
+        # silently receives zero frames.
+        qos_profile: sensor_data
         family: 36h11           # tag family name
         size: 0.173             # tag edge size in meter
         max_hamming: 0          # maximum allowed hamming distance (corrected bits)

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/launch/tags_36h11.yaml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/launch/tags_36h11.yaml
@@ -1,6 +1,10 @@
 /**:
     ros__parameters:
         image_transport: raw    # image format
+        # apriltag_ros >= 3.4.0 defaults qos_profile to RELIABLE, which cannot match the
+        # BEST_EFFORT (SensorDataQoS) MuJoCo camera publishers - the detector then
+        # silently receives zero frames.
+        qos_profile: sensor_data
         family: 36h11           # tag family name
         size: 0.173             # tag edge size in meter
         max_hamming: 0          # maximum allowed hamming distance (corrected bits)


### PR DESCRIPTION
[written by AI]

## Problem

Since the ROS Jazzy migration, the `Grapple Moving Satellite via Fiducial Tracking` objective in `space_satellite_sim` fails and floods the log with velocity-clamp and joint-limit warnings at 10 Hz.

Root cause: `apriltag_ros` >= 3.4.0 replaced its hardcoded `sensor_data` subscription QoS with a read-only `qos_profile` parameter defaulting to `default` (RELIABLE), while the MuJoCo camera publishers use `SensorDataQoS` (BEST_EFFORT). A RELIABLE subscription cannot match a BEST_EFFORT publisher, so the AprilTag nodes silently receive zero frames — the node starts cleanly, the subscription registers, and nothing in the log hints at the mismatch. Downstream, the fuse state estimator never receives a measurement, `/odom_filtered` publishes all zeros, and the objective drives the arm toward world origin (outside its workspace), producing the warning storm.

## Fix

- Set `qos_profile: sensor_data` in the shared AprilTag parameter files of `space_satellite_sim` and `space_satellite_sim_camera_cal` (the only two configs launching `apriltag_ros` nodes; the `/**` wildcard covers both the scene and wrist detectors).
- Fix a dead estimation frame in `space_satellite_sim/config/fuse/fuse.yaml`: `wrist_mounted_camera_optical_frame` does not exist in this config (the real frame is `wrist_camera_optical_frame`), so fuse silently dropped every wrist-camera measurement. Surfaced by platform review once the detectors were alive again.

Both AprilTag nodes intentionally publish the same `satellite_tag_N` child frames from their own camera parents: fuse's `transform_sensor` consumes each `/tf` message parented to an `estimation_frame` as an independent measurement (see the comment in `fuse.yaml`), and nothing in the config performs tf-tree lookups on the tag frames (no objective references them), so the dual-parent pattern is the design rather than a conflict.

## Verification

On a Parallels VM dev stack running `space_satellite_sim` at current `main`:

- Before: `ros2 topic info -v /servicer_camera/color` shows the apriltag subscription RELIABLE vs publisher BEST_EFFORT; `/apriltag/detections` never publishes; `/odom_filtered` pose is all zeros at 100 Hz.
- After the QoS change: subscription matches, `/apriltag/detections` publishes at 10 Hz (camera rate), `/odom_filtered` tracks the moving satellite, and the objective's tracking loop commands update every cycle.

With perception restored the objective still emits some clamp/joint-limit warnings while the satellite is beyond the arm's reach envelope — that is tracking behavior, not this bug.

## Follow-ups (out of scope here)

- No CI coverage would catch this regressing: `space_satellite_sim` has no integration test and is not in the per-PR test matrix. A pytest asserting non-empty `/apriltag/detections` and non-zero `/odom_filtered` (pattern exists in `hangar_sim/test/objectives_integration_test.py`) would pin it.
- The two `tags_36h11.yaml` copies must be edited in lockstep (this PR is the demonstration); the cal package could instead load the base file plus a small `tag.sizes` override.
- Consider filing the QoS default change upstream with `apriltag_ros` — every user pointed at a BEST_EFFORT camera silently broke at 3.4.0.

## Release notes

Bug Fix: Fixed AprilTag detection in `space_satellite_sim` producing no detections on ROS Jazzy due to a QoS mismatch with the simulated cameras.