### PR TITLE
Bump moveit_pro_ci to v0.9.1 for the integration container's hardware identity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,7 +252,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@a0e3b30c9aa8f8f82f95c91e5a34989d01caa046 # v0.9.0
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@2eff8c8aa644ed07acaaebc9eb15af4af7169e79 # v0.9.1
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}
@@ -305,7 +305,7 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (matches integration-test).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@a0e3b30c9aa8f8f82f95c91e5a34989d01caa046 # v0.9.0
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@2eff8c8aa644ed07acaaebc9eb15af4af7169e79 # v0.9.1
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}


### PR DESCRIPTION
[written by AI]

## Why

MoveIt Pro 10.0 ([moveit_pro#21236](https://github.com/PickNikRobotics/moveit_pro/pull/21236)) binds a license to machine-unique hardware — a TPM, else a permanent NIC — and **fails closed** when it finds neither, rather than falling back to a value an entire fleet could share.

The integration container has neither, so both `lab_sim` and `hangar_sim` die at startup on any 10.0 image — [run 31229142749](https://github.com/PickNikRobotics/moveit_pro_example_ws/actions/runs/31229142749):

```text
[move_group-9] * ERROR Activating License Failed to initialize licensing client:
  Failed to generate hardware fingerprint: No machine-unique hardware identity is
  available, so this license cannot be bound to this machine.
```

Everything downstream then reports `'No objective action server running.'`, which is a symptom, not the cause.

## What

The fix is in the reusable workflow — [moveit_pro_ci#38](https://github.com/PickNikRobotics/moveit_pro_ci/pull/38), **merged**. It adds no new inputs, so this side is only the pin bump, applied to both references (`integration-test` and `integration-test-weekly`).

Pinned to `2eff8c8` — now tagged and released as [`v0.9.1`](https://github.com/PickNikRobotics/moveit_pro_ci/releases/tag/v0.9.1), matching the convention the other pins use (`@<sha> # v0.9.1`).

## ⚠️ Merge this BEFORE moveit_pro#21236

This is the opposite of what I said on these PRs earlier, and the correction matters.

Once the tier ladder lands on moveit_pro `main` and 10.0 images publish, **every run here that pulls a main image hits fail-closed licensing** — and without this bump there is no hardware identity for it to bind to. Landing #21236 first breaks this repo's CI for everyone until this merges.

I had it backwards because I misread how the `example_ws / integration` check works. It is a cross-repo commit status posted by `sister-repos-control-app[bot]`, and **two** different runs here can post it: a `repository_dispatch` run on `main` (uses `main`'s pin — no fix), or a `pull_request` run on a PR paired via `needs: moveit_pro/#N` (uses that branch's pin — has the fix). Last writer wins. #21236's check went green from the paired path, which says nothing about whether `main` can build a 10.0 image.

## Verification

Verified green end to end while paired with #21236: `Detected paired moveit_pro PR: #21236` confirmed the run pulled a real 10.0 image with fail-closed licensing rather than a main image that would pass without exercising it, and both sims passed with no licensing errors.
