### PR TITLE
Fix: Enable MPPI open_loop to restore hangar_sim nav speed

### DIFF
--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -122,6 +122,10 @@ controller_server:
       vy_max: 0.5
       wz_max: 1.9
       iteration_count: 1
+      # Seed each rollout from the last commanded velocity instead of the
+      # reported odometry, which lags and otherwise pins the commanded speed
+      # near a third of vx_max on Jazzy (moveit_pro issue #21202).
+      open_loop: true
       prune_distance: 1.7
       transform_tolerance: 0.1
       temperature: 0.3


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#21347

> [!WARNING]
> **Inert until moveit_pro#21347 merges.** `open_loop` is silently ignored by the stock Jazzy `nav2_mppi_controller`, which does not declare the parameter. This only takes effect once the image ships the patched build.

## Problem

The `hangar_sim` base drives at roughly a third of its configured speed on Jazzy. MPPI seeds each control cycle's rollout from the last *reported* velocity (`/odom`) rather than its own last *commanded* velocity, so lagging odometry re-anchors the optimizer near the current speed every cycle.

Measured here (`vx_max: 0.5`, 6 m goal):

| | Before | After |
|---|---|---|
| Commanded mean | 0.165 m/s | **0.466 m/s** |
| Commanded max | 0.173 m/s | **0.500 m/s** (reaches `vx_max`) |
| Ground-truth mean | 0.138 m/s | **0.452 m/s** |

Raising `vx_max` alone does nothing (0.5 → 1.5 changed nothing), so this is not tuning.

Part of PickNikRobotics/moveit_pro#21202.

## Approach

One parameter. `open_loop` comes from ros-navigation/navigation2#5617, which is merged to nav2 `main` but was never backported to the Jazzy release; moveit_pro#21347 pins a build that carries it. The comment records why the setting exists so it is not mistaken for arbitrary tuning.

## Release notes

None
