### PR TITLE
Fix: vla_sim teleop gripper close/open falls back to unconfigured default Objective

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,7 @@ Every objective XML file must include a `MetadataFields` block inside the `TreeN
 
 - `runnable` — set to `"true"` for top-level objectives the user can run, `"false"` for subtrees only called by other objectives
 - `subcategory` — groups the objective in the UI (e.g., `"AprilTag"`, `"Grasping"`, `"MuJoCo Simulation"`)
+
+### A gripper config needs `close_gripper.xml` / `open_gripper.xml`, or teleop gripper silently fails
+
+Teleoperation drives the gripper by looking up Objectives named exactly `"Close Gripper"` / `"Open Gripper"` (the `Request Teleoperation` SubTree in moveit_pro core). If a config package doesn't provide those overrides in its `objectives/` directory, the lookup falls back to moveit_pro's core placeholder, which logs `[ERROR] LogMessage Error: This robot configuration does not have a \`Close Gripper\` Objective configured to override this default.` on every BT tick for as long as the control is held, and the gripper never moves — even if some other Objective in the same config already drives the gripper directly via `MoveGripperAction` (that path bypasses the named-Objective lookup entirely). Any new config with a gripper needs both files; see `moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/{close,open}_gripper.xml` for the reference pattern.

--- a/src/vla_sim/objectives/close_gripper.xml
+++ b/src/vla_sim/objectives/close_gripper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Close Gripper">
+  <BehaviorTree
+    ID="Close Gripper"
+    _description="Close the gripper"
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="root">
+      <Action
+        ID="MoveGripperAction"
+        gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
+        position="0.7"
+        timeout="15.000000"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Close Gripper">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Grasping" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/vla_sim/objectives/open_gripper.xml
+++ b/src/vla_sim/objectives/open_gripper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Open Gripper">
+  <BehaviorTree
+    ID="Open Gripper"
+    _description="Open the gripper"
+    _favorite="false"
+  >
+    <Control ID="Sequence" name="root">
+      <Action
+        ID="MoveGripperAction"
+        gripper_command_action_name="/robotiq_gripper_controller/gripper_cmd"
+        position="0.0"
+        timeout="15.000000"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Open Gripper">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Grasping" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
Closing (or opening) the gripper during teleoperation in `vla_sim` does nothing and spams the log with:

```
[ERROR] LogMessage Error: This robot configuration does not have a `Close Gripper` Objective configured to override this default.
```

repeated on every BT tick (~10ms) for as long as the control is held — same for Open Gripper.

**Cause:** Teleoperation invokes the gripper through a named-Objective lookup ("Close Gripper" / "Open Gripper" SubTree in `Request Teleoperation`), which every other sim config (`lab_sim`, `kinova_sim`, `hangar_sim`, `dual_arm_sim`, etc.) overrides with a config-specific Objective that calls `MoveGripperAction`. `vla_sim` never got one, so the lookup falls back to moveit_pro's core placeholder, which logs an error and always fails by design (it exists to flag exactly this kind of missing config, not to silently no-op).

Confirmed the mechanism still works for this robot: `vla_sim`'s own `stack_cubes_with_the_vla_policy.xml` already drives the same gripper via `MoveGripperAction` on `/robotiq_gripper_controller/gripper_cmd` directly — it just doesn't go through the named-Objective path teleop uses.

**Fix:** add `close_gripper.xml` / `open_gripper.xml` overrides for `vla_sim`, following the same `MoveGripperAction` pattern (and joint range: `robotiq_85_left_knuckle_joint` limit is `0.0`–`0.8` in this config's own URDF) used by the other Robotiq-85 configs.
