### PR TITLE
Fix: Remove the web_ui service dropped in 10.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
   # The base image that all MoveIt Pro services extend off of. Builds the user workspace.
   base: {}
 
-  # Starts the MoveIt Pro runtime: the Agent and its Bridge to the Web UI.
+  # Starts the MoveIt Pro Runtime: the Agent and its Bridge to the Desktop App.
   runtime:
     environment:
       # The vla_sim adapter's target; derived from the same
@@ -22,9 +22,6 @@ services:
     volumes:
       # Allow access to host hardware e.g. RealSense cameras
       - /dev:/dev
-
-  # Starts the web UI frontend.
-  web_ui: {}
 
   # Developer specific configuration when running `moveit_pro dev`.
   dev:


### PR DESCRIPTION
[written by AI]

`docker-compose.yaml` mirrored a `web_ui` service for merging with `/opt/moveit_pro/docker-compose.yaml`, but MoveIt Pro 10.0 removed that service — the Desktop App is a host application, not a container. A service that exists only in the workspace file has no image and no build context, so Compose rejects the entire merged project:

```
service "web_ui" has neither an image nor a build context specified: invalid compose project
```

The launcher passes this file as an extra `-f` on every command (`bin/scripts/moveit_pro_docker_wrapper.py`, `get_extra_compose_file`), so `moveit_pro run`, `build`, `shell`, and `down` all fail — not just starting the UI.

Deletion is the whole fix: nothing in Compose replaces `web_ui`. `moveit_pro run` notifies an already-installed Desktop App through pairing discovery (`bin/scripts/moveit_pro.py`, `schedule_local_backend_registration`). The `runtime` comment is updated to current product terminology in passing.

Manual verification — merging this file with the 10.0 product Compose file:

```bash
git -C moveit_pro show origin/v10.0:docker-compose-prod.yaml > prod.yaml
docker compose -f prod.yaml -f docker-compose.yaml config
```

Fails with the error above on `v10.0`; exits 0 on this branch, resolving to `base`, `runtime`, `drivers`.

Reported in PickNikRobotics/moveit_pro#21456. Customer workspaces carry the same line — the 9.0 migration guide instructs adding it — so PickNikRobotics/moveit_pro#21459 adds a removal step to the 10.0 user workspace migration guide.
