### PR TITLE
Fix: Remove web_ui compose service that no longer exists in v10

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
   # The base image that all MoveIt Pro services extend off of. Builds the user workspace.
   base: {}
 
-  # Starts the MoveIt Pro runtime: the Agent and its Bridge to the Web UI.
+  # Starts the MoveIt Pro Runtime: the Agent and the web bridge the
+  # MoveIt Pro Desktop App connects to.
   runtime:
     environment:
       # The vla_sim adapter's target; derived from the same
@@ -22,9 +23,6 @@ services:
     volumes:
       # Allow access to host hardware e.g. RealSense cameras
       - /dev:/dev
-
-  # Starts the web UI frontend.
-  web_ui: {}
 
   # Developer specific configuration when running `moveit_pro dev`.
   dev:


### PR DESCRIPTION
[written by AI]

## Motivation

Every `Deploy release` job on the `10.0.0-rc*` tags fails while building this workspace:

```
service "web_ui" has neither an image nor a build context specified: invalid compose project
Failed to build user workspace at .../moveit_pro_example_ws
```

MoveIt Pro 10 removed the `web_ui` container from the default backend deployment. This file mirrors the product's services for Compose merging, and still lists `web_ui: {}`. With nothing on the product side left to merge into, the entry has neither an image nor a build context, so Docker rejects the whole project and `moveit_pro build` aborts.

That one line takes down 7 jobs in CI run [31671827280](https://github.com/PickNikRobotics/moveit_pro/actions/runs/31671827280): `Install deb` on ubuntu:24.04 / ubuntu:26.04 / debian:bookworm / debian:trixie, `Install rpm` on fedora:42 / fedora:43, and `AMI Build (Release)` — the AMI fails the same way, inside cloud-init's `moveit_pro build`.

## Brief description

Removes the `web_ui: {}` entry. Also corrects the `runtime` comment, which described the service as bridging to a Web UI that no longer ships.

## How it was tested

Merged this workspace's `docker-compose.yaml` against `docker-compose-prod.yaml` from `moveit_pro` `v10.0` (`0c7f628170`), which is what the launcher does:

```
docker compose -f docker-compose-prod.yaml -f <ws>/docker-compose.yaml config --services
```

- Before: `service "web_ui" has neither an image nor a build context specified: invalid compose project` — byte-identical to the CI failure.
- After: exits clean, listing `base`, `drivers`, `runtime`.

## Note on timing

The launcher clones this workspace pinned to the installed MoveIt Pro version, so the Deploy jobs only pick this up once it is merged **and** included in the example_ws tag cut for the next RC. Merging alone will not turn `10.0.0-rc3` green.

`main` carries the same `web_ui: {}` and needs the same removal so 10.1 does not inherit it — not included here.
