### PR TITLE
Fix: vla_sim config missing required runtime_launch_file

### DIFF
--- a/src/vla_sim/config/config.yaml
+++ b/src/vla_sim/config/config.yaml
@@ -4,6 +4,10 @@
 #
 ###############################################################
 
+runtime_launch_file:
+  package: "vla_sim"
+  path: "launch/runtime.launch.xml"
+
 # Baseline hardware configuration parameters for MoveIt Pro.
 # [Required]
 hardware:


### PR DESCRIPTION
[written by AI]

`vla_sim`'s configuration cannot start on MoveIt Pro 10.0: `config.yaml` never declares `runtime_launch_file`, which the platform requires (`MoveItProConfig` in `moveit_pro` has no default for this field). Every other runnable configuration in this workspace already declares it (`april_tag_sim`, `dual_arm_sim`, `factory_sim`, `grinding_sim`, `hangar_sim`, `kitchen_sim`, `lab_sim`, `lunar_sim`), and `vla_sim`'s own `launch/runtime.launch.xml` already exists — only the pointer to it was missing.

Adds the same four-line block used by the other configs, matched to `lab_sim`'s exact key style, placed right after the file header and before the baseline hardware comment:

```yaml
runtime_launch_file:
  package: "vla_sim"
  path: "launch/runtime.launch.xml"
```

Found while validating the `vla_sim` training-data documentation.

The same gap exists on `main` — this PR does not fix it there. That needs a separate decision (forward-port vs. merge-back) rather than a second PR opened here.