### PR TITLE
Add Collect Training Data with Behaviors Objective to lab_sim

### DIFF
--- a/src/lab_sim/objectives/collect_training_data_with_behaviors.xml
+++ b/src/lab_sim/objectives/collect_training_data_with_behaviors.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root
+  BTCPP_format="4"
+  main_tree_to_execute="Collect Training Data with Behaviors"
+>
+  <BehaviorTree
+    ID="Collect Training Data with Behaviors"
+    _description="Wraps the Pick April Tag Labeled Object task with data-recording Behaviors: starts a Trainer recording, runs the task, saves the successful episode, and converts the dataset to LeRobotDataset v3.0. A failed pick is discarded and the Objective fails."
+    _favorite="false"
+  >
+    <Control ID="Fallback" name="RecordWithCleanup">
+      <Control ID="Sequence" name="RecordAndConvert">
+        <Action
+          ID="RecordEpisode"
+          name="Start Trainer recording"
+          dataset_name="behavior_bottle_pick"
+          task="Pick up an AprilTag-labeled bottle."
+          config_name="lab_sim"
+          num_episodes="1"
+        />
+        <!--Let the recording settle before motion begins.-->
+        <Action
+          ID="WaitForDuration"
+          name="Let recording settle"
+          delay_duration="2.0"
+        />
+        <SubTree ID="Pick April Tag Labeled Object" _collapsed="true" />
+        <Action ID="SaveEpisode" name="Keep successful demonstration" />
+        <!--Let the saved episode finish updating in Trainer before the
+             session closes.-->
+        <Action
+          ID="WaitForDuration"
+          name="Let episode finish saving"
+          delay_duration="1.0"
+        />
+        <Action ID="StopRecording" name="Finish recording session" />
+        <Action
+          ID="ConvertDataset"
+          name="Convert to LeRobot dataset"
+          dataset_name="behavior_bottle_pick"
+        />
+      </Control>
+      <!--Cleanup, not a forced success: if the task fails before SaveEpisode,
+           StopRecording discards the unsaved attempt and AlwaysFailure
+           preserves the Objective's failed result, so a failed pick is never
+           labeled as a successful demonstration.-->
+      <Control ID="Sequence" name="DiscardFailedAttempt">
+        <Action ID="StopRecording" name="Discard unsaved attempt" />
+        <Action ID="AlwaysFailure" />
+      </Control>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Collect Training Data with Behaviors">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - Advanced Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/pick_from_pose.xml
+++ b/src/lab_sim/objectives/pick_from_pose.xml
@@ -83,7 +83,7 @@
         joint_trajectory_msg="{joint_trajectory_msg}"
         path="{retract_path}"
         planning_group_name="manipulator"
-        position_only="false"
+        cartesian_constraint="[{constraint_type: position_and_orientation}]"
         tip_links="grasp_link"
         trajectory_timing="[{mode: time_optimal}]"
       />

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -274,6 +274,7 @@ cancel_objectives = {
 # Objectives to skip entirely from integration testing
 skip_objectives = {
     "AddBottlesToPlanningScene",
+    "Collect Training Data with Behaviors",  # Requires setup for data collection (recording infrastructure not available in CI)
     "Grasp Planning",
     "Joint Diagnostic",
     "ML Find Bottles on Table from Image Exemplar",  # Skipped because it looks for a file on a home path


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#21510

## Problem

The [Collect Training Data with Behaviors](https://docs.picknik.ai/next/how_to/vla/collect_training_data_with_behaviors/) guide walks the reader through building a recording-wrapper Objective in `lab_sim`, but the Objective itself does not ship with the config — QA has to rebuild it by hand and users have no reference to open.

## Changes

- **New `Collect Training Data with Behaviors` Objective** (`src/lab_sim/objectives/collect_training_data_with_behaviors.xml`), matching the guide exactly: a `Fallback` whose first `Sequence` runs `RecordEpisode` (`dataset_name=behavior_bottle_pick`, `config_name=lab_sim`, `num_episodes=1`) → 2 s settle → the collapsed `Pick April Tag Labeled Object` Subtree → `SaveEpisode` → 1 s settle → `StopRecording` → `ConvertDataset`. The second `Sequence` (`StopRecording` → `AlwaysFailure`) discards an unsaved failed attempt and preserves the failed result, so a failed pick is never labeled as a successful demonstration.
- **`Pick from Pose`**: replaced the deprecated `PlanCartesianPath` `position_only="false"` port with the equivalent `cartesian_constraint="[{constraint_type: position_and_orientation}]"`. The wrapped task uses this Subtree for its retract move, and the deprecated port made every run of the new Objective emit a deprecation warning.

## Verification

- All node IDs and port names were checked against the Behavior sources in moveit_pro (`providedPorts()` of `RecordEpisode`, `SaveEpisode`, `StopRecording`, `ConvertDataset`, `PlanCartesianPath`) rather than written from memory; the `cartesian_constraint` YAML form matches the parser's accepted syntax.
- The Objective was run in `lab_sim` before the `Pick from Pose` port migration; that run surfaced the `position_only` deprecation warning this PR removes. It has not yet been re-run on top of the migration — worth one QA pass before merge.
