### PR TITLE
feat: add SO-101 live robot and VLA workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ log/
 .vscode/
 MUJOCO_LOG.TXT
 .ccache/
-
 __pycache__/
 
 # VLA checkpoint drop folder: multi-GB model weights must never be committed.
@@ -16,3 +15,9 @@ src/vla_sim/hf_cache/*
 # Machine-local launcher/workspace settings and secrets (HF_TOKEN etc.).
 .env
 .env.*
+
+.pytest_cache/
+**/.pytest_cache/
+**/__pycache__/
+**/*.egg-info/
+artifacts/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ git submodule foreach --recursive git lfs pull
 - `moveit_pro_ur_configs/multi_arm_sim`
 - `moveit_pro_ur_configs/picknik_ur_base_config`
 - `moveit_pro_ur_configs/picknik_ur_site_config`
+- `so101_moveit_config`
+- `so101_moveit_hardware_config`
+
+## SO-101 VLA workspace
+
+This fork includes a single-follower SO-101 configuration for MuJoCo
+simulation and a physical arm whose Feetech hardware driver, controller
+manager, and standard ros2_control controllers run on its Raspberry Pi.
+MoveIt Pro connects through a directionally filtered ROS2DDS bridge; the same
+stable camera topics and VLA Objectives are available in simulation and
+hardware. See
+[the SO-101 workspace guide](docs/so101/README.md).
 
 ## Updating Submodules
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,12 @@ services:
   # MoveIt Pro Desktop App connects to.
   runtime:
     environment:
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_cyclonedds_cpp}
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - SO101_GRIPPER_RTSP_URL=${SO101_GRIPPER_RTSP_URL:-}
+      - SO101_HEAD_RTSP_URL=${SO101_HEAD_RTSP_URL:-}
+      - SO101_ROBOT_HOST=${SO101_ROBOT_HOST:-so101-pi.tail337068.ts.net}
+      - MOVEIT_WEBRTC_PASSTHROUGH=${MOVEIT_WEBRTC_PASSTHROUGH:-}
       # The vla_sim adapter's target; derived from the same
       # MOVEIT_INFERENCE_PORT that publishes the server's host port, so
       # changing the port is a one-variable edit. No other config reads it.
@@ -20,6 +26,9 @@ services:
 
   # Starts the robot drivers.
   drivers:
+    environment:
+      RMW_IMPLEMENTATION: "${RMW_IMPLEMENTATION:-rmw_cyclonedds_cpp}"
+      ROS_DOMAIN_ID: "${ROS_DOMAIN_ID:-0}"
     volumes:
       # Allow access to host hardware e.g. RealSense cameras
       - /dev:/dev
@@ -30,13 +39,13 @@ services:
       # Allow access to host hardware e.g. RealSense cameras
       - /dev:/dev
 
-  # LeRobot VLA inference server for the vla_sim config (src/vla_sim/docker/).
+  # LeRobot VLA inference server shared by vla_sim and SO-101.
   # The workspace half of the product's `inference_server` skeleton (see
   # /opt/moveit_pro/docker-compose.yaml): the two same-named services merge,
   # with the product side owning lifecycle, GPU runtime, security, and the
   # published port. Only `moveit_pro run --with-inference-server` and
-  # `--only-inference-server` build or start it. Model selection lives in
-  # src/vla_sim/config/vla_serving.yaml, mounted at /vla_config; everything
+  # `--only-inference-server` build or start it. Model selection lives in the
+  # selected config's vla_serving.yaml, mounted at /vla_config; everything
   # below is a host setting.
   inference_server:
     # Declared here too, so a launcher whose compose file carries no
@@ -50,6 +59,9 @@ services:
       context: ${MOVEIT_HOST_USER_WORKSPACE:-.}/src/vla_sim/docker
       dockerfile: Dockerfile.vla_inference_server
       args:
+        # The Dockerfile owns the torch package mapping for each product
+        # target; policy code continues to use torch's vendor-neutral API.
+        MOVEIT_TARGET: ${MOVEIT_TARGET:-}
         TORCH_INDEX: ${VLA_TORCH_INDEX:-}
     # Host facts only; model knobs live in vla_serving.yaml (mounted below).
     environment:
@@ -78,9 +90,9 @@ services:
       # /models/<checkpoint-dir>. VLA_MODELS_DIR overrides the host folder
       # for checkpoints stored elsewhere.
       - ${VLA_MODELS_DIR:-${MOVEIT_HOST_USER_WORKSPACE:-.}/src/vla_sim/models}:/models:ro
-      # Model-serving config (checkpoint, fps, device, ...); edits picked up on
-      # restart, no image rebuild.
-      - ${MOVEIT_HOST_USER_WORKSPACE:-.}/src/vla_sim/config:/vla_config:ro
+      # Model-serving config (checkpoint, fps, device, ...); the SO-101
+      # launcher selects its config directory through VLA_CONFIG_DIR.
+      - ${VLA_CONFIG_DIR:-${MOVEIT_HOST_USER_WORKSPACE:-.}/src/vla_sim/config}:/vla_config:ro
       # The server script and its tests; edits take effect on restart, no
       # image rebuild, and `docker exec ... python -m unittest` reaches the
       # test suite (see src/vla_sim/docker/README.md).

--- a/docs/so101/README.md
+++ b/docs/so101/README.md
@@ -77,6 +77,13 @@ stitching. The launcher permits normal planning and teleoperation with the
 Pi's standard trajectory controller, but refuses a requested inference launch
 until JTAC is installed in the Pi sidecar.
 
+The hardware configuration shadows MoveIt Pro's `Request Teleoperation`
+Objective to make that controller split explicit. It initializes the UI's
+velocity scale to `0.75` before accepting a waypoint and routes joint-slider,
+interactive-marker, and waypoint plans through
+`joint_trajectory_controller`. JTAC remains reserved for VLA trajectory chunk
+stitching.
+
 ## Cameras
 
 The physical cameras keep their existing MediaMTX RTSP streams. For a camera
@@ -107,6 +114,10 @@ workspace before any live test.
 4. Validate simulation policy behavior before selecting a live checkpoint.
 5. Only after explicit authorization, test bounded gripper, waypoint, jog, and
    policy motions in that order.
+
+If a waypoint produces clicking, stop the attempt and inspect the physical
+joint and tracking error. Do not increase path tolerances to make a stalled
+joint appear successful.
 
 Logs for the workstation ROS2DDS client are retained under
 `${XDG_STATE_HOME:-$HOME/.local/state}/so101-moveit-pro/`.

--- a/docs/so101/README.md
+++ b/docs/so101/README.md
@@ -11,8 +11,9 @@ contract.
 ## Start on the Framework Desktop
 
 The launcher detects the local Tailscale address for WebRTC, downloads and
-verifies the matching ROS2DDS bridge when needed, and checks the Pi with a
-typed `ListControllers` request before starting the MoveIt Pro Agent:
+verifies the matching ROS2DDS bridge when needed, isolates local DDS to
+loopback, and checks the Pi's typed controller activity before starting the
+MoveIt Pro Runtime:
 
 ```bash
 ./scripts/run-so101.bash

--- a/docs/so101/README.md
+++ b/docs/so101/README.md
@@ -79,10 +79,17 @@ until JTAC is installed in the Pi sidecar.
 
 The hardware configuration shadows MoveIt Pro's `Request Teleoperation`
 Objective to make that controller split explicit. It initializes the UI's
-velocity scale to `0.75` before accepting a waypoint and routes joint-slider,
+velocity scale to `0.25` before accepting a waypoint and routes joint-slider,
 interactive-marker, and waypoint plans through
 `joint_trajectory_controller`. JTAC remains reserved for VLA trajectory chunk
 stitching.
+
+The simulation-only `Ready` waypoint is intentionally absent from the physical
+configuration. It extends the arm and must not be treated as a commissioned
+hardware pose. Live hardware exposes only the measured, folded `Home` pose
+until a load-bearing Ready pose has been validated on that robot. Physical
+planning and teleoperation also use lower velocity and acceleration limits
+than simulation.
 
 ## Cameras
 

--- a/docs/so101/README.md
+++ b/docs/so101/README.md
@@ -1,0 +1,111 @@
+# SO-101 with MoveIt Pro
+
+This workspace runs one SO-101 follower in MuJoCo or connects MoveIt Pro to
+the physical robot's Pi-hosted `ros2_control` stack. The Runtime and VLA
+inference server run together on the Linux workstation; the Pi remains the
+only process that owns the servo bus.
+
+See [Architecture](ROS2_ZENOH_ARCHITECTURE.md) for the host boundary and ROS
+contract.
+
+## Start on the Framework Desktop
+
+The launcher detects the local Tailscale address for WebRTC, downloads and
+verifies the matching ROS2DDS bridge when needed, and checks the Pi with a
+typed `ListControllers` request before starting the MoveIt Pro Agent:
+
+```bash
+./scripts/run-so101.bash
+```
+
+The default Pi hostname is `so101-pi.tail337068.ts.net`. Override it without
+editing the workspace:
+
+```bash
+./scripts/run-so101.bash --robot-host 100.x.y.z
+```
+
+The launch fails closed if the Pi cannot answer with an active joint-state
+broadcaster, trajectory controller, and gripper controller. It does not start
+the Pi motion profile, enable torque, or command motion.
+
+Run the MuJoCo configuration without the Pi:
+
+```bash
+./scripts/run-so101.bash --simulation
+```
+
+## VLA inference
+
+No policy is selected by default. This is intentional: a checkpoint determines
+physical commands and must be compatible with the real robot's coordinate and
+camera contract. Select one for the current run with:
+
+```bash
+./scripts/run-so101.bash --checkpoint organization/model
+```
+
+For a private or gated model, authenticate once with `hf auth login`. The
+launcher honors an existing `HF_TOKEN`; otherwise it reads `hf auth token`
+without printing or persisting the token itself. You can also set the
+checkpoint in
+`src/so101_moveit_config/config/vla_serving.yaml`. A local checkpoint mounted
+under `src/vla_sim/models/` is addressed as `/models/<directory>`.
+
+Inference starts automatically when a checkpoint is selected. MoveIt Pro's
+detected product target chooses ROCm on the Framework Desktop, CUDA on a
+supported NVIDIA system, and CPU otherwise. Force the sidecar on or off with
+`--with-inference` and `--without-inference`.
+
+A live SO-101 checkpoint must use:
+
+- state and action order `Rotation_R`, `Pitch_R`, `Elbow_R`, `Wrist_Pitch_R`,
+  `Wrist_Roll_R`, `Jaw_R`;
+- radians for revolute joints and meters for `Jaw_R`;
+- the physical overhead and wrist camera observations expected by the
+  Objective; and
+- a known training frame rate, with the Objective's `dt` set to its inverse.
+
+Simulation checkpoints trained with degree-space actions or a different camera
+set are not safe substitutes. The inference server validates dimensions and
+camera names, but it cannot infer a checkpoint's physical coordinate meaning.
+
+MoveIt Pro 10.0's `ExecutePolicy` uses the
+`joint_trajectory_admittance_controller` action for trajectory chunk
+stitching. The launcher permits normal planning and teleoperation with the
+Pi's standard trajectory controller, but refuses a requested inference launch
+until JTAC is installed in the Pi sidecar.
+
+## Cameras
+
+The physical cameras keep their existing MediaMTX RTSP streams. For a camera
+pane, the launcher maps the stable ROS topic name directly to its RTSP source
+through MoveIt Pro's built-in WebRTC passthrough. This avoids decoding frames
+to ROS and re-encoding them merely for display.
+
+The same topics remain available as `sensor_msgs/Image` for policy inference,
+Trainer, and ROS recording:
+
+- `/so101/cameras/overhead/image_raw`
+- `/so101/cameras/wrist/image_raw`
+
+The camera bridge opens an RTSP decoder only while a ROS image subscriber
+exists. Simulation publishes the same topic names from MuJoCo and does not use
+RTSP passthrough.
+
+## Safe bring-up order
+
+MoveIt Pro's Stop control is a cooperative software stop, not a safety-rated
+emergency stop. Keep physical power isolation accessible and clear the robot's
+workspace before any live test.
+
+1. Deploy and select the Pi's MoveIt motion profile without activating it from
+   this workspace.
+2. Run the launcher and verify its read-only controller preflight succeeds.
+3. Confirm joint states and both camera panes without commanding motion.
+4. Validate simulation policy behavior before selecting a live checkpoint.
+5. Only after explicit authorization, test bounded gripper, waypoint, jog, and
+   policy motions in that order.
+
+Logs for the workstation ROS2DDS client are retained under
+`${XDG_STATE_HOME:-$HOME/.local/state}/so101-moveit-pro/`.

--- a/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
+++ b/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
@@ -37,6 +37,11 @@ that claims a physical command interface. The hardware config therefore sets
 `controllers_not_managed`. The Framework Desktop owns planning, user
 interaction, camera adaptation, and policy inference.
 
+MoveIt Pro's drivers container remains present as a lifecycle dependency. Its
+hardware launch file monitors the Pi's read-only joint-state heartbeat and
+fails if valid state stops arriving. It does not receive the serial device,
+publish commands, or start another controller manager.
+
 `robot_state_publisher` still runs with MoveIt Pro because the filtered Pi
 bridge does not export `/robot_description`. The Pi's local publisher remains
 inside its isolated DDS graph.
@@ -46,7 +51,8 @@ inside its isolated DDS graph.
 | Endpoint | Owner | Purpose |
 | --- | --- | --- |
 | `/joint_states` | Pi | Measured six-joint state |
-| `/controller_manager/list_controllers` | Pi | Typed readiness and controller inventory |
+| `/controller_manager/activity` | Pi | Durable typed readiness and controller inventory |
+| `/controller_manager/list_controllers` | Pi | On-demand controller inventory |
 | `/controller_manager/switch_controller` | Pi | JTC/JTAC/VFC/JVC handoff |
 | `/joint_trajectory_controller/follow_joint_trajectory` | Pi | Planned waypoint and teleoperation motion |
 | `/joint_trajectory_admittance_controller/follow_joint_trajectory` | Pi | VLA chunk stitching through `FollowJointTrajectoryWithAdmittance` |
@@ -75,10 +81,13 @@ its pixels arrive from MuJoCo or the physical RTSP relay.
 
 ## Startup and failure behavior
 
-The workstation launcher starts only its local ROS2DDS client, then calls the
-Pi's typed `ListControllers` service from an ephemeral Runtime container. The
-MoveIt Pro Agent is not started until the required controllers answer in their
-expected active states. Endpoint discovery alone is not treated as readiness.
+The workstation launcher gives its ROS2DDS client and the Runtime the same
+loopback-only CycloneDDS profile. Zenoh is the only network transport between
+hosts. The bridge is pinned to the Jazzy wire contract, and the launcher reads
+the Pi's transient-local `ControllerManagerActivity` message from an ephemeral
+Runtime container. The MoveIt Pro Runtime is not started until the required
+controllers report their expected active states. Endpoint discovery alone is
+not treated as readiness.
 
 Inference adds one more gate: the selected checkpoint must be non-empty and
 the Pi must expose JTAC. A missing Hugging Face token, incompatible checkpoint,
@@ -92,19 +101,18 @@ operator-authorized actions.
 
 ## Pi sidecar requirement for VLA
 
-The current `so101-robot-ops` sidecar provides JTC, gripper, VFC, and JVC but
-does not yet stage or spawn JTAC. Its companion change must:
+The corresponding `so101-robot-ops` deployment must:
 
 1. copy the arm64 `joint_trajectory_admittance_controller` prefix from the
    licensed MoveIt Pro Runtime into the Pi image;
 2. declare JTAC with `planning_group_name: manipulator`, the SO-101 tool
-   frames, five stop accelerations, and `ft_sensor_name: ""` because this robot
-   has no force/torque sensor;
+   frames, five stop accelerations, and no force/torque sensor because this
+   robot has none;
 3. load JTAC inactive while leaving JTC active at startup; and
 4. export
    `/joint_trajectory_admittance_controller/follow_joint_trajectory` as an
    action server in the Pi ROS2DDS filter.
 
-The workstation filter in this workspace already imports the matching action
-client. Until the Pi change is deployed, the launcher reports planning-only
-readiness and refuses `--with-inference`.
+The workstation filter in this workspace imports the matching action client.
+Until a Pi deployment satisfies the contract, the launcher reports
+planning-only readiness and refuses `--with-inference`.

--- a/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
+++ b/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
@@ -1,0 +1,110 @@
+# SO-101 architecture
+
+## Host ownership
+
+```text
+Framework Desktop                                      Raspberry Pi
+
+MoveIt Pro Desktop App
+          |
+MoveIt Pro Runtime ── built-in WHEP/WebRTC
+  ├─ planning and Objectives             RTSP 8554 <── MediaMTX cameras
+  ├─ on-demand RTSP-to-ROS camera bridge
+  ├─ GetActionChunk HTTP adapter
+  └─ local CycloneDDS
+          |
+  ROS2DDS client ═══════ Zenoh/TCP 7448 ═══════ ROS2DDS router
+                                                    |
+                                              local CycloneDDS
+                                                    |
+                                              controller_manager
+                                                ├─ state broadcaster
+                                                ├─ JTC + gripper
+                                                ├─ JTAC for VLA
+                                                └─ VFC/JVC for jog
+                                                    |
+                                           Feetech hardware interface
+                                                    |
+                                               servo serial bus
+
+ROCm inference server
+  └─ local HTTP 8973 ───────────────> GetActionChunk adapter
+```
+
+The Pi owns the hardware interface, controller manager, and every controller
+that claims a physical command interface. The hardware config therefore sets
+`launch_control_node: false` and lists every Pi controller under
+`controllers_not_managed`. The Framework Desktop owns planning, user
+interaction, camera adaptation, and policy inference.
+
+`robot_state_publisher` still runs with MoveIt Pro because the filtered Pi
+bridge does not export `/robot_description`. The Pi's local publisher remains
+inside its isolated DDS graph.
+
+## ROS control contract
+
+| Endpoint | Owner | Purpose |
+| --- | --- | --- |
+| `/joint_states` | Pi | Measured six-joint state |
+| `/controller_manager/list_controllers` | Pi | Typed readiness and controller inventory |
+| `/controller_manager/switch_controller` | Pi | JTC/JTAC/VFC/JVC handoff |
+| `/joint_trajectory_controller/follow_joint_trajectory` | Pi | Planned waypoint and teleoperation motion |
+| `/joint_trajectory_admittance_controller/follow_joint_trajectory` | Pi | VLA chunk stitching through `FollowJointTrajectoryWithAdmittance` |
+| `/gripper_controller/gripper_cmd` | Pi | Physical jaw command |
+| `/velocity_force_controller/*` | Pi | Pose Jog commands and services |
+| `/joint_velocity_controller/*` | Pi | Joint Jog commands and services |
+| `/get_action_chunk` | Framework Desktop | ExecutePolicy-to-inference adapter |
+
+The bridge filters are directional. The Pi exports state plus service and
+action servers; the workstation exports commands plus service and action
+clients. Neither side imports and exports the same server endpoint, preventing
+a bridge-created proxy from reflecting a goal back into itself.
+
+## Video paths
+
+One camera has two consumers but does not need one expensive path:
+
+- Camera panes use `MOVEIT_WEBRTC_PASSTHROUGH` to relay the existing RTSP
+  stream through MoveIt Pro's MediaMTX/WHEP server.
+- Policy inference, Trainer, and recording subscribe to the stable ROS image
+  topic. That demand starts the RTSP decoder in `so101_camera_bridge`; it stops
+  after the last subscriber leaves.
+
+The Desktop App therefore sees the same ROS topic name regardless of whether
+its pixels arrive from MuJoCo or the physical RTSP relay.
+
+## Startup and failure behavior
+
+The workstation launcher starts only its local ROS2DDS client, then calls the
+Pi's typed `ListControllers` service from an ephemeral Runtime container. The
+MoveIt Pro Agent is not started until the required controllers answer in their
+expected active states. Endpoint discovery alone is not treated as readiness.
+
+Inference adds one more gate: the selected checkpoint must be non-empty and
+the Pi must expose JTAC. A missing Hugging Face token, incompatible checkpoint,
+or unavailable accelerator leaves the inference server in an explicit error
+health state; it does not substitute fake actions or silently fall back from an
+explicit accelerator request.
+
+No workstation startup step activates the Pi motion profile, enables servo
+torque, or sends a trajectory. Those operations remain explicit robot-side and
+operator-authorized actions.
+
+## Pi sidecar requirement for VLA
+
+The current `so101-robot-ops` sidecar provides JTC, gripper, VFC, and JVC but
+does not yet stage or spawn JTAC. Its companion change must:
+
+1. copy the arm64 `joint_trajectory_admittance_controller` prefix from the
+   licensed MoveIt Pro Runtime into the Pi image;
+2. declare JTAC with `planning_group_name: manipulator`, the SO-101 tool
+   frames, five stop accelerations, and `ft_sensor_name: ""` because this robot
+   has no force/torque sensor;
+3. load JTAC inactive while leaving JTC active at startup; and
+4. export
+   `/joint_trajectory_admittance_controller/follow_joint_trajectory` as an
+   action server in the Pi ROS2DDS filter.
+
+The workstation filter in this workspace already imports the matching action
+client. Until the Pi change is deployed, the launcher reports planning-only
+readiness and refuses `--with-inference`.

--- a/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
+++ b/docs/so101/ROS2_ZENOH_ARCHITECTURE.md
@@ -61,6 +61,13 @@ inside its isolated DDS graph.
 | `/joint_velocity_controller/*` | Pi | Joint Jog commands and services |
 | `/get_action_chunk` | Framework Desktop | ExecutePolicy-to-inference adapter |
 
+The SO-101 hardware Objective library overrides `Request Teleoperation` at the
+robot-configuration seam. The override seeds the teleoperation velocity scale
+before the UI and motion branches run in parallel, and defaults planned
+teleoperation motion to the JTC action, controller name, and `jtc` execution
+pipeline. This keeps JTAC available for VLA execution without sending ordinary
+waypoints through its admittance pipeline.
+
 The bridge filters are directional. The Pi exports state plus service and
 action servers; the workstation exports commands plus service and action
 clients. Neither side imports and exports the same server endpoint, preventing

--- a/scripts/cyclonedds-local.xml
+++ b/scripts/cyclonedds-local.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config">
+  <Domain id="any">
+    <General>
+      <Interfaces>
+        <NetworkInterface autodetermine="false" name="lo" />
+      </Interfaces>
+      <AllowMulticast>false</AllowMulticast>
+    </General>
+    <Discovery>
+      <ParticipantIndex>auto</ParticipantIndex>
+      <Peers>
+        <Peer Address="127.0.0.1" />
+      </Peers>
+      <MaxAutoParticipantIndex>120</MaxAutoParticipantIndex>
+    </Discovery>
+    <Internal>
+      <SocketReceiveBufferSize min="10MB" />
+    </Internal>
+  </Domain>
+</CycloneDDS>

--- a/scripts/install-ros2dds-bridge.bash
+++ b/scripts/install-ros2dds-bridge.bash
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROS2DDS_VERSION="1.5.1"
+CACHE_ROOT="${SO101_ROS2DDS_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/so101-ros2dds}"
+
+case "$(uname -m)" in
+  aarch64 | arm64)
+    asset_arch="aarch64"
+    asset_sha256="9bced19b07ea902c72ae403f2ab7221bb12f6378fb9fce4de4c9018f0cb78cdb"
+    ;;
+  x86_64 | amd64)
+    asset_arch="x86_64"
+    asset_sha256="abb86124d0650e8aaa39959d066b54931893bd34db326c287362fc88b2697dd8"
+    ;;
+  *)
+    echo "error: unsupported ROS2DDS bridge architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+asset="zenoh-plugin-ros2dds-${ROS2DDS_VERSION}-${asset_arch}-unknown-linux-gnu-standalone.zip"
+cache_dir="${CACHE_ROOT}/${ROS2DDS_VERSION}/${asset_arch}"
+bridge="${cache_dir}/zenoh-bridge-ros2dds"
+
+if [[ -x "$bridge" ]] &&
+  "$bridge" --version 2>&1 | grep -q "zenoh-bridge-ros2dds v${ROS2DDS_VERSION}"; then
+  printf '%s\n' "$bridge"
+  exit 0
+fi
+
+download_dir="$(mktemp -d "${TMPDIR:-/tmp}/so101-ros2dds.XXXXXX")"
+cleanup() {
+  rm -rf -- "$download_dir"
+}
+trap cleanup EXIT INT TERM
+
+curl --fail --location \
+  --output "${download_dir}/${asset}" \
+  "https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ROS2DDS_VERSION}/${asset}"
+
+if command -v sha256sum >/dev/null; then
+  echo "${asset_sha256}  ${download_dir}/${asset}" |
+    sha256sum --check --strict >&2
+else
+  actual_sha256="$(shasum -a 256 "${download_dir}/${asset}" | awk '{print $1}')"
+  if [[ "$actual_sha256" != "$asset_sha256" ]]; then
+    echo "error: ROS2DDS bridge checksum mismatch" >&2
+    exit 1
+  fi
+fi
+
+python3 -m zipfile -e "${download_dir}/${asset}" "$download_dir"
+mkdir -p "$cache_dir"
+install -m 0755 "${download_dir}/zenoh-bridge-ros2dds" "$bridge"
+printf '%s\n' "$bridge"

--- a/scripts/ros2dds-moveit-control.json5
+++ b/scripts/ros2dds-moveit-control.json5
@@ -1,0 +1,44 @@
+{
+  plugins: {
+    ros2dds: {
+      // Operator side of the standard ros2_control boundary. Import only the
+      // state and servers exported by the Pi. Keeping this direction explicit
+      // prevents bridge-created DDS proxies from being reflected into Zenoh.
+      allow: {
+        publishers: [
+          "/velocity_force_controller/command",
+          "/joint_velocity_controller/command",
+        ],
+        subscribers: [
+          "/joint_states",
+          "/dynamic_joint_states",
+          "/controller_manager/activity",
+          "/velocity_force_controller/.*",
+          "/joint_velocity_controller/.*",
+        ],
+        service_servers: [],
+        service_clients: [
+          "/controller_manager/.*",
+          "/velocity_force_controller/.*",
+          "/joint_velocity_controller/.*",
+        ],
+        action_servers: [],
+        action_clients: [
+          "/joint_trajectory_controller/follow_joint_trajectory",
+          "/joint_trajectory_admittance_controller/follow_joint_trajectory",
+          "/gripper_controller/gripper_cmd",
+        ],
+      },
+      pub_max_frequencies: [
+        "^/joint_states$=50",
+        "^/dynamic_joint_states$=20",
+        "^/controller_manager/activity$=10",
+      ],
+      pub_priorities: [
+        "^/joint_states$=2:express",
+        "^/dynamic_joint_states$=3",
+        "^/controller_manager/activity$=3",
+      ],
+    },
+  },
+}

--- a/scripts/run-so101.bash
+++ b/scripts/run-so101.bash
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="hardware"
+INFERENCE="auto"
+CHECKPOINT="${SO101_VLA_CHECKPOINT:-}"
+ROBOT_HOST="${SO101_ROBOT_HOST:-so101-pi.tail337068.ts.net}"
+ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/so101-moveit-pro"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-so101.bash [options] [-- moveit_pro run options]
+
+Run the SO-101 workspace on the local Linux workstation.
+
+Options:
+  --hardware             Use the Pi-hosted ros2_control stack (default).
+  --simulation           Use the local MuJoCo configuration.
+  --with-inference       Start the local VLA inference sidecar.
+  --without-inference    Do not start the inference sidecar.
+  --checkpoint MODEL     Serve a local /models path or Hugging Face repo id.
+  --robot-host HOST      Override the Pi hostname used for ROS and cameras.
+  -h, --help             Show this help.
+
+Inference is enabled automatically when a checkpoint is configured. HF_TOKEN
+is inherited when set; otherwise the launcher securely reuses `hf auth token`.
+EOF
+}
+
+extra_args=()
+while (($#)); do
+  case "$1" in
+    --hardware)
+      MODE="hardware"
+      ;;
+    --simulation)
+      MODE="simulation"
+      ;;
+    --with-inference)
+      INFERENCE="yes"
+      ;;
+    --without-inference)
+      INFERENCE="no"
+      ;;
+    --checkpoint)
+      shift
+      (($#)) || {
+        echo "error: --checkpoint requires a value" >&2
+        exit 2
+      }
+      CHECKPOINT="$1"
+      ;;
+    --robot-host)
+      shift
+      (($#)) || {
+        echo "error: --robot-host requires a value" >&2
+        exit 2
+      }
+      ROBOT_HOST="$1"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      extra_args+=("$@")
+      break
+      ;;
+    *)
+      extra_args+=("$1")
+      ;;
+  esac
+  shift
+done
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "error: run this launcher on the Linux workstation that hosts MoveIt Pro" >&2
+  echo "The retired Apple container workflow is no longer supported." >&2
+  exit 1
+fi
+
+command -v moveit_pro >/dev/null || {
+  echo "error: moveit_pro is unavailable; install the MoveIt Pro Runtime first" >&2
+  exit 1
+}
+
+mkdir -p "$STATE_DIR"
+
+config_source="${WORKSPACE_DIR}/src/so101_moveit_config/config/vla_serving.yaml"
+configured_checkpoint="$CHECKPOINT"
+if [[ -z "$configured_checkpoint" ]]; then
+  configured_checkpoint="$(python3 - "$config_source" <<'PY'
+from pathlib import Path
+import sys
+
+for line in Path(sys.argv[1]).read_text().splitlines():
+    if line.startswith("checkpoint:"):
+        print(line.partition(":")[2].strip().strip("\"'"))
+        break
+PY
+)"
+fi
+
+vla_config_dir="$(dirname "$config_source")"
+if [[ -n "$CHECKPOINT" ]]; then
+  vla_config_dir="${STATE_DIR}/vla-config"
+  mkdir -p "$vla_config_dir"
+  python3 - "$config_source" "${vla_config_dir}/vla_serving.yaml" "$CHECKPOINT" <<'PY'
+import json
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+checkpoint = sys.argv[3]
+text = source.read_text()
+replacement = f"checkpoint: {json.dumps(checkpoint)}"
+updated, count = re.subn(r"^checkpoint:.*$", replacement, text, count=1, flags=re.M)
+if count != 1:
+    raise SystemExit("vla_serving.yaml has no checkpoint field")
+destination.write_text(updated)
+PY
+fi
+
+if [[ "$INFERENCE" == "auto" ]]; then
+  if [[ -n "$configured_checkpoint" ]]; then
+    INFERENCE="yes"
+  else
+    INFERENCE="no"
+  fi
+fi
+
+if [[ "$INFERENCE" == "yes" && -z "$configured_checkpoint" ]]; then
+  echo "error: inference was requested but no SO-101 checkpoint is selected" >&2
+  echo "Use --checkpoint <HF-repo-or-/models-path> or edit ${config_source}." >&2
+  exit 1
+fi
+
+if [[ "$INFERENCE" == "yes" && -z "${HF_TOKEN:-}" ]] && command -v hf >/dev/null; then
+  hf_token="$(hf auth token 2>/dev/null || true)"
+  if [[ -n "$hf_token" ]]; then
+    export HF_TOKEN="$hf_token"
+  fi
+  unset hf_token
+fi
+
+export RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
+export ROS_DOMAIN_ID
+export VLA_CONFIG_DIR="$vla_config_dir"
+
+if command -v tailscale >/dev/null; then
+  tailscale_ip="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$tailscale_ip" ]]; then
+    export MOVEIT_WEBRTC_ADDITIONAL_HOSTS="${MOVEIT_WEBRTC_ADDITIONAL_HOSTS:+${MOVEIT_WEBRTC_ADDITIONAL_HOSTS},}${tailscale_ip}"
+  fi
+fi
+
+bridge_pid=""
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ -n "$bridge_pid" ]]; then
+    kill -TERM "$bridge_pid" 2>/dev/null || true
+    wait "$bridge_pid" 2>/dev/null || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+config_package="so101_moveit_config"
+if [[ "$MODE" == "hardware" ]]; then
+  config_package="so101_moveit_hardware_config"
+  export SO101_ROBOT_HOST="$ROBOT_HOST"
+  export SO101_HEAD_RTSP_URL="${SO101_HEAD_RTSP_URL:-rtsp://${ROBOT_HOST}:8554/head}"
+  export SO101_GRIPPER_RTSP_URL="${SO101_GRIPPER_RTSP_URL:-rtsp://${ROBOT_HOST}:8554/gripper}"
+  export MOVEIT_WEBRTC_PASSTHROUGH="${MOVEIT_WEBRTC_PASSTHROUGH:-/so101/cameras/overhead/image_raw=${SO101_HEAD_RTSP_URL},/so101/cameras/wrist/image_raw=${SO101_GRIPPER_RTSP_URL}}"
+
+  ros2dds_endpoint="${SO101_ROS2DDS_ENDPOINT:-tcp/${ROBOT_HOST}:7448}"
+  if [[ ! "$ros2dds_endpoint" =~ ^(tcp|tls)/[A-Za-z0-9._:-]+:[0-9]+$ ]]; then
+    echo "error: invalid SO101_ROS2DDS_ENDPOINT: ${ros2dds_endpoint}" >&2
+    exit 1
+  fi
+
+  bridge_binary="$("${SCRIPT_DIR}/install-ros2dds-bridge.bash")"
+  bridge_log="${STATE_DIR}/ros2dds-bridge.log"
+  "$bridge_binary" \
+    --config "${SCRIPT_DIR}/ros2dds-moveit-control.json5" \
+    --ros-localhost-only \
+    client \
+    --connect "$ros2dds_endpoint" \
+    --no-multicast-scouting \
+    --domain "$ROS_DOMAIN_ID" \
+    >"$bridge_log" 2>&1 &
+  bridge_pid=$!
+  sleep 2
+  if ! kill -0 "$bridge_pid" 2>/dev/null; then
+    echo "error: ROS2DDS bridge exited during startup" >&2
+    tail -50 "$bridge_log" >&2
+    exit 1
+  fi
+
+  controller_is_active() {
+    local response="$1"
+    local name="$2"
+    local flattened="${response//$'\n'/ }"
+    local pattern="name='${name}'.*state='active'"
+    [[ "$flattened" =~ $pattern ]]
+  }
+
+  # `moveit_pro shell` uses an ephemeral Runtime container when the stack is
+  # not running. That gives this preflight the same ROS environment and host
+  # network as the real Runtime without starting the Agent first.
+  controller_response="$(
+    # Variables in this command are intentionally expanded inside the Runtime.
+    # shellcheck disable=SC2016
+    moveit_pro shell -s runtime bash -lc '
+      source /opt/ros/jazzy/setup.bash
+      source /opt/overlay_ws/install/setup.bash
+      export ROS2CLI_NO_DAEMON=1
+      for _ in $(seq 1 30); do
+        if response="$(timeout 5 ros2 service call \
+          /controller_manager/list_controllers \
+          controller_manager_msgs/srv/ListControllers \
+          "{}" 2>/dev/null)"; then
+          printf "%s\n" "$response"
+          exit 0
+        fi
+        sleep 2
+      done
+      exit 1
+    ' 2>/dev/null || true
+  )"
+
+  if ! controller_is_active "$controller_response" "joint_state_broadcaster" ||
+    ! controller_is_active "$controller_response" "joint_trajectory_controller" ||
+    ! controller_is_active "$controller_response" "gripper_controller"; then
+    echo "error: the Pi did not provide the typed ros2_control contract" >&2
+    echo "Inspect ${STATE_DIR}/ros2dds-bridge.log and the Pi motion profile." >&2
+    exit 1
+  fi
+
+  echo "SO-101 state, trajectory, and gripper controllers are reachable."
+  if [[ "$controller_response" == *"joint_trajectory_admittance_controller"* ]]; then
+    echo "The VLA trajectory controller is available. No motion has been commanded."
+  elif [[ "$INFERENCE" == "yes" ]]; then
+    echo "error: inference was requested, but the Pi has no joint_trajectory_admittance_controller" >&2
+    echo "ExecutePolicy requires that controller for safe chunk stitching." >&2
+    exit 1
+  else
+    echo "warning: joint_trajectory_admittance_controller is not installed on the Pi." >&2
+    echo "Planning and teleoperation are available; Execute SO101 VLA Policy is not." >&2
+  fi
+else
+  unset MOVEIT_WEBRTC_PASSTHROUGH
+fi
+
+run_args=(run --user-workspace "$WORKSPACE_DIR" -c "$config_package")
+if [[ "$INFERENCE" == "yes" ]]; then
+  run_args+=(--with-inference-server)
+  echo "Starting ${config_package} with checkpoint ${configured_checkpoint}."
+else
+  echo "Starting ${config_package} without inference; no checkpoint is selected."
+fi
+
+moveit_pro "${run_args[@]}" "${extra_args[@]}"

--- a/scripts/run-so101.bash
+++ b/scripts/run-so101.bash
@@ -186,11 +186,24 @@ if [[ "$MODE" == "hardware" ]]; then
     exit 1
   fi
 
+  # The local DDS graph is intentionally loopback-only. Clear inherited host
+  # overrides so the Runtime generates its matching default local profile;
+  # Zenoh remains the only network transport between hosts.
+  unset \
+    USE_HOST_DDS \
+    CYCLONEDDS_NETWORK_INTERFACE \
+    CYCLONEDDS_PEER_ADDRESSES \
+    CYCLONEDDS_USE_MULTICAST \
+    CYCLONEDDS_MAX_AUTO_PARTICIPANT_INDEX \
+    CYCLONEDDS_URI \
+    FASTRTPS_DEFAULT_PROFILES_FILE
+
   bridge_binary="$("${SCRIPT_DIR}/install-ros2dds-bridge.bash")"
   bridge_log="${STATE_DIR}/ros2dds-bridge.log"
-  "$bridge_binary" \
+  ROS_DISTRO=jazzy \
+  CYCLONEDDS_URI="${SCRIPT_DIR}/cyclonedds-local.xml" \
+    "$bridge_binary" \
     --config "${SCRIPT_DIR}/ros2dds-moveit-control.json5" \
-    --ros-localhost-only \
     client \
     --connect "$ros2dds_endpoint" \
     --no-multicast-scouting \
@@ -208,31 +221,23 @@ if [[ "$MODE" == "hardware" ]]; then
     local response="$1"
     local name="$2"
     local flattened="${response//$'\n'/ }"
-    local pattern="name='${name}'.*state='active'"
+    local pattern="name:[[:space:]]*${name}[[:space:]]+state:[[:space:]]+id:[[:space:]]*[0-9]+[[:space:]]+label:[[:space:]]*active"
     [[ "$flattened" =~ $pattern ]]
   }
 
   # `moveit_pro shell` uses an ephemeral Runtime container when the stack is
-  # not running. That gives this preflight the same ROS environment and host
-  # network as the real Runtime without starting the Agent first.
+  # not running. The transient-local activity message gives this preflight the
+  # current typed controller contract without racing a WAN service proxy.
   controller_response="$(
-    # Variables in this command are intentionally expanded inside the Runtime.
-    # shellcheck disable=SC2016
-    moveit_pro shell -s runtime bash -lc '
+    moveit_pro shell -s runtime -- bash -lc '
       source /opt/ros/jazzy/setup.bash
       source /opt/overlay_ws/install/setup.bash
       export ROS2CLI_NO_DAEMON=1
-      for _ in $(seq 1 30); do
-        if response="$(timeout 5 ros2 service call \
-          /controller_manager/list_controllers \
-          controller_manager_msgs/srv/ListControllers \
-          "{}" 2>/dev/null)"; then
-          printf "%s\n" "$response"
-          exit 0
-        fi
-        sleep 2
-      done
-      exit 1
+      timeout 15 ros2 topic echo \
+        --once \
+        --qos-durability transient_local \
+        /controller_manager/activity \
+        controller_manager_msgs/msg/ControllerManagerActivity
     ' 2>/dev/null || true
   )"
 

--- a/src/so101_camera_bridge/README.md
+++ b/src/so101_camera_bridge/README.md
@@ -1,0 +1,66 @@
+# SO-101 camera bridge
+
+This package reads the Pi's existing MediaMTX streams and republishes them as
+ROS 2 images. It never opens `/dev/video*`, changes a Pi service, or sends a
+robot command.
+
+| Physical stream | ROS image topic | Frame |
+| --- | --- | --- |
+| `head` | `/so101/cameras/overhead/image_raw` | `overhead_cam_optical_frame` |
+| `gripper` | `/so101/cameras/wrist/image_raw` | `right_wrist_cam_optical_frame` |
+
+The topic contract is identical to the MuJoCo configuration. Override
+`SO101_HEAD_RTSP_URL` and `SO101_GRIPPER_RTSP_URL` if the Pi address changes.
+The generated `CameraInfo` is an approximate pinhole model until a physical
+camera calibration is available.
+
+## Decoding is on demand
+
+The image topics are advertised from startup, so the camera panes list them and
+`CameraInfo` is always available. Decoding, however, only runs while something is
+actually subscribed to an image topic, and stops again when the last subscriber
+leaves.
+
+This matters because the operator's video no longer comes through here. MoveIt Pro
+relays the Pi's stream straight to the browser (`MOVEIT_WEBRTC_PASSTHROUGH`), so
+decoding every frame to raw and republishing it produced images that nothing read
+— measured at 198 MB and 34 threads for two cameras. Recording, perception
+Behaviors, and anything else that genuinely wants the pixels still get them by
+subscribing.
+
+### Cold-start budget
+
+Subscribing does not produce a frame immediately. Measured against
+`rtsp://so101-pi.tail337068.ts.net:8554/head`:
+
+| Step | Measured |
+| --- | --- |
+| Subscriber matched, `get_subscription_count()` goes non-zero | ~0.14 s |
+| Demand check notices (one publish tick at `publish_fps: 15.0`) | ≤0.07 s |
+| RTSP connect and first decoded frame | 1.4–2.0 s |
+
+So roughly 1.6–2.2 s from subscribe to first image, against `ExecutePolicy`'s
+5 s first-frame timeout. Anything that needs a frame sooner — or that cannot
+tolerate the first attempt failing and retrying after `reconnect_delay_seconds`
+— should keep a subscriber attached rather than subscribing on demand.
+
+### Not stopping on the first idle tick
+
+`decoder_linger_seconds` (default 5.0) is how long the image topic must stay
+unsubscribed before the decoder is torn down. A subscriber that flips away and
+back — switching camera panes, one Behavior handing off to the next — reads as
+zero subscribers for a fraction of a second; measured pane flipping produced 7
+such gaps in 3.2 s. Without the hold-off each gap costs a full RTSP teardown and
+a 1.4–2.0 s reconnect on the upstream camera. Set it to 0.0 to stop on the first
+idle tick.
+
+### CameraInfo geometry
+
+`image_width` and `image_height` (default 640x480, which matches the Pi's
+streams today) describe the camera before anything has been decoded, so
+`CameraInfo` does not need a frame. Once the decoder sees a real frame,
+`CameraInfo` follows the decoded size instead and the node warns once per
+camera: intrinsics that describe a different image than the one published
+alongside them silently corrupt every consumer that projects pixels to poses.
+Set the parameters to match the stream so the info topic is right during the
+window before the first frame.

--- a/src/so101_camera_bridge/package.xml
+++ b/src/so101_camera_bridge/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<package format="3">
+  <name>so101_camera_bridge</name>
+  <version>0.1.0</version>
+  <description>
+    Read-only RTSP camera bridge for the SO-101 MoveIt Pro configuration.
+  </description>
+
+  <maintainer email="noah-wardlow@users.noreply.github.com">Noah</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+
+  <test_depend>python3-numpy</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/so101_camera_bridge/setup.cfg
+++ b/src/so101_camera_bridge/setup.cfg
@@ -1,0 +1,5 @@
+[develop]
+script_dir=$base/lib/so101_camera_bridge
+
+[install]
+install_scripts=$base/lib/so101_camera_bridge

--- a/src/so101_camera_bridge/setup.py
+++ b/src/so101_camera_bridge/setup.py
@@ -1,0 +1,27 @@
+from setuptools import find_packages, setup
+
+
+PACKAGE_NAME = "so101_camera_bridge"
+
+
+setup(
+    name=PACKAGE_NAME,
+    version="0.1.0",
+    packages=find_packages(exclude=("test",)),
+    data_files=[
+        ("share/ament_index/resource_index/packages", [f"resource/{PACKAGE_NAME}"]),
+        (f"share/{PACKAGE_NAME}", ["package.xml", "README.md"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Noah",
+    maintainer_email="noah-wardlow@users.noreply.github.com",
+    description="Read-only RTSP camera bridge for SO-101.",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "rtsp_camera_bridge = so101_camera_bridge.bridge_node:main",
+        ],
+    },
+)

--- a/src/so101_camera_bridge/so101_camera_bridge/__init__.py
+++ b/src/so101_camera_bridge/so101_camera_bridge/__init__.py
@@ -1,0 +1,1 @@
+"""SO-101 read-only camera bridge."""

--- a/src/so101_camera_bridge/so101_camera_bridge/bridge_node.py
+++ b/src/so101_camera_bridge/so101_camera_bridge/bridge_node.py
@@ -1,0 +1,393 @@
+"""Publish the existing SO-101 MediaMTX RTSP streams as ROS images."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from typing import Any, Callable
+
+import cv2
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from sensor_msgs.msg import CameraInfo, Image
+
+from .contract import StreamSpec, pinhole_projection, validate_stream_spec
+
+
+class StreamWorker:
+    """Keep one RTSP decoder alive and retain only its newest frame."""
+
+    def __init__(
+        self,
+        spec: StreamSpec,
+        *,
+        reconnect_delay: float,
+        open_timeout_ms: int,
+        read_timeout_ms: int,
+        log: Callable[[str], None],
+    ) -> None:
+        self.spec = spec
+        self._reconnect_delay = reconnect_delay
+        self._open_timeout_ms = open_timeout_ms
+        self._read_timeout_ms = read_timeout_ms
+        self._log = log
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._latest: Any | None = None
+        self._sequence = 0
+        self._thread: threading.Thread | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def stopping(self) -> bool:
+        """A stop was requested but the decoder thread has not exited yet."""
+        return self.running and self._stop.is_set()
+
+    def start(self) -> None:
+        """Begin decoding. Idempotent, so the demand check can call it freely.
+
+        A no-op while a previous run is still winding down: that thread still
+        owns an RTSP connection and would keep writing into `_latest`, so a
+        second decoder alongside it is a leak, not a restart. The next tick
+        starts one once the old thread is gone.
+        """
+        if self._thread is not None:
+            if self._thread.is_alive():
+                return
+            self._thread = None
+        # Each run owns its stop event. Sharing one event across runs means a
+        # later start() can clear the flag a previous run is still watching and
+        # revive a thread that was already abandoned.
+        stop = threading.Event()
+        with self._lock:
+            # Drop a frame retained from a previous run; a subscriber that
+            # arrives now wants live video, not whatever was on screen when the
+            # last one left.
+            self._latest = None
+        self._stop = stop
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(stop,),
+            name=f"rtsp-{self.spec.name}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Ask the decoder to stop. Returns immediately; `join` waits for it.
+
+        The demand check calls this from the node's timer callback, which runs
+        on the executor thread. Joining there stalls every other callback for
+        as long as the decoder takes to notice — measured at 1.4 s against the
+        real stream when the stop lands mid-connect, and the join timeout
+        allows up to 4 s at the default `read_timeout_ms`.
+        """
+        self._stop.set()
+
+    def join(self, timeout: float | None = None) -> bool:
+        """Wait for the decoder thread to exit. True once it has."""
+        thread = self._thread
+        if thread is None:
+            return True
+        if timeout is None:
+            timeout = max(2.0, self._read_timeout_ms / 1000.0 + 1.0)
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            return False
+        self._thread = None
+        return True
+
+    def newest_after(self, sequence: int) -> tuple[int, Any] | None:
+        with self._lock:
+            if self._latest is None or self._sequence <= sequence:
+                return None
+            return self._sequence, self._latest
+
+    def _open(self) -> Any:
+        capture = cv2.VideoCapture()
+        if hasattr(cv2, "CAP_PROP_OPEN_TIMEOUT_MSEC"):
+            capture.set(cv2.CAP_PROP_OPEN_TIMEOUT_MSEC, self._open_timeout_ms)
+        if hasattr(cv2, "CAP_PROP_READ_TIMEOUT_MSEC"):
+            capture.set(cv2.CAP_PROP_READ_TIMEOUT_MSEC, self._read_timeout_ms)
+        capture.open(self.spec.url, cv2.CAP_FFMPEG)
+        return capture
+
+    def _run(self, stop: threading.Event) -> None:
+        announced = False
+        while not stop.is_set():
+            capture = self._open()
+            if not capture.isOpened():
+                capture.release()
+                if not announced:
+                    self._log(f"{self.spec.name} RTSP stream is unavailable; retrying")
+                    announced = True
+                stop.wait(self._reconnect_delay)
+                continue
+            self._log(f"{self.spec.name} RTSP stream connected")
+            announced = False
+            while not stop.is_set():
+                ok, frame = capture.read()
+                if not ok or frame is None:
+                    self._log(f"{self.spec.name} RTSP stream interrupted; reconnecting")
+                    break
+                if len(frame.shape) != 3 or frame.shape[2] != 3:
+                    self._log(
+                        f"{self.spec.name} produced a non-BGR frame; reconnecting"
+                    )
+                    break
+                with self._lock:
+                    self._latest = frame
+                    self._sequence += 1
+            capture.release()
+            stop.wait(self._reconnect_delay)
+
+
+class RtspCameraBridge(Node):
+    """Read two existing RTSP streams without owning camera hardware."""
+
+    def __init__(self) -> None:
+        super().__init__("so101_rtsp_camera_bridge")
+        self.declare_parameter(
+            "head_url", "rtsp://so101-pi.tail337068.ts.net:8554/head"
+        )
+        self.declare_parameter(
+            "gripper_url",
+            "rtsp://so101-pi.tail337068.ts.net:8554/gripper",
+        )
+        self.declare_parameter("publish_fps", 15.0)
+        # CameraInfo used to be derived from a decoded frame, which meant the
+        # decoder had to run just to describe the camera. Declaring the geometry
+        # lets the info topic stand on its own; the decoder validates it against
+        # the first real frame it sees.
+        self.declare_parameter("image_width", 640)
+        self.declare_parameter("image_height", 480)
+        # How long the image topic must stay unsubscribed before the decoder is
+        # torn down. Reconnecting costs 1.4-2.0 s against the real stream, and a
+        # subscriber that flips away and back (switching camera panes, one
+        # Behavior handing off to the next) reads as zero subscribers for a
+        # fraction of a second. Without the hold-off each of those flips costs a
+        # full RTSP teardown and reconnect on the upstream camera.
+        self.declare_parameter("decoder_linger_seconds", 5.0)
+        self.declare_parameter("vertical_fov_degrees", 74.5)
+        self.declare_parameter("reconnect_delay_seconds", 1.0)
+        self.declare_parameter("open_timeout_ms", 5000)
+        self.declare_parameter("read_timeout_ms", 3000)
+
+        specs = [
+            StreamSpec(
+                name="head",
+                url=self.get_parameter("head_url").value,
+                image_topic="/so101/cameras/overhead/image_raw",
+                camera_info_topic="/so101/cameras/overhead/camera_info",
+                frame_id="overhead_cam_optical_frame",
+            ),
+            StreamSpec(
+                name="gripper",
+                url=self.get_parameter("gripper_url").value,
+                image_topic="/so101/cameras/wrist/image_raw",
+                camera_info_topic="/so101/cameras/wrist/camera_info",
+                frame_id="right_wrist_cam_optical_frame",
+            ),
+        ]
+        for spec in specs:
+            validate_stream_spec(spec)
+
+        publish_fps = float(self.get_parameter("publish_fps").value)
+        self._vertical_fov = float(self.get_parameter("vertical_fov_degrees").value)
+        reconnect_delay = float(self.get_parameter("reconnect_delay_seconds").value)
+        open_timeout_ms = int(self.get_parameter("open_timeout_ms").value)
+        read_timeout_ms = int(self.get_parameter("read_timeout_ms").value)
+        if publish_fps <= 0.0:
+            raise ValueError("publish_fps must be greater than zero")
+        if reconnect_delay <= 0.0:
+            raise ValueError("reconnect_delay_seconds must be greater than zero")
+        if min(open_timeout_ms, read_timeout_ms) <= 0:
+            raise ValueError("RTSP timeouts must be greater than zero")
+        pinhole_projection(640, 480, self._vertical_fov)
+
+        # Not `self._publishers`: rclpy's Node keeps its own list of publishers
+        # under that name, and shadowing it with a dict makes destroy_node()
+        # index a dict by integer and raise KeyError while tearing the node down.
+        self._camera_publishers = {
+            spec.name: (
+                self.create_publisher(Image, spec.image_topic, 2),
+                self.create_publisher(CameraInfo, spec.camera_info_topic, 2),
+            )
+            for spec in specs
+        }
+        self._last_sequences = {spec.name: 0 for spec in specs}
+        self._workers = [
+            StreamWorker(
+                spec,
+                reconnect_delay=reconnect_delay,
+                open_timeout_ms=open_timeout_ms,
+                read_timeout_ms=read_timeout_ms,
+                log=self.get_logger().info,
+            )
+            for spec in specs
+        ]
+        self._width = int(self.get_parameter("image_width").value)
+        self._height = int(self.get_parameter("image_height").value)
+        if min(self._width, self._height) <= 0:
+            raise ValueError("image_width and image_height must be positive")
+        self._decoder_linger = float(self.get_parameter("decoder_linger_seconds").value)
+        if not math.isfinite(self._decoder_linger) or self._decoder_linger < 0.0:
+            raise ValueError("decoder_linger_seconds must be finite and non-negative")
+        # Warned about once per stream rather than per frame.
+        self._geometry_warned: set[str] = set()
+        # Geometry of the frames actually decoded, once any have been. CameraInfo
+        # follows this in preference to the declared parameters so the intrinsics
+        # always describe the image published alongside them.
+        self._observed_geometry: dict[str, tuple[int, int]] = {}
+        # When the image topic first read zero subscribers, per camera.
+        self._idle_since: dict[str, Any] = {spec.name: None for spec in specs}
+
+        # Workers are NOT started here. Decoding begins only when something
+        # subscribes to the image topic — see _publish_latest. The publishers
+        # exist from construction, so the topics are discoverable and the camera
+        # panes list them whether or not anything is decoding.
+        self._timer = self.create_timer(1.0 / publish_fps, self._publish_latest)
+        self.get_logger().info(
+            "Publishing read-only SO-101 camera taps on stable ROS topics; "
+            "decoding starts on the first image subscriber"
+        )
+
+    def _camera_info(self, frame_id: str, stamp, width: int, height: int) -> CameraInfo:
+        """Describe the camera. Needs no decoded frame."""
+        k, p = pinhole_projection(width, height, self._vertical_fov)
+        camera_info = CameraInfo()
+        camera_info.header.stamp = stamp
+        camera_info.header.frame_id = frame_id
+        camera_info.height = height
+        camera_info.width = width
+        camera_info.distortion_model = "plumb_bob"
+        camera_info.d = [0.0] * 5
+        camera_info.k = k
+        camera_info.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        camera_info.p = p
+        return camera_info
+
+    def _publish_latest(self) -> None:
+        """Publish CameraInfo always; decode and publish images only on demand.
+
+        The video path no longer runs through this node — an already-encoded
+        camera is relayed straight to the browser — so decoding every frame
+        unconditionally burned CPU and memory producing images nothing read.
+        Subscriber count is the honest signal for whether anyone still wants
+        them: a recording session or a perception Behavior subscribing starts
+        the decoder, and it stops again once nothing has wanted them for
+        `decoder_linger_seconds`.
+        """
+        now = self.get_clock().now()
+        stamp = now.to_msg()
+        for worker in self._workers:
+            name = worker.spec.name
+            image_publisher, info_publisher = self._camera_publishers[name]
+
+            # Cheap, and it keeps calibration available to anything that needs
+            # to describe the camera without wanting its pixels. Prefer the
+            # geometry of the frames actually decoded: the parameters are only a
+            # declaration, and publishing intrinsics for a size the stream does
+            # not produce silently corrupts any pixel-to-pose math downstream.
+            width, height = self._observed_geometry.get(
+                name, (self._width, self._height)
+            )
+            info_publisher.publish(
+                self._camera_info(worker.spec.frame_id, stamp, width, height)
+            )
+
+            if image_publisher.get_subscription_count() == 0:
+                if worker.running and not worker.stopping:
+                    idle_since = self._idle_since[name]
+                    if idle_since is None:
+                        self._idle_since[name] = now
+                    elif (now - idle_since).nanoseconds * 1e-9 >= self._decoder_linger:
+                        self.get_logger().info(
+                            f"{name}: no image subscriber for "
+                            f"{self._decoder_linger:g}s; stopping decoder"
+                        )
+                        worker.stop()
+                        self._last_sequences[name] = 0
+                        self._idle_since[name] = None
+                continue
+
+            # Someone is subscribed, so cancel any pending stop. A worker that
+            # was already asked to stop is left to finish; the next tick starts
+            # a fresh one rather than racing the thread that is winding down.
+            self._idle_since[name] = None
+            if not worker.running:
+                self.get_logger().info(
+                    f"{name}: image subscriber appeared; starting decoder"
+                )
+                worker.start()
+
+            latest = worker.newest_after(self._last_sequences[name])
+            if latest is None:
+                continue
+            sequence, frame = latest
+            height, width = frame.shape[:2]
+            self._observed_geometry[name] = (width, height)
+
+            if (width, height) != (self._width, self._height):
+                if name not in self._geometry_warned:
+                    self._geometry_warned.add(name)
+                    self.get_logger().warning(
+                        f"{name}: stream is {width}x{height} but image_width/"
+                        f"image_height say {self._width}x{self._height}; "
+                        "CameraInfo now follows the stream, but set the "
+                        "parameters so it is right before the first frame"
+                    )
+
+            image = Image()
+            image.header.stamp = stamp
+            image.header.frame_id = worker.spec.frame_id
+            image.height = height
+            image.width = width
+            image.encoding = "bgr8"
+            image.is_bigendian = 0
+            image.step = width * 3
+            image.data = frame.tobytes()
+            image_publisher.publish(image)
+            self._last_sequences[name] = sequence
+
+    def destroy_node(self) -> None:
+        # Signal every decoder first, then wait, so teardown costs one timeout
+        # rather than one per camera.
+        for worker in self._workers:
+            worker.stop()
+        for worker in self._workers:
+            if not worker.join():
+                self.get_logger().warning(
+                    f"{worker.spec.name}: decoder thread did not exit; it is a "
+                    "daemon and will not hold up process shutdown"
+                )
+        super().destroy_node()
+
+
+def main(args: list[str] | None = None) -> None:
+    rclpy.init(args=args)
+    node = RtspCameraBridge()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        # rclpy installs its own SIGINT and SIGTERM handlers, and they shut the
+        # context down before the interpreter can raise KeyboardInterrupt. spin
+        # therefore reports the stop as ExternalShutdownException on both
+        # signals; KeyboardInterrupt only surfaces if those handlers are
+        # disabled. Neither is a failure, so neither should exit nonzero.
+        pass
+    finally:
+        node.destroy_node()
+        # Guarded: the signal handler already shut the context down, and calling
+        # shutdown a second time raises over the top of whatever stopped us.
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/so101_camera_bridge/so101_camera_bridge/contract.py
+++ b/src/so101_camera_bridge/so101_camera_bridge/contract.py
@@ -1,0 +1,52 @@
+"""Pure validation and camera-model helpers for the RTSP bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    name: str
+    url: str
+    image_topic: str
+    camera_info_topic: str
+    frame_id: str
+
+
+def validate_stream_spec(spec: StreamSpec) -> None:
+    if not spec.name.strip():
+        raise ValueError("stream name must not be empty")
+    if not spec.url.startswith(("rtsp://", "rtsps://")):
+        raise ValueError(f"{spec.name} URL must use rtsp:// or rtsps://")
+    for label, topic in (
+        ("image", spec.image_topic),
+        ("camera_info", spec.camera_info_topic),
+    ):
+        if not topic.startswith("/") or topic.endswith("/"):
+            raise ValueError(f"{spec.name} {label} topic must be an absolute ROS topic")
+    if not spec.frame_id.strip() or spec.frame_id.startswith("/"):
+        raise ValueError(
+            f"{spec.name} frame_id must be non-empty and have no leading slash"
+        )
+
+
+def pinhole_projection(
+    width: int, height: int, vertical_fov_degrees: float
+) -> tuple[list[float], list[float]]:
+    """Return approximate K and P matrices when physical calibration is absent."""
+    if width <= 0 or height <= 0:
+        raise ValueError("image width and height must be greater than zero")
+    if (
+        not math.isfinite(vertical_fov_degrees)
+        or not 1.0 < vertical_fov_degrees < 179.0
+    ):
+        raise ValueError("vertical FOV must be finite and between 1 and 179 degrees")
+    fy = (height / 2.0) / math.tan(math.radians(vertical_fov_degrees) / 2.0)
+    fx = fy
+    cx = (width - 1.0) / 2.0
+    cy = (height - 1.0) / 2.0
+    k = [fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0]
+    p = [fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0, 1.0, 0.0]
+    return k, p

--- a/src/so101_camera_bridge/test/test_contract.py
+++ b/src/so101_camera_bridge/test/test_contract.py
@@ -1,0 +1,206 @@
+import math
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from so101_camera_bridge.contract import (
+    StreamSpec,
+    pinhole_projection,
+    validate_stream_spec,
+)
+
+
+def test_valid_stream_contract() -> None:
+    validate_stream_spec(
+        StreamSpec(
+            "head",
+            "rtsp://robot:8554/head",
+            "/camera/image_raw",
+            "/camera/camera_info",
+            "camera_optical_frame",
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("url", "https://robot/head"),
+        ("image_topic", "camera/image_raw"),
+        ("camera_info_topic", "/camera/info/"),
+        ("frame_id", "/camera_optical_frame"),
+    ],
+)
+def test_invalid_stream_contract(field: str, value: str) -> None:
+    values = {
+        "name": "head",
+        "url": "rtsp://robot:8554/head",
+        "image_topic": "/camera/image_raw",
+        "camera_info_topic": "/camera/camera_info",
+        "frame_id": "camera_optical_frame",
+    }
+    values[field] = value
+    with pytest.raises(ValueError):
+        validate_stream_spec(StreamSpec(**values))
+
+
+def test_pinhole_projection_is_centered_and_finite() -> None:
+    k, p = pinhole_projection(640, 480, 74.5)
+    assert len(k) == 9
+    assert len(p) == 12
+    assert k[2] == 319.5
+    assert k[5] == 239.5
+    assert k[0] == k[4]
+    assert all(math.isfinite(value) for value in k + p)
+
+
+@pytest.mark.parametrize(
+    "width,height,fov",
+    [(0, 480, 74.5), (640, 0, 74.5), (640, 480, 0.0), (640, 480, 180.0)],
+)
+def test_invalid_projection(width: int, height: int, fov: float) -> None:
+    with pytest.raises(ValueError):
+        pinhole_projection(width, height, fov)
+
+
+def _worker(**overrides):
+    from so101_camera_bridge.bridge_node import StreamWorker
+
+    kwargs = {
+        "reconnect_delay": 0.05,
+        "open_timeout_ms": 100,
+        "read_timeout_ms": 100,
+        "log": lambda _message: None,
+    }
+    kwargs.update(overrides)
+    return StreamWorker(
+        StreamSpec(
+            name="probe",
+            url="rtsp://127.0.0.1:1/none",
+            image_topic="/probe/image_raw",
+            camera_info_topic="/probe/camera_info",
+            frame_id="probe_frame",
+        ),
+        **kwargs,
+    )
+
+
+def _decoder_threads() -> list[str]:
+    return [t.name for t in threading.enumerate() if t.name.startswith("rtsp-")]
+
+
+class _SlowCapture:
+    """A capture whose open() outlasts the join timeout, then reads nothing."""
+
+    def __init__(self, open_seconds: float) -> None:
+        time.sleep(open_seconds)
+
+    def isOpened(self) -> bool:  # noqa: N802 - matches the cv2 API
+        return True
+
+    def read(self):
+        time.sleep(0.02)
+        return False, None
+
+    def release(self) -> None:
+        pass
+
+
+class _OneFrameCapture:
+    """Yields a single frame, then behaves like an interrupted stream."""
+
+    def __init__(self) -> None:
+        self._sent = False
+
+    def isOpened(self) -> bool:  # noqa: N802 - matches the cv2 API
+        return True
+
+    def read(self):
+        if self._sent:
+            time.sleep(0.02)
+            return False, None
+        self._sent = True
+        return True, np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def release(self) -> None:
+        pass
+
+
+def test_stream_worker_start_and_stop_are_idempotent() -> None:
+    """The demand check calls these on every publish tick, so repeated calls
+    must not spawn a second decoder or fail on an already-stopped worker."""
+    worker = _worker()
+    assert not worker.running
+    worker.stop()  # stopping a worker that never ran is a no-op
+    assert worker.join(), "joining a worker that never ran must not block"
+    worker.start()
+    assert worker.running
+    worker.start()  # must not spawn a second decoder
+    assert len(_decoder_threads()) == 1
+    worker.stop()
+    assert worker.join(timeout=5.0)
+    assert not worker.running
+
+
+def test_stop_does_not_block_the_caller() -> None:
+    """stop() runs on the executor thread, so it must not wait on the decoder.
+
+    Regression: joining inside stop() stalled every other node callback for as
+    long as the decoder took to notice — measured at 1.4 s mid-connect against
+    the real stream, and bounded only by the 2-4 s join timeout.
+    """
+    worker = _worker()
+    worker._open = lambda: _SlowCapture(3.0)  # noqa: SLF001 - seam for the test
+    worker.start()
+    time.sleep(0.1)
+    started = time.perf_counter()
+    worker.stop()
+    elapsed = time.perf_counter() - started
+    assert elapsed < 0.1, f"stop() blocked the caller for {elapsed:.2f}s"
+    worker.join(timeout=5.0)
+
+
+def test_restart_while_winding_down_does_not_spawn_a_second_decoder() -> None:
+    """Regression: stop() dropped the thread handle when the join timed out, so
+    the next start() cleared the stop flag under the still-live decoder and ran
+    a second one beside it — two RTSP connections per camera, growing with every
+    subscriber flip, and destroy_node() only ever stopped the newest.
+    """
+    before = len(_decoder_threads())
+    worker = _worker()
+    worker._open = lambda: _SlowCapture(3.0)  # noqa: SLF001 - seam for the test
+    worker.start()
+    time.sleep(0.1)
+
+    worker.stop()
+    assert not worker.join(timeout=0.2), "this test needs the join to time out"
+    worker.start()  # the demand check does exactly this when a subscriber returns
+    assert len(_decoder_threads()) - before == 1, "a second decoder was spawned"
+
+    assert worker.join(timeout=5.0), "the abandoned decoder never exited"
+    assert len(_decoder_threads()) == before
+
+
+def test_restart_drops_the_frame_from_the_previous_run() -> None:
+    """A subscriber that arrives after an idle period wants live video, not the
+    frame that was on screen when the last one left — a stale frame republished
+    with a fresh timestamp is indistinguishable from current data downstream."""
+    worker = _worker()
+    worker._open = _OneFrameCapture  # noqa: SLF001 - seam for the test
+    worker.start()
+    deadline = time.monotonic() + 5.0
+    while worker.newest_after(-1) is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert worker.newest_after(-1) is not None, "the decoder never produced a frame"
+    worker.stop()
+    assert worker.join(timeout=5.0)
+    assert worker.newest_after(-1) is not None, "a stopped worker keeps its last frame"
+
+    worker._open = lambda: _SlowCapture(0.0)  # noqa: SLF001 - never yields a frame
+    worker.start()
+    time.sleep(0.1)
+    assert worker.newest_after(-1) is None, "the previous run's frame was served"
+    worker.stop()
+    worker.join(timeout=5.0)

--- a/src/so101_camera_bridge/test/test_node_lifecycle.py
+++ b/src/so101_camera_bridge/test/test_node_lifecycle.py
@@ -1,0 +1,399 @@
+"""Node construction and teardown. Needs rclpy, unlike the pure contract tests."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+import time
+
+import numpy as np
+import pytest
+
+rclpy = pytest.importorskip("rclpy")
+
+import so101_camera_bridge  # noqa: E402
+from so101_camera_bridge.bridge_node import RtspCameraBridge  # noqa: E402
+
+# Unroutable, so the decoder fails fast instead of reaching a real camera.
+DEAD_URL = "rtsp://127.0.0.1:1/none"
+
+
+@pytest.fixture
+def ros():
+    rclpy.init()
+    yield
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+def _node() -> RtspCameraBridge:
+    from rclpy.parameter import Parameter
+
+    node = RtspCameraBridge()
+    node.set_parameters(
+        [
+            Parameter("head_url", Parameter.Type.STRING, DEAD_URL),
+            Parameter("gripper_url", Parameter.Type.STRING, DEAD_URL),
+        ]
+    )
+    return node
+
+
+class _FakePublisher:
+    """Reports a subscription count the test controls and records publications."""
+
+    def __init__(self) -> None:
+        self.subscription_count = 0
+        self.published: list = []
+
+    def get_subscription_count(self) -> int:
+        return self.subscription_count
+
+    def publish(self, message) -> None:
+        self.published.append(message)
+
+
+class _FakeWorker:
+    """A decoder the test can start, stop, and hand frames to."""
+
+    def __init__(self, spec, frame=None) -> None:
+        self.spec = spec
+        self.running = False
+        self.stopping = False
+        self.starts = 0
+        self.stops = 0
+        self._frame = frame
+        self._sequence = 1 if frame is not None else 0
+
+    def start(self) -> None:
+        if self.running:
+            return
+        self.starts += 1
+        self.running = True
+
+    def stop(self) -> None:
+        self.stops += 1
+        self.stopping = True
+
+    def join(self, timeout: float | None = None) -> bool:
+        self.running = False
+        self.stopping = False
+        return True
+
+    def newest_after(self, sequence: int):
+        if self._frame is None or self._sequence <= sequence:
+            return None
+        return self._sequence, self._frame
+
+
+def _instrument(
+    node: RtspCameraBridge, frames: dict | None = None
+) -> tuple[dict, dict]:
+    """Swap in fake publishers and workers, leaving `_publish_latest` itself real."""
+    frames = frames or {}
+    publishers = {
+        name: (_FakePublisher(), _FakePublisher()) for name in node._camera_publishers
+    }
+    workers = {
+        worker.spec.name: _FakeWorker(worker.spec, frames.get(worker.spec.name))
+        for worker in node._workers
+    }
+    node._camera_publishers = publishers
+    node._workers = list(workers.values())
+    return publishers, workers
+
+
+def _set_subscribers(publishers: dict, count: int) -> None:
+    for image_publisher, _ in publishers.values():
+        image_publisher.subscription_count = count
+
+
+@pytest.fixture
+def ros_with_args(request):
+    rclpy.init(args=request.param)
+    yield
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+@pytest.mark.parametrize(
+    "ros_with_args,message",
+    [
+        (["--ros-args", "-p", "image_width:=0"], "image_width"),
+        (["--ros-args", "-p", "image_height:=-1"], "image_height"),
+        (
+            ["--ros-args", "-p", "decoder_linger_seconds:=-1.0"],
+            "decoder_linger_seconds",
+        ),
+    ],
+    indirect=["ros_with_args"],
+)
+def test_invalid_geometry_or_linger_is_rejected_at_construction(
+    ros_with_args, message: str
+) -> None:
+    """Bad values must fail bring-up, not surface later as wrong intrinsics or a
+    decoder that never stops."""
+    with pytest.raises(ValueError, match=message):
+        RtspCameraBridge()
+
+
+def test_destroy_node_does_not_raise(ros) -> None:
+    """rclpy's Node keeps its own `_publishers` list and walks it on teardown.
+
+    Shadowing that name with a dict keyed by camera makes destroy_node() index a
+    dict by integer, so every shutdown raised KeyError after the node had already
+    stopped serving — visible only in the logs, and easy to mistake for noise.
+    """
+    node = _node()
+    node.destroy_node()  # must not raise
+
+
+def test_camera_publishers_do_not_shadow_the_node_attribute(ros) -> None:
+    """Pins the cause, so a rename back is caught at the point of the mistake."""
+    node = _node()
+    try:
+        assert isinstance(node._publishers, list)
+        assert set(node._camera_publishers) == {"head", "gripper"}
+    finally:
+        node.destroy_node()
+
+
+def test_no_subscribers_publishes_camera_info_without_decoding(ros) -> None:
+    """The info topic stands on its own; nothing decodes until asked."""
+    node = _node()
+    try:
+        publishers, workers = _instrument(node)
+        node._publish_latest()
+        for name, (image_publisher, info_publisher) in publishers.items():
+            assert len(info_publisher.published) == 1, f"{name} published no CameraInfo"
+            assert image_publisher.published == [], f"{name} published an image"
+            assert workers[name].starts == 0
+    finally:
+        node.destroy_node()
+
+
+def test_camera_info_before_any_frame_uses_the_declared_geometry(ros) -> None:
+    """640x480 is the declared default and must describe a plausible pinhole."""
+    node = _node()
+    try:
+        publishers, _ = _instrument(node)
+        node._publish_latest()
+        info = publishers["head"][1].published[0]
+        assert (info.width, info.height) == (640, 480)
+        assert info.k[2] == 319.5
+        assert info.k[5] == 239.5
+        assert info.header.frame_id == "overhead_cam_optical_frame"
+    finally:
+        node.destroy_node()
+
+
+def test_subscriber_starts_the_decoder(ros) -> None:
+    """A subscriber on the image topic is what turns decoding on."""
+    node = _node()
+    try:
+        publishers, workers = _instrument(node)
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        assert workers["head"].starts == 1
+        assert workers["gripper"].starts == 1
+        node._publish_latest()
+        assert workers["head"].starts == 1, "a running decoder was restarted"
+    finally:
+        node.destroy_node()
+
+
+def test_frames_are_published_and_not_republished(ros) -> None:
+    """Only frames newer than the last published sequence go out."""
+    node = _node()
+    try:
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        publishers, _ = _instrument(node, frames={"head": frame, "gripper": frame})
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        node._publish_latest()
+        image_publisher = publishers["head"][0]
+        assert len(image_publisher.published) == 1
+        image = image_publisher.published[0]
+        assert (image.width, image.height) == (640, 480)
+        assert image.encoding == "bgr8"
+        assert image.step == 640 * 3
+    finally:
+        node.destroy_node()
+
+
+def test_decoder_survives_a_brief_gap_in_subscribers(ros) -> None:
+    """Regression: a subscriber that flips away and back cost a full RTSP
+    teardown and reconnect (measured 1.4-2.0 s to the next frame) because the
+    stop fired on the first tick that read zero."""
+    node = _node()
+    try:
+        publishers, workers = _instrument(node)
+        node._decoder_linger = 0.5
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        _set_subscribers(publishers, 0)
+        for _ in range(5):
+            node._publish_latest()
+        assert workers["head"].stops == 0, "decoder stopped inside the linger window"
+        assert workers["head"].running
+    finally:
+        node.destroy_node()
+
+
+def test_returning_subscriber_cancels_the_pending_stop(ros) -> None:
+    """The countdown restarts on re-subscribe, so flipping never accumulates."""
+    node = _node()
+    try:
+        publishers, workers = _instrument(node)
+        node._decoder_linger = 0.3
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+
+        _set_subscribers(publishers, 0)
+        node._publish_latest()
+        time.sleep(0.2)
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+
+        _set_subscribers(publishers, 0)
+        node._publish_latest()
+        time.sleep(0.2)
+        node._publish_latest()
+        assert workers["head"].stops == 0, "the linger window did not restart"
+    finally:
+        node.destroy_node()
+
+
+def test_decoder_stops_once_the_linger_elapses(ros) -> None:
+    """Sustained absence of subscribers still releases the upstream stream."""
+    node = _node()
+    try:
+        publishers, workers = _instrument(node)
+        node._decoder_linger = 0.2
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        node._last_sequences["head"] = 7
+
+        _set_subscribers(publishers, 0)
+        node._publish_latest()
+        time.sleep(0.3)
+        node._publish_latest()
+        assert workers["head"].stops == 1
+        assert node._last_sequences["head"] == 0, "sequence bookkeeping not reset"
+
+        node._publish_latest()
+        assert workers["head"].stops == 1, "stop re-issued while winding down"
+    finally:
+        node.destroy_node()
+
+
+def test_camera_info_follows_the_stream_when_it_differs_from_the_parameters(
+    ros,
+) -> None:
+    """Intrinsics for a size the stream does not produce silently corrupt every
+    consumer that projects pixels to poses, so the decoded frame wins."""
+    node = _node()
+    try:
+        frame = np.zeros((720, 1280, 3), dtype=np.uint8)
+        publishers, _ = _instrument(node, frames={"head": frame})
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        node._publish_latest()
+
+        image = publishers["head"][0].published[0]
+        info = publishers["head"][1].published[-1]
+        assert (image.width, image.height) == (1280, 720)
+        assert (info.width, info.height) == (image.width, image.height)
+        assert info.k[2] == 639.5
+        assert info.k[5] == 359.5
+        assert "head" in node._geometry_warned
+    finally:
+        node.destroy_node()
+
+
+def test_camera_info_and_image_share_a_stamp(ros) -> None:
+    """Consumers pair them with an exact-time synchronizer."""
+    node = _node()
+    try:
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        publishers, _ = _instrument(node, frames={"head": frame})
+        _set_subscribers(publishers, 1)
+        node._publish_latest()
+        image = publishers["head"][0].published[0]
+        info = publishers["head"][1].published[0]
+        assert image.header.stamp == info.header.stamp
+    finally:
+        node.destroy_node()
+
+
+UPSTREAM_WAIT_SET_RACE = "failed to initialize wait set"
+
+
+# --- process-level signal regression: needs main() in a real child process ---
+
+PACKAGE_ROOT = str(Path(so101_camera_bridge.__file__).resolve().parent.parent)
+DEAD_URL_ARGS = [
+    "-p",
+    f"head_url:={DEAD_URL}",
+    "-p",
+    f"gripper_url:={DEAD_URL}",
+]
+READY_LOG = "Publishing read-only SO-101 camera taps"
+SPIN_SETTLE_SECONDS = 1.0
+
+
+def _spawn_bridge() -> subprocess.Popen[str]:
+    """Run main() in its own process so real signals can be delivered to it."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in (PACKAGE_ROOT, env.get("PYTHONPATH")) if path
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "from so101_camera_bridge.bridge_node import main; main()",
+            "--ros-args",
+            *DEAD_URL_ARGS,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        line = process.stdout.readline()
+        if not line:
+            break
+        if READY_LOG in line:
+            time.sleep(SPIN_SETTLE_SECONDS)
+            return process
+    process.kill()
+    pytest.fail(f"bridge never reached {READY_LOG!r}: {process.communicate()[0]}")
+
+
+@pytest.mark.parametrize("stop_signal", [signal.SIGINT, signal.SIGTERM])
+def test_regression_signal_during_spin_exits_zero(stop_signal) -> None:
+    """Regression: an ordinary stop signal made main() exit nonzero with a traceback.
+
+    rclpy handles both SIGINT and SIGTERM by shutting the context down, so spin
+    raises ExternalShutdownException and the unguarded rclpy.shutdown() in the
+    `finally` then raised RCLError on top of it. Ctrl-C and a systemd stop are
+    both normal, so the process must exit 0.
+    """
+    process = _spawn_bridge()
+    process.send_signal(stop_signal)
+    output = process.communicate(timeout=30)[0]
+    assert "KeyError" not in output, f"teardown walked the wrong list:\n{output}"
+    assert (
+        "rcl_shutdown already called" not in output
+    ), f"shutdown ran twice on an already-stopped context:\n{output}"
+    if process.returncode != 0:
+        assert UPSTREAM_WAIT_SET_RACE in output, (
+            f"{stop_signal.name} is a clean stop but exited "
+            f"{process.returncode}:\n{output}"
+        )

--- a/src/so101_moveit_config/CMakeLists.txt
+++ b/src/so101_moveit_config/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.22)
+project(so101_moveit_config)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY config description launch objectives simulation_objectives waypoints
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/so101_moveit_config/config/config.yaml
+++ b/src/so101_moveit_config/config/config.yaml
@@ -1,0 +1,84 @@
+runtime_launch_file:
+  package: "so101_moveit_config"
+  path: "launch/runtime.launch.xml"
+
+hardware:
+  launch_control_node: true
+  launch_robot_state_publisher: true
+  robot_description:
+    urdf:
+      package: "so101_moveit_config"
+      path: "description/so101_follower.urdf.xacro"
+    srdf:
+      package: "so101_moveit_config"
+      path: "config/moveit/so101_follower.srdf"
+    urdf_params:
+      - hardware_interface: "mujoco"
+      - mujoco_model: "description/so101_follower_scene.xml"
+      - mujoco_keyframe: "home"
+      - mujoco_viewer: false
+
+ros_global_params:
+  use_sim_time: false
+
+moveit_params:
+  joint_group_name: "manipulator"
+  kinematics:
+    package: "so101_moveit_config"
+    path: "config/moveit/pose_ik.yaml"
+  joint_limits:
+    package: "so101_moveit_config"
+    path: "config/moveit/joint_limits.yaml"
+  pose_jog:
+    package: "so101_moveit_config"
+    path: "config/moveit/pose_jog.yaml"
+  joint_jog:
+    package: "so101_moveit_config"
+    path: "config/moveit/joint_jog.yaml"
+  publish:
+    planning_scene: true
+    geometry_updates: true
+    state_updates: true
+    transforms_updates: true
+
+ros2_control:
+  config:
+    package: "so101_moveit_config"
+    path: "config/control/so101.ros2_control.yaml"
+  controllers_active_at_startup:
+    - "joint_state_broadcaster"
+    - "joint_trajectory_controller"
+    - "gripper_controller"
+  controllers_inactive_at_startup:
+    - "joint_trajectory_admittance_controller"
+    - "velocity_force_controller"
+    - "joint_velocity_controller"
+  controllers_not_managed: []
+  controller_shared_topics: []
+
+objectives:
+  behavior_loader_plugins:
+    core:
+      - "moveit_pro::behaviors::CoreBehaviorsLoader"
+      - "moveit_pro::behaviors::MTCCoreBehaviorsLoader"
+      - "moveit_pro::behaviors::ConverterBehaviorsLoader"
+      - "moveit_pro::behaviors::MujocoBehaviorsLoader"
+  objective_library_paths:
+    core_objectives:
+      package_name: "moveit_pro_objectives"
+      relative_path: "objectives/core"
+    motion_objectives:
+      package_name: "moveit_pro_objectives"
+      relative_path: "objectives/motion"
+    mujoco_objectives:
+      package_name: "moveit_pro_objectives"
+      relative_path: "objectives/mujoco"
+    so101_objectives:
+      package_name: "so101_moveit_config"
+      relative_path: "objectives"
+    so101_simulation_objectives:
+      package_name: "so101_moveit_config"
+      relative_path: "simulation_objectives"
+  waypoints_file:
+    package_name: "so101_moveit_config"
+    relative_path: "waypoints/so101_waypoints.yaml"

--- a/src/so101_moveit_config/config/control/so101.ros2_control.yaml
+++ b/src/so101_moveit_config/config/control/so101.ros2_control.yaml
@@ -44,6 +44,12 @@ joint_trajectory_controller:
     state_interfaces:
       - position
       - velocity
+    command_joints:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
     state_publish_rate: 50.0
     action_monitor_rate: 20.0
     allow_partial_joints_goal: false
@@ -66,6 +72,12 @@ joint_trajectory_controller:
       Wrist_Roll_R:
         trajectory: 0.15
         goal: 0.06
+    acceleration_limits:
+      Rotation_R: 0.50
+      Pitch_R: 0.50
+      Elbow_R: 0.50
+      Wrist_Pitch_R: 0.50
+      Wrist_Roll_R: 0.50
 
 gripper_controller:
   ros__parameters:

--- a/src/so101_moveit_config/config/control/so101.ros2_control.yaml
+++ b/src/so101_moveit_config/config/control/so101.ros2_control.yaml
@@ -1,0 +1,118 @@
+controller_manager:
+  ros__parameters:
+    # This controller manager is used only by MuJoCo. On physical hardware the
+    # Pi owns controller_manager and exposes the same standard controller names.
+    update_rate: 50
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+    gripper_controller:
+      type: position_controllers/GripperActionController
+    joint_trajectory_admittance_controller:
+      type: joint_trajectory_admittance_controller/JointTrajectoryAdmittanceController
+    velocity_force_controller:
+      type: velocity_force_controller/VelocityForceController
+    joint_velocity_controller:
+      type: joint_velocity_controller/JointVelocityController
+
+joint_state_broadcaster:
+  ros__parameters:
+    use_local_topics: false
+    joints:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
+      - Jaw_R
+    interfaces:
+      - position
+      - velocity
+      - effort
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 50.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    # Simulation tolerances mirror the physical controller's public contract.
+    constraints:
+      stopped_velocity_tolerance: 0.02
+      goal_time: 3.0
+      Rotation_R:
+        trajectory: 0.15
+        goal: 0.06
+      Pitch_R:
+        trajectory: 0.15
+        goal: 0.06
+      Elbow_R:
+        trajectory: 0.15
+        goal: 0.08
+      Wrist_Pitch_R:
+        trajectory: 0.15
+        goal: 0.06
+      Wrist_Roll_R:
+        trajectory: 0.15
+        goal: 0.06
+
+gripper_controller:
+  ros__parameters:
+    default: true
+    joint: Jaw_R
+    allow_stalling: true
+    stall_timeout: 0.5
+    stall_velocity_threshold: 0.001
+    goal_tolerance: 0.002
+
+joint_trajectory_admittance_controller:
+  ros__parameters:
+    planning_group_name: manipulator
+    sensor_frame: gripper_tip
+    ee_frame: gripper_tip
+    # The SO-101 has no force/torque sensor. JTAC is used for ExecutePolicy's
+    # chunk-stitching action contract, with admittance disabled.
+    ft_sensor_name: ""
+    stop_accelerations: [0.60, 0.60, 0.60, 0.60, 0.60]
+    state_publish_rate: 20
+    jacobian_damping: 0.02
+    gravity_vector: [0.0, 0.0, -9.81]
+    default_path_tolerance: 0.15
+    default_goal_tolerance: 0.08
+    default_absolute_force_torque_threshold: [1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0]
+
+velocity_force_controller:
+  ros__parameters:
+    planning_group_name: manipulator
+    ee_frame: gripper_tip
+    sensor_frame: gripper_tip
+    max_joint_velocity: [1.00, 1.00, 1.00, 1.00, 1.00]
+    max_joint_acceleration: [2.00, 2.00, 2.00, 2.00, 2.00]
+    max_cartesian_velocity: [0.15, 0.15, 0.15, 1.00, 1.00, 1.00]
+    max_cartesian_acceleration: [2.00, 2.00, 2.00, 4.00, 4.00, 4.00]
+    state_publish_rate: 10
+    jacobian_damping: 0.02
+    command_timeout: 0.2
+    joint_limit_position_tolerance: 0.02
+    command_interfaces: ["position"]
+
+joint_velocity_controller:
+  ros__parameters:
+    planning_group_name: manipulator
+    max_joint_velocity: [1.00, 1.00, 1.00, 1.00, 1.00]
+    max_joint_acceleration: [2.00, 2.00, 2.00, 2.00, 2.00]
+    command_interfaces: ["position"]
+    joint_limit_position_tolerance: 0.02
+    command_timeout: 0.2
+    state_publish_rate: 20

--- a/src/so101_moveit_config/config/control/so101.ros2_control.yaml
+++ b/src/so101_moveit_config/config/control/so101.ros2_control.yaml
@@ -80,7 +80,7 @@ joint_trajectory_admittance_controller:
   ros__parameters:
     planning_group_name: manipulator
     sensor_frame: gripper_tip
-    ee_frame: gripper_tip
+    ee_frames: [gripper_tip]
     # The SO-101 has no force/torque sensor. JTAC is used for ExecutePolicy's
     # chunk-stitching action contract, with admittance disabled.
     ft_sensor_name: ""

--- a/src/so101_moveit_config/config/moveit/joint_jog.yaml
+++ b/src/so101_moveit_config/config/moveit/joint_jog.yaml
@@ -1,0 +1,2 @@
+planning_groups: ['manipulator']
+controllers: ['joint_velocity_controller']

--- a/src/so101_moveit_config/config/moveit/joint_limits.yaml
+++ b/src/so101_moveit_config/config/moveit/joint_limits.yaml
@@ -1,0 +1,49 @@
+joint_limits:
+  Rotation_R:
+    has_position_limits: true
+    min_position: -2.16
+    max_position: 2.16
+    has_velocity_limits: true
+    max_velocity: 1.20
+    has_acceleration_limits: true
+    max_acceleration: 2.50
+  Pitch_R:
+    has_position_limits: true
+    min_position: -0.24
+    max_position: 3.56
+    has_velocity_limits: true
+    max_velocity: 1.20
+    has_acceleration_limits: true
+    max_acceleration: 2.50
+  Elbow_R:
+    has_position_limits: true
+    min_position: -0.47
+    max_position: 3.40
+    has_velocity_limits: true
+    max_velocity: 1.20
+    has_acceleration_limits: true
+    max_acceleration: 2.50
+  Wrist_Pitch_R:
+    has_position_limits: true
+    min_position: -1.86
+    max_position: 1.94
+    has_velocity_limits: true
+    max_velocity: 1.20
+    has_acceleration_limits: true
+    max_acceleration: 2.50
+  Wrist_Roll_R:
+    has_position_limits: true
+    min_position: -3.15
+    max_position: 3.15
+    has_velocity_limits: true
+    max_velocity: 1.20
+    has_acceleration_limits: true
+    max_acceleration: 2.50
+  Jaw_R:
+    has_position_limits: true
+    min_position: 0.0
+    max_position: 0.027
+    has_velocity_limits: true
+    max_velocity: 0.01
+    has_acceleration_limits: true
+    max_acceleration: 0.02

--- a/src/so101_moveit_config/config/moveit/pose_ik.yaml
+++ b/src/so101_moveit_config/config/moveit/pose_ik.yaml
@@ -1,0 +1,5 @@
+manipulator:
+  kinematics_solver: pose_ik_plugin/PoseIKPlugin
+  target_tolerance: 0.002
+  solve_mode: "optimize_distance"
+  optimization_timeout: 0.01

--- a/src/so101_moveit_config/config/moveit/pose_jog.yaml
+++ b/src/so101_moveit_config/config/moveit/pose_jog.yaml
@@ -1,0 +1,2 @@
+planning_groups: ['manipulator']
+controllers: ['velocity_force_controller']

--- a/src/so101_moveit_config/config/moveit/so101_follower.srdf
+++ b/src/so101_moveit_config/config/moveit/so101_follower.srdf
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<robot name="so101_follower">
+  <group name="manipulator">
+    <chain base_link="Base_2" tip_link="gripper_tip" />
+  </group>
+  <group name="gripper">
+    <!--
+      Include the complete end-effector model and the manipulator tip used by
+      interactive-marker teleoperation. Jaw_R remains the only independently
+      actuated gripper joint; the mate and gear are URDF mimics.
+    -->
+    <link name="Norma_Gear_R" />
+    <link name="Norma_Jaw_Neg_R" />
+    <link name="gripper_tip" />
+    <joint name="Jaw_R" />
+  </group>
+  <end_effector
+    name="norma_gripper"
+    parent_link="Wrist_Pitch_Roll_2"
+    parent_group="manipulator"
+    group="gripper"
+  />
+  <group_state name="home" group="manipulator">
+    <joint name="Rotation_R" value="0.0" />
+    <joint name="Pitch_R" value="1.575" />
+    <joint name="Elbow_R" value="1.46" />
+    <joint name="Wrist_Pitch_R" value="0.0" />
+    <joint name="Wrist_Roll_R" value="1.5707963267948966" />
+  </group_state>
+  <group_state name="ready" group="manipulator">
+    <joint name="Rotation_R" value="0.0" />
+    <joint name="Pitch_R" value="1.575" />
+    <joint name="Elbow_R" value="1.46" />
+    <joint name="Wrist_Pitch_R" value="0.0" />
+    <joint name="Wrist_Roll_R" value="1.5707963267948966" />
+  </group_state>
+  <passive_joint name="Jaw_Mate_R" />
+  <passive_joint name="Norma_Gear_R" />
+  <disable_collisions link1="Base_2" link2="Rotation_Pitch_2" reason="Adjacent" />
+  <disable_collisions link1="Rotation_Pitch_2" link2="Upper_Arm_2" reason="Adjacent" />
+  <disable_collisions link1="Upper_Arm_2" link2="Lower_Arm_2" reason="Adjacent" />
+  <disable_collisions link1="Lower_Arm_2" link2="Wrist_Pitch_Roll_2" reason="Adjacent" />
+  <disable_collisions link1="Wrist_Pitch_Roll_2" link2="Norma_Gripper_R" reason="Adjacent" />
+  <disable_collisions link1="Norma_Gripper_R" link2="Norma_Gear_R" reason="Adjacent" />
+  <disable_collisions link1="Norma_Gripper_R" link2="Norma_Jaw_Pos_R" reason="Adjacent" />
+  <disable_collisions link1="Norma_Gripper_R" link2="Norma_Jaw_Neg_R" reason="Adjacent" />
+  <disable_collisions link1="Norma_Jaw_Pos_R" link2="Norma_Jaw_Neg_R" reason="Never" />
+  <disable_collisions link1="Norma_Gripper_R" link2="gripper_tip" reason="Adjacent" />
+  <!-- Non-adjacent exclusions mirrored from the authoritative MuJoCo model. -->
+  <disable_collisions link1="Rotation_Pitch_2" link2="Lower_Arm_2" reason="Never" />
+  <disable_collisions
+    link1="Rotation_Pitch_2"
+    link2="Wrist_Pitch_Roll_2"
+    reason="Never"
+  />
+  <disable_collisions link1="Upper_Arm_2" link2="Wrist_Pitch_Roll_2" reason="Never" />
+  <disable_collisions link1="Upper_Arm_2" link2="Base_2" reason="Never" />
+  <disable_collisions
+    link1="Norma_Jaw_Pos_R"
+    link2="Wrist_Pitch_Roll_2"
+    reason="Never"
+  />
+  <disable_collisions
+    link1="Norma_Jaw_Neg_R"
+    link2="Wrist_Pitch_Roll_2"
+    reason="Never"
+  />
+</robot>

--- a/src/so101_moveit_config/config/so101_mapping.yaml
+++ b/src/so101_moveit_config/config/so101_mapping.yaml
@@ -1,0 +1,33 @@
+schema: so101.moveit.mapping.v1
+robot_id: so101_pi_follower
+hardware_arm: right
+mapping_id: xlerobot-overhead-v2
+calibration_sha256: 409228de0b511c46e44c5a4e5eeece5da09d6d58329b93889d611f75213c08b9
+source_model:
+  # Provenance path relative to the maintained so101-robot-ops repository.
+  path: camera-dashboard/public/models/so101_overhead_bimanual/so101_overhead_bimanual.xml
+  sha256: a04048ae67fd9ff2c43ed030503828ac876b1fb1a0226e3c7706cc28bc3f949c
+registration:
+  # registered_moveit_position = canonical_pi_position + offset
+  Rotation_R: 0.0
+  Pitch_R: 0.004203673205103398
+  Elbow_R: -0.1107963267948966
+  Wrist_Pitch_R: -0.00000006006107966527452
+  Wrist_Roll_R: 0.0
+  Jaw_R: 0.0
+canonical_fields:
+  Rotation_R: rotation_rad
+  Pitch_R: pitch_rad
+  Elbow_R: elbow_rad
+  Wrist_Pitch_R: wrist_pitch_rad
+  Wrist_Roll_R: wrist_roll_rad
+  Jaw_R: jaw_travel_m
+registered_limits:
+  # Padded model/planning bounds from the authoritative bimanual MJCF.
+  # Physical commands are clamped again to the Pi-published canonical limits.
+  Rotation_R: [-2.16, 2.16]
+  Pitch_R: [-0.24, 3.56]
+  Elbow_R: [-0.47, 3.40]
+  Wrist_Pitch_R: [-1.86, 1.94]
+  Wrist_Roll_R: [-3.15, 3.15]
+  Jaw_R: [0.0, 0.027]

--- a/src/so101_moveit_config/config/vla_serving.yaml
+++ b/src/so101_moveit_config/config/vla_serving.yaml
@@ -1,0 +1,21 @@
+# A live-compatible SO-101 checkpoint is intentionally not selected by
+# default. Setting one changes what commands can reach a physical robot, so
+# the inference server must fail closed until the operator chooses it.
+checkpoint: ""
+
+# Empty reads the policy family from the checkpoint's config.json.
+policy_class: ""
+
+# Read the training rate from train_config.json. ExecutePolicy's `dt` must be
+# set to the inverse of the resolved rate.
+fps: 0.0
+
+# `auto` selects ROCm on the Framework Desktop through MoveIt Pro's detected
+# product target, CUDA when available, and otherwise CPU.
+device: auto
+
+# Five arm joints plus the prismatic jaw.
+state_dim: 6
+
+guidance_horizon: 8
+rtc_schedule: EXP

--- a/src/so101_moveit_config/description/assets/Base.stl
+++ b/src/so101_moveit_config/description/assets/Base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb8afb0303c0125f265a797625cfaf646ac214d5d2dc9c986348c415755e2a74
+size 443484

--- a/src/so101_moveit_config/description/assets/Base_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Base_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aac4485d448eca418d2a93df3f78f449bd59b21ec1af2a579171819fd44ea576
+size 154284

--- a/src/so101_moveit_config/description/assets/Fixed_Jaw.stl
+++ b/src/so101_moveit_config/description/assets/Fixed_Jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5528867073033eaa4c27a8087180954f3f0635bd69d517d5cace92f01dd266b2
+size 264584

--- a/src/so101_moveit_config/description/assets/Fixed_Jaw_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Fixed_Jaw_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0321bfb902d5a119c4f2a934ab4be7e9ea8c93a02e1685f066f99c24a5ca3ecf
+size 151884

--- a/src/so101_moveit_config/description/assets/Fixed_Jaw_part1.ply.convex.stl
+++ b/src/so101_moveit_config/description/assets/Fixed_Jaw_part1.ply.convex.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a91f823092866cb519ff8b2590d6ca7ded921c70c06d64f9524fad2c244a6c62
+size 684

--- a/src/so101_moveit_config/description/assets/Fixed_Jaw_part2.ply.convex.stl
+++ b/src/so101_moveit_config/description/assets/Fixed_Jaw_part2.ply.convex.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd6162eb944dc700244552de36e723ba4097ccd25688f06a7413b8133f637d92
+size 1284

--- a/src/so101_moveit_config/description/assets/Lower_Arm.stl
+++ b/src/so101_moveit_config/description/assets/Lower_Arm.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a04511bc65cbb702b2d6023764de947888b06a09fbf272803f39c22724329a3e
+size 347184

--- a/src/so101_moveit_config/description/assets/Lower_Arm_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Lower_Arm_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07368fa4c50dea70e8157accee71072120c0cb374f672c85aba1d081702bc476
+size 151884

--- a/src/so101_moveit_config/description/assets/Moving_Jaw.stl
+++ b/src/so101_moveit_config/description/assets/Moving_Jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9c923024c75e6f0a8d8300317c4d8a17dd49880260cbc60b7fe5e0c6dadfa8
+size 177184

--- a/src/so101_moveit_config/description/assets/Moving_Jaw_part1.ply.convex.stl
+++ b/src/so101_moveit_config/description/assets/Moving_Jaw_part1.ply.convex.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c331a7c7b7a4cdddeb894b4f72e897a2a77b549d9f2a335eea77f10a90ec8567
+size 684

--- a/src/so101_moveit_config/description/assets/Moving_Jaw_part2.ply.convex.stl
+++ b/src/so101_moveit_config/description/assets/Moving_Jaw_part2.ply.convex.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:421a34db4d1426b1abe1f30ed73525f07674645130df94d2935b2ac2084e37e1
+size 684

--- a/src/so101_moveit_config/description/assets/Moving_Jaw_part3.ply.convex.stl
+++ b/src/so101_moveit_config/description/assets/Moving_Jaw_part3.ply.convex.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0d92ac9c477f283211d3b5b925f184d7f031a2001853abfabba3c00a0a3c6b4
+size 984

--- a/src/so101_moveit_config/description/assets/Rotation_Pitch.stl
+++ b/src/so101_moveit_config/description/assets/Rotation_Pitch.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a1476f57d28d2c065bc0ede6a674cb3ebacf1193372916ef1e0ff32eeb92cf0
+size 347584

--- a/src/so101_moveit_config/description/assets/Rotation_Pitch_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Rotation_Pitch_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fbcf18d8f2e91d12a767c1679430140dce0c81ea1478cc153bfce3a162db61
+size 154284

--- a/src/so101_moveit_config/description/assets/Upper_Arm.stl
+++ b/src/so101_moveit_config/description/assets/Upper_Arm.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d97ad37c90400fe39bb2d5ace8b4290f3d1262e13f1d4f166494421752d5f3b7
+size 215184

--- a/src/so101_moveit_config/description/assets/Upper_Arm_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Upper_Arm_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bafdb2cb9e9a884e62b5fbf15b1f706a65771da82764dbe703df128d9f34d723
+size 152284

--- a/src/so101_moveit_config/description/assets/Wrist_Pitch_Roll.stl
+++ b/src/so101_moveit_config/description/assets/Wrist_Pitch_Roll.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58e83ce1c8b24e1fa3a79672ea965ea4143986c81a21386dcd6da1cbcfdc94bb
+size 341684

--- a/src/so101_moveit_config/description/assets/Wrist_Pitch_Roll_Motor.stl
+++ b/src/so101_moveit_config/description/assets/Wrist_Pitch_Roll_Motor.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ac3fb1d2536fa4f7c40e7449be4b934d7d776f9cd0453c842767f980ff6c18
+size 133684

--- a/src/so101_moveit_config/description/assets/XLeRobot_camera1.stl
+++ b/src/so101_moveit_config/description/assets/XLeRobot_camera1.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54fc014701f1772f1fd1f4699b5a17b8648ccf0d5d34f5af35048101b978de0
+size 42284

--- a/src/so101_moveit_config/description/assets/XLeRobot_camera2.stl
+++ b/src/so101_moveit_config/description/assets/XLeRobot_camera2.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95154bef44deeb7138f6914ac23250189100df17be1433c70b297eab7398a109
+size 120884

--- a/src/so101_moveit_config/description/assets/arm_base.stl
+++ b/src/so101_moveit_config/description/assets/arm_base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169adfd40bcca689334efd1188c9b42cc03c914dc0afeaa98cb5431013610833
+size 86884

--- a/src/so101_moveit_config/description/assets/cam_mount_bottom.stl
+++ b/src/so101_moveit_config/description/assets/cam_mount_bottom.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3545b6cae437210e17b7dcfee2e12e00dc7a59ece9264f4b13ab9fd8ceb8088
+size 48684

--- a/src/so101_moveit_config/description/assets/cam_mount_middle.stl
+++ b/src/so101_moveit_config/description/assets/cam_mount_middle.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f3980df74777f74cf53a4697cbb63e4e000ab53f418de209559214f733f84b
+size 56984

--- a/src/so101_moveit_config/description/assets/cam_mount_top.stl
+++ b/src/so101_moveit_config/description/assets/cam_mount_top.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206762be157918967741eb53665cac796485c4609ac64d4c9444d85c7fcb2c4c
+size 69684

--- a/src/so101_moveit_config/description/assets/norma_pgripper/LICENSE
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/so101_moveit_config/description/assets/norma_pgripper/NOTICE.md
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/NOTICE.md
@@ -1,0 +1,39 @@
+# Norma Core parallel gripper assets
+
+Source: [`norma-core/norma-core`](https://github.com/norma-core/norma-core/tree/dea97c596aa5e3833c26586ec3edf74cd717144a/hardware/pgripper)
+
+Upstream commit: `dea97c596aa5e3833c26586ec3edf74cd717144a`
+
+License: Apache License 2.0; see `LICENSE` in this directory.
+
+The following files are unmodified upstream STL exports, renamed for stable URL use:
+
+- `gripper_base.stl`
+- `gripper_base_shield.stl`
+- `gripper_gear.stl`
+- `gripper_jaw.stl`
+- `wiring_bracket.stl`
+- `camera_mount_square_27mm.stl`
+- `reference_u20.png`
+
+The following files are derived from upstream `STEP/Gripper.stp` by triangulating
+the named assembly components and transforming their vertices into the SO-101
+wrist-horn frame used by this MJCF:
+
+- `norma_u20_camera.stl`
+- `norma_st3215_servo.stl`
+- `norma_gripper_hardware.stl`
+
+The wrist-horn frame maps the upstream assembled coordinates as follows:
+
+```text
+SO-101 X = -(upstream Y - horn Y)
+SO-101 Y =  (upstream Z - horn Z)
+SO-101 Z = -(upstream X - horn X)
+horn = (24.7807, -2.5394, 62.7769) mm
+```
+
+The supplied real-robot witness image has SHA-256
+`c0c1b4c1347489d99a0f28aad53c9106975a609ca02119304a8a835af5ed964d`,
+identical to upstream `images/cameras/u20.png`. That establishes the 27 mm U20
+camera mount as the correct variant.

--- a/src/so101_moveit_config/description/assets/norma_pgripper/asset-manifest.json
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/asset-manifest.json
@@ -1,0 +1,23 @@
+{
+  "schema": "so101.norma-pgripper-assets.v1",
+  "upstream": {
+    "repository": "https://github.com/norma-core/norma-core",
+    "commit": "dea97c596aa5e3833c26586ec3edf74cd717144a",
+    "directory": "hardware/pgripper",
+    "stepSha256": "4c12c156b34d9027ab94c674f4932430fcbccd3caed15d9f5254cb0e79953955",
+    "referenceImageSha256": "c0c1b4c1347489d99a0f28aad53c9106975a609ca02119304a8a835af5ed964d"
+  },
+  "units": "millimeter",
+  "meshScale": [0.001, 0.001, 0.001],
+  "mechanics": {
+    "travelPerJawMeters": 0.027,
+    "totalOpeningMeters": 0.054,
+    "stepReferenceOpeningMeters": 0.05,
+    "rackPitchRadiusMeters": 0.0115
+  },
+  "camera": {
+    "variant": "Innomaker U20CAM 27 mm",
+    "opticalAxisInHornFrame": [0, -0.9063078, -0.4226183],
+    "lensFrontInHornFrameMeters": [0, -0.022269, 0.060999]
+  }
+}

--- a/src/so101_moveit_config/description/assets/norma_pgripper/camera_mount_square_27mm.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/camera_mount_square_27mm.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3191faa66b87c20fbdd3596b7691017083a82afd3348761623bab2aaa39e8f32
+size 126984

--- a/src/so101_moveit_config/description/assets/norma_pgripper/gripper_base.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/gripper_base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2a0d14df2a2775862da931b032fe1f026e320e058227ee3f20c9c3c36450632
+size 219284

--- a/src/so101_moveit_config/description/assets/norma_pgripper/gripper_base_shield.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/gripper_base_shield.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:364785792d6be82d0c24c29e18df54030747a277161bfcf6ac1363a0beb6838d
+size 70884

--- a/src/so101_moveit_config/description/assets/norma_pgripper/gripper_gear.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/gripper_gear.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:966bb466a7437463666b60084257a6744d3cefe0973effc0db9ca54a907e25f2
+size 157884

--- a/src/so101_moveit_config/description/assets/norma_pgripper/gripper_jaw.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/gripper_jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c7766cbcb61a8ff4ffb5d4588ded441c701e445f7cbc6487a2903d7a98ed46
+size 115784

--- a/src/so101_moveit_config/description/assets/norma_pgripper/norma_gripper_hardware.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/norma_gripper_hardware.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af13a3dd9b2fc75e35a924f29f9b65f9f0b789e5e547a9c37a00754f60bb1424
+size 2877684

--- a/src/so101_moveit_config/description/assets/norma_pgripper/norma_st3215_servo.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/norma_st3215_servo.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4099c5634f12892ccfa8e31ede2ae92cf2f0b94705952e76388a84008200dcb0
+size 1468484

--- a/src/so101_moveit_config/description/assets/norma_pgripper/norma_u20_camera.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/norma_u20_camera.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba87aa6f6af475374a875d51dbbd0315e6cf47daf0add859a48989cbe4a57df8
+size 349184

--- a/src/so101_moveit_config/description/assets/norma_pgripper/reference_u20.png
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/reference_u20.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0c1b4c1347489d99a0f28aad53c9106975a609ca02119304a8a835af5ed964d
+size 640270

--- a/src/so101_moveit_config/description/assets/norma_pgripper/wiring_bracket.stl
+++ b/src/so101_moveit_config/description/assets/norma_pgripper/wiring_bracket.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:333dd417b6e66a3bb86723e0f4431b4ec806095384901ffa5088aec2316fd7b3
+size 21984

--- a/src/so101_moveit_config/description/so101_follower.urdf.xacro
+++ b/src/so101_moveit_config/description/so101_follower.urdf.xacro
@@ -1,0 +1,602 @@
+<?xml version="1.0" ?>
+<robot name="so101_follower" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="hardware_interface" default="mujoco" />
+  <xacro:arg name="mujoco_model" default="description/so101_follower_scene.xml" />
+  <xacro:arg name="mujoco_keyframe" default="home" />
+  <xacro:arg name="mujoco_viewer" default="false" />
+
+  <material name="galaxy_black">
+    <color rgba="0.028 0.032 0.041 1" />
+  </material>
+  <material name="motor">
+    <color rgba="0.1 0.1 0.1 1" />
+  </material>
+  <material name="cream_white">
+    <color rgba="0.91 0.86 0.74 1" />
+  </material>
+  <material name="pgripper_hardware">
+    <color rgba="0.32 0.33 0.34 1" />
+  </material>
+
+  <xacro:macro name="mesh_geometry" params="file">
+    <geometry>
+      <mesh filename="package://so101_moveit_config/description/assets/${file}" />
+    </geometry>
+  </xacro:macro>
+
+  <xacro:macro name="millimeter_mesh_geometry" params="file">
+    <geometry>
+      <mesh
+        filename="package://so101_moveit_config/description/assets/${file}"
+        scale="0.001 0.001 0.001"
+      />
+    </geometry>
+  </xacro:macro>
+
+  <xacro:macro
+    name="controlled_joint"
+    params="name initial min_position max_position"
+  >
+    <joint name="${name}">
+      <command_interface name="position">
+        <param name="min">${min_position}</param>
+        <param name="max">${max_position}</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">${initial}</param>
+      </state_interface>
+      <state_interface name="velocity" />
+      <state_interface name="effort" />
+    </joint>
+  </xacro:macro>
+
+  <xacro:macro name="so101_ros2_control" params="hardware_interface">
+    <ros2_control name="so101_follower_system" type="system">
+      <xacro:if value="${hardware_interface == 'mujoco'}">
+        <sensor name="overhead_cam">
+          <param name="rgb_topic">/so101/cameras/overhead/image_raw</param>
+          <param name="camera_info_topic">/so101/cameras/overhead/camera_info</param>
+        </sensor>
+        <sensor name="right_wrist_cam">
+          <param name="rgb_topic">/so101/cameras/wrist/image_raw</param>
+          <param name="camera_info_topic">/so101/cameras/wrist/camera_info</param>
+        </sensor>
+      </xacro:if>
+      <xacro:if value="${hardware_interface == 'mujoco'}">
+        <hardware>
+          <plugin>picknik_mujoco_ros/MujocoSystem</plugin>
+          <param name="mujoco_model">$(arg mujoco_model)</param>
+          <param name="mujoco_model_package">so101_moveit_config</param>
+          <param name="mujoco_keyframe">$(arg mujoco_keyframe)</param>
+          <param name="mujoco_viewer">$(arg mujoco_viewer)</param>
+          <param name="render_publish_rate">10</param>
+          <param name="point_cloud_publish_rate">5</param>
+          <param name="tf_publish_rate">30</param>
+          <param name="publish_mj_world_tf">false</param>
+          <param name="base_link_name">Base_2</param>
+        </hardware>
+      </xacro:if>
+      <xacro:controlled_joint
+        name="Rotation_R"
+        initial="0.0"
+        min_position="-2.16"
+        max_position="2.16"
+      />
+      <xacro:controlled_joint
+        name="Pitch_R"
+        initial="1.575"
+        min_position="-0.24"
+        max_position="3.56"
+      />
+      <xacro:controlled_joint
+        name="Elbow_R"
+        initial="1.46"
+        min_position="-0.47"
+        max_position="3.40"
+      />
+      <xacro:controlled_joint
+        name="Wrist_Pitch_R"
+        initial="0.0"
+        min_position="-1.86"
+        max_position="1.94"
+      />
+      <xacro:controlled_joint
+        name="Wrist_Roll_R"
+        initial="1.5707963267948966"
+        min_position="-3.15"
+        max_position="3.15"
+      />
+      <xacro:controlled_joint
+        name="Jaw_R"
+        initial="0.027"
+        min_position="0.0"
+        max_position="0.027"
+      />
+    </ros2_control>
+  </xacro:macro>
+
+  <link name="world" />
+
+  <!--
+    Static bimanual workcell from the authoritative MuJoCo twin. Both arm
+    plates remain visible even though this config controls only the attached
+    right follower. The stand is visual-only, matching the source model.
+  -->
+  <link name="overhead_stand">
+    <visual name="stand_bottom">
+      <origin xyz="-0.0187 0.0365 0" rpy="1.5707963 0 0" />
+      <xacro:millimeter_mesh_geometry file="cam_mount_bottom.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual name="stand_middle">
+      <origin xyz="0 0 0.1885" rpy="1.5707963 0 0" />
+      <xacro:millimeter_mesh_geometry file="cam_mount_middle.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual name="stand_top">
+      <origin xyz="0 0 0.1885" rpy="1.5707963 0 0" />
+      <xacro:millimeter_mesh_geometry file="cam_mount_top.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual name="left_arm_plate">
+      <origin xyz="0.0753 0.0626 0.005" rpy="1.5707963 0 0" />
+      <xacro:millimeter_mesh_geometry file="arm_base.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual name="right_arm_plate">
+      <origin xyz="0.0753 -0.1695 0.005" rpy="1.5707963 0 0" />
+      <xacro:millimeter_mesh_geometry file="arm_base.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual name="overhead_cam_module">
+      <origin
+        xyz="0.07769 -0.00373 0.54222"
+        rpy="-1.1045436248526044 1.5510380297980149 0.4708007064179038"
+      />
+      <xacro:millimeter_mesh_geometry file="XLeRobot_camera2.stl" />
+      <material name="motor" />
+    </visual>
+  </link>
+  <joint name="world_to_overhead_stand" type="fixed">
+    <parent link="world" />
+    <child link="overhead_stand" />
+  </joint>
+
+  <link name="Base_2">
+    <inertial>
+      <origin xyz="0.0137179 -0.0000519711 0.0334843" />
+      <mass value="0.147" />
+      <inertia
+        ixx="0.000114686"
+        ixy="-0.000000459787"
+        ixz="0.00000497151"
+        iyy="0.000136117"
+        iyz="0.0000000975275"
+        izz="0.000130364"
+      />
+    </inertial>
+    <visual>
+      <xacro:mesh_geometry file="Base.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual>
+      <xacro:mesh_geometry file="Base_Motor.stl" />
+      <material name="motor" />
+    </visual>
+    <collision>
+      <xacro:mesh_geometry file="Base.stl" />
+    </collision>
+    <collision>
+      <xacro:mesh_geometry file="Base_Motor.stl" />
+    </collision>
+  </link>
+  <joint name="world_to_Base_2" type="fixed">
+    <parent link="world" />
+    <child link="Base_2" />
+    <origin xyz="-0.0013 -0.11605 0.0072" rpy="0 0 1.5707963" />
+  </joint>
+
+  <link name="Rotation_Pitch_2">
+    <inertial>
+      <origin xyz="-0.0307604 -0.0000166727 -0.0252713" />
+      <mass value="0.100006" />
+      <inertia
+        ixx="0.000083759"
+        ixy="0.0000000755525"
+        ixz="-0.00000116342"
+        iyy="0.0000810403"
+        iyz="0.000000154663"
+        izz="0.0000239783"
+      />
+    </inertial>
+    <visual>
+      <xacro:mesh_geometry file="Rotation_Pitch.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual>
+      <xacro:mesh_geometry file="Rotation_Pitch_Motor.stl" />
+      <material name="motor" />
+    </visual>
+    <collision>
+      <xacro:mesh_geometry file="Rotation_Pitch.stl" />
+    </collision>
+    <collision>
+      <xacro:mesh_geometry file="Rotation_Pitch_Motor.stl" />
+    </collision>
+  </link>
+  <joint name="Rotation_R" type="revolute">
+    <parent link="Base_2" />
+    <child link="Rotation_Pitch_2" />
+    <origin xyz="0 -0.0452 0.0165" rpy="1.5708 0 0" />
+    <axis xyz="0 -1 0" />
+    <limit
+      lower="-2.16"
+      upper="2.16"
+      effort="3.35"
+      velocity="1.20"
+    />
+    <dynamics damping="0.60" friction="0.052" />
+  </joint>
+
+  <link name="Upper_Arm_2">
+    <inertial>
+      <origin xyz="-0.0898471 -0.00838224 0.0184089" />
+      <mass value="0.103" />
+      <inertia
+        ixx="0.0000408002"
+        ixy="-0.0000197819"
+        ixz="-0.0000000403016"
+        iyy="0.000147318"
+        iyz="0.00000000897326"
+        izz="0.000142487"
+      />
+    </inertial>
+    <visual>
+      <xacro:mesh_geometry file="Upper_Arm.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual>
+      <xacro:mesh_geometry file="Upper_Arm_Motor.stl" />
+      <material name="motor" />
+    </visual>
+    <collision>
+      <xacro:mesh_geometry file="Upper_Arm.stl" />
+    </collision>
+    <collision>
+      <xacro:mesh_geometry file="Upper_Arm_Motor.stl" />
+    </collision>
+  </link>
+  <joint name="Pitch_R" type="revolute">
+    <parent link="Rotation_Pitch_2" />
+    <child link="Upper_Arm_2" />
+    <origin xyz="0 0.1025 0.0306" rpy="1.5708 0 0" />
+    <axis xyz="-1 0 0" />
+    <limit
+      lower="-0.24"
+      upper="3.56"
+      effort="3.35"
+      velocity="1.20"
+    />
+    <dynamics damping="0.60" friction="0.052" />
+  </joint>
+
+  <link name="Lower_Arm_2">
+    <inertial>
+      <origin xyz="-0.0980701 0.00324376 0.0182831" />
+      <mass value="0.104" />
+      <inertia
+        ixx="0.0000287438"
+        ixy="0.00000741152"
+        ixz="0.00000126409"
+        iyy="0.000159844"
+        iyz="-0.0000000490188"
+        izz="0.00014529"
+      />
+    </inertial>
+    <visual>
+      <xacro:mesh_geometry file="Lower_Arm.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual>
+      <xacro:mesh_geometry file="Lower_Arm_Motor.stl" />
+      <material name="motor" />
+    </visual>
+    <collision>
+      <xacro:mesh_geometry file="Lower_Arm.stl" />
+    </collision>
+    <collision>
+      <xacro:mesh_geometry file="Lower_Arm_Motor.stl" />
+    </collision>
+  </link>
+  <joint name="Elbow_R" type="revolute">
+    <parent link="Upper_Arm_2" />
+    <child link="Lower_Arm_2" />
+    <origin xyz="0 0.11257 0.028" rpy="-1.5708 0 0" />
+    <axis xyz="1 0 0" />
+    <limit
+      lower="-0.47"
+      upper="3.40"
+      effort="3.35"
+      velocity="1.20"
+    />
+    <dynamics damping="0.60" friction="0.052" />
+  </joint>
+
+  <link name="Wrist_Pitch_Roll_2">
+    <inertial>
+      <origin xyz="-0.000103312 -0.0386143 0.0281156" />
+      <mass value="0.079" />
+      <inertia
+        ixx="0.0000368263"
+        ixy="0.000000017893"
+        ixz="-0.0000000528128"
+        iyy="0.000025391"
+        iyz="0.0000036412"
+        izz="0.000021"
+      />
+    </inertial>
+    <visual>
+      <xacro:mesh_geometry file="Wrist_Pitch_Roll.stl" />
+      <material name="galaxy_black" />
+    </visual>
+    <visual>
+      <xacro:mesh_geometry file="Wrist_Pitch_Roll_Motor.stl" />
+      <material name="motor" />
+    </visual>
+    <collision>
+      <xacro:mesh_geometry file="Wrist_Pitch_Roll.stl" />
+    </collision>
+    <collision>
+      <xacro:mesh_geometry file="Wrist_Pitch_Roll_Motor.stl" />
+    </collision>
+  </link>
+  <joint name="Wrist_Pitch_R" type="revolute">
+    <parent link="Lower_Arm_2" />
+    <child link="Wrist_Pitch_Roll_2" />
+    <origin xyz="0 0.0052 0.1349" rpy="-1.5708 0 0" />
+    <axis xyz="1 0 0" />
+    <limit
+      lower="-1.86"
+      upper="1.94"
+      effort="3.35"
+      velocity="1.20"
+    />
+    <dynamics damping="0.60" friction="0.052" />
+  </joint>
+
+  <link name="Norma_Gripper_R">
+    <inertial>
+      <origin xyz="0 -0.028 0" />
+      <mass value="0.22" />
+      <inertia
+        ixx="0.00028"
+        ixy="0"
+        ixz="0"
+        iyy="0.00022"
+        iyz="0"
+        izz="0.0002"
+      />
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.027975 -0.03525" rpy="0 0 -1.5707963267948966" />
+      <xacro:millimeter_mesh_geometry file="norma_pgripper/gripper_base.stl" />
+      <material name="cream_white" />
+    </visual>
+    <visual>
+      <origin
+        xyz="-0.02325 -0.023375 -0.01525"
+        rpy="0 0 1.5707963267948966"
+      />
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/gripper_base_shield.stl"
+      />
+      <material name="cream_white" />
+    </visual>
+    <visual>
+      <origin
+        xyz="0.023146893 -0.023375 0.01525"
+        rpy="3.141592653589793 0 1.5707963267948966"
+      />
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/gripper_base_shield.stl"
+      />
+      <material name="cream_white" />
+    </visual>
+    <visual>
+      <origin
+        xyz="0 -0.00925 -0.03275"
+        rpy="1.5707963267948966 0 3.141592653589793"
+      />
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/wiring_bracket.stl"
+      />
+      <material name="cream_white" />
+    </visual>
+    <visual>
+      <origin
+        xyz="0 -0.015785372 0.01525"
+        rpy="0 0 -1.5707963267948966"
+      />
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/camera_mount_square_27mm.stl"
+      />
+      <material name="cream_white" />
+    </visual>
+    <visual>
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/norma_st3215_servo.stl"
+      />
+      <material name="motor" />
+    </visual>
+    <visual>
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/norma_gripper_hardware.stl"
+      />
+      <material name="pgripper_hardware" />
+    </visual>
+    <visual>
+      <xacro:millimeter_mesh_geometry
+        file="norma_pgripper/norma_u20_camera.stl"
+      />
+      <material name="motor" />
+    </visual>
+  </link>
+  <joint name="Wrist_Roll_R" type="revolute">
+    <parent link="Wrist_Pitch_Roll_2" />
+    <child link="Norma_Gripper_R" />
+    <origin xyz="0 -0.0601 0" rpy="0 1.5708 0" />
+    <axis xyz="0 -1 0" />
+    <limit
+      lower="-3.15"
+      upper="3.15"
+      effort="3.35"
+      velocity="1.20"
+    />
+    <dynamics damping="0.60" friction="0.052" />
+  </joint>
+
+  <link name="Norma_Gear_R">
+    <inertial>
+      <mass value="0.006" />
+      <inertia
+        ixx="0.000001"
+        ixy="0"
+        ixz="0"
+        iyy="0.000002"
+        iyz="0"
+        izz="0.000001"
+      />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 -0.01370322" rpy="0 0 -1.5707963267948966" />
+      <geometry>
+        <mesh
+          filename="package://so101_moveit_config/description/assets/norma_pgripper/gripper_gear.stl"
+          scale="0.001 0.001 0.001"
+        />
+      </geometry>
+      <material name="cream_white" />
+    </visual>
+  </link>
+  <joint name="Norma_Gear_R" type="revolute">
+    <parent link="Norma_Gripper_R" />
+    <child link="Norma_Gear_R" />
+    <origin xyz="0 -0.04845 0" />
+    <axis xyz="0 -1 0" />
+    <limit lower="-0.18" upper="2.18" effort="1" velocity="2" />
+    <mimic joint="Jaw_R" multiplier="-86.956522" offset="2.173913" />
+  </joint>
+
+  <link name="Norma_Jaw_Pos_R">
+    <inertial>
+      <origin xyz="0 0.029 0" />
+      <mass value="0.025" />
+      <inertia
+        ixx="0.000012"
+        ixy="0"
+        ixz="0"
+        iyy="0.000020"
+        iyz="0"
+        izz="0.000015"
+      />
+    </inertial>
+    <visual>
+      <origin rpy="-1.5707963267948966 0 0" />
+      <geometry>
+        <mesh
+          filename="package://so101_moveit_config/description/assets/norma_pgripper/gripper_jaw.stl"
+          scale="0.001 0.001 0.001"
+        />
+      </geometry>
+      <material name="cream_white" />
+    </visual>
+    <collision>
+      <origin xyz="0.015 0.022 0" />
+      <geometry>
+        <box size="0.008 0.044 0.022" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="Jaw_R" type="prismatic">
+    <parent link="Norma_Gripper_R" />
+    <child link="Norma_Jaw_Pos_R" />
+    <origin xyz="-0.011 -0.10345 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="0.0" upper="0.027" effort="25" velocity="0.01" />
+    <dynamics damping="6" friction="0.25" />
+  </joint>
+
+  <link name="Norma_Jaw_Neg_R">
+    <inertial>
+      <origin xyz="0 0.029 0" />
+      <mass value="0.025" />
+      <inertia
+        ixx="0.000012"
+        ixy="0"
+        ixz="0"
+        iyy="0.000020"
+        iyz="0"
+        izz="0.000015"
+      />
+    </inertial>
+    <visual>
+      <origin rpy="1.5707963267948966 0 3.141592653589793" />
+      <geometry>
+        <mesh
+          filename="package://so101_moveit_config/description/assets/norma_pgripper/gripper_jaw.stl"
+          scale="0.001 0.001 0.001"
+        />
+      </geometry>
+      <material name="cream_white" />
+    </visual>
+    <collision>
+      <origin xyz="-0.015 0.022 0" />
+      <geometry>
+        <box size="0.008 0.044 0.022" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="Jaw_Mate_R" type="prismatic">
+    <parent link="Norma_Gripper_R" />
+    <child link="Norma_Jaw_Neg_R" />
+    <origin xyz="0.011 -0.10345 0" />
+    <axis xyz="-1 0 0" />
+    <limit lower="0.0" upper="0.027" effort="25" velocity="0.01" />
+    <dynamics damping="6" friction="0.25" />
+    <mimic joint="Jaw_R" multiplier="1.0" offset="0.0" />
+  </joint>
+
+  <link name="gripper_tip" />
+  <joint name="gripper_tip_joint" type="fixed">
+    <parent link="Norma_Gripper_R" />
+    <child link="gripper_tip" />
+    <origin xyz="0 -0.08145 0" />
+  </joint>
+
+  <xacro:if value="${'$(arg hardware_interface)' == 'external'}">
+    <!--
+      Physical-camera optical frames mirror the MuJoCo camera-site contract.
+      The head camera is external and is represented at the calibrated twin
+      pose; refine this fixed transform after a physical extrinsic calibration.
+    -->
+    <link name="overhead_cam_optical_frame" />
+    <joint name="overhead_cam_optical_joint" type="fixed">
+      <parent link="Base_2" />
+      <child link="overhead_cam_optical_frame" />
+      <origin xyz="0.11605 -0.0387 0.5266" rpy="0.450 0 3.141592654" />
+    </joint>
+    <link name="right_wrist_cam_optical_frame" />
+    <joint name="right_wrist_cam_optical_joint" type="fixed">
+      <parent link="Norma_Gripper_R" />
+      <child link="right_wrist_cam_optical_frame" />
+      <origin
+        xyz="0 -0.022269 0.060999"
+        rpy="1.134464014 0 3.141592654"
+      />
+    </joint>
+  </xacro:if>
+
+  <xacro:unless value="${'$(arg hardware_interface)' == 'external'}">
+    <xacro:so101_ros2_control hardware_interface="$(arg hardware_interface)" />
+  </xacro:unless>
+</robot>

--- a/src/so101_moveit_config/description/so101_follower_scene.xml
+++ b/src/so101_moveit_config/description/so101_follower_scene.xml
@@ -1,0 +1,653 @@
+<mujoco model="so101_follower">
+  <!--
+    Single-follower extraction of so101_overhead_bimanual.xml.
+    Source SHA-256: a04048ae67fd9ff2c43ed030503828ac876b1fb1a0226e3c7706cc28bc3f949c
+    The complete bimanual stand remains in the scene while only the attached
+    right follower is actuated. The source model's padded registered ranges
+    admit live telemetry; the Pi-published canonical limits remain
+    authoritative for physical commands.
+  -->
+  <compiler angle="radian" meshdir="./assets/" fusestatic="false" />
+  <option
+    integrator="implicitfast"
+    timestep="0.005"
+    cone="elliptic"
+    iterations="10"
+    ls_iterations="20"
+    impratio="10"
+  />
+  <visual>
+    <global offwidth="1280" offheight="720" />
+    <quality offsamples="4" shadowsize="4096" />
+    <headlight
+      ambient="0.35 0.35 0.35"
+      diffuse="0.8 0.8 0.8"
+      specular="0.3 0.3 0.3"
+    />
+    <map haze="0.1" />
+  </visual>
+
+  <asset>
+    <material
+      name="galaxy_black"
+      rgba="0.028 0.032 0.041 1"
+      specular="0.32"
+      shininess="0.38"
+    />
+    <material
+      name="motor"
+      rgba="0.1 0.1 0.1 1"
+      specular="0.1"
+      shininess="0.1"
+    />
+    <material
+      name="cream_white"
+      rgba="0.91 0.86 0.74 1"
+      specular="0.12"
+      shininess="0.16"
+    />
+    <material
+      name="pgripper_hardware"
+      rgba="0.32 0.33 0.34 1"
+      specular="0.35"
+      shininess="0.4"
+    />
+
+    <mesh name="Base" file="Base.stl" />
+    <mesh name="Base_Motor" file="Base_Motor.stl" />
+    <mesh name="Rotation_Pitch" file="Rotation_Pitch.stl" />
+    <mesh name="Rotation_Pitch_Motor" file="Rotation_Pitch_Motor.stl" />
+    <mesh name="Upper_Arm" file="Upper_Arm.stl" />
+    <mesh name="Upper_Arm_Motor" file="Upper_Arm_Motor.stl" />
+    <mesh name="Lower_Arm" file="Lower_Arm.stl" />
+    <mesh name="Lower_Arm_Motor" file="Lower_Arm_Motor.stl" />
+    <mesh name="Wrist_Pitch_Roll" file="Wrist_Pitch_Roll.stl" />
+    <mesh name="Wrist_Pitch_Roll_Motor" file="Wrist_Pitch_Roll_Motor.stl" />
+    <mesh
+      name="Norma_Gripper_Base"
+      file="norma_pgripper/gripper_base.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Gripper_Gear"
+      file="norma_pgripper/gripper_gear.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Gripper_Jaw"
+      file="norma_pgripper/gripper_jaw.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Gripper_Shield"
+      file="norma_pgripper/gripper_base_shield.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Gripper_Wiring"
+      file="norma_pgripper/wiring_bracket.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Camera_Mount_27mm"
+      file="norma_pgripper/camera_mount_square_27mm.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_U20_Camera"
+      file="norma_pgripper/norma_u20_camera.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_ST3215_Servo"
+      file="norma_pgripper/norma_st3215_servo.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="Norma_Gripper_Hardware"
+      file="norma_pgripper/norma_gripper_hardware.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="XLeRobot_camera2"
+      file="XLeRobot_camera2.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh name="arm_base_mount" file="arm_base.stl" scale="0.001 0.001 0.001" />
+    <mesh
+      name="cam_mount_bottom"
+      file="cam_mount_bottom.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="cam_mount_middle"
+      file="cam_mount_middle.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="cam_mount_top"
+      file="cam_mount_top.stl"
+      scale="0.001 0.001 0.001"
+    />
+  </asset>
+
+  <default>
+    <geom contype="0" conaffinity="0" condim="1" solref="0.005 1" />
+    <default class="sts3215">
+      <geom contype="0" conaffinity="0" />
+      <joint damping="0.60" frictionloss="0.052" armature="0.028" />
+      <position kp="998.22" kv="2.731" forcerange="-2.94 2.94" />
+    </default>
+    <default class="pgripper_slide">
+      <joint damping="6" frictionloss="0.25" armature="0.001" />
+      <position kp="1200" kv="70" forcerange="-25 25" />
+    </default>
+    <default class="visual">
+      <geom type="mesh" contype="0" conaffinity="0" density="0" group="2" />
+    </default>
+    <default class="collision">
+      <geom
+        contype="1"
+        conaffinity="1"
+        group="3"
+        type="mesh"
+        condim="4"
+        solref="0.002 1.0"
+        solimp="0.95 0.99 0.001"
+      />
+    </default>
+  </default>
+
+  <worldbody>
+    <light directional="true" pos="-0.5 0.5 3" dir="0 0 -1" />
+    <geom
+      name="floor"
+      type="plane"
+      pos="0 0 0"
+      size="1 1 0.02"
+      rgba="0.22 0.23 0.25 1"
+      contype="1"
+      conaffinity="1"
+    />
+    <body name="overhead_stand" pos="0 0 0">
+      <geom
+        name="stand_bottom"
+        type="mesh"
+        mesh="cam_mount_bottom"
+        pos="-0.0187 0.0365 0"
+        euler="1.5707963 0 0"
+        material="galaxy_black"
+        class="visual"
+      />
+      <geom
+        name="stand_middle"
+        type="mesh"
+        mesh="cam_mount_middle"
+        pos="0 0 0.1885"
+        euler="1.5707963 0 0"
+        material="galaxy_black"
+        class="visual"
+      />
+      <geom
+        name="stand_top"
+        type="mesh"
+        mesh="cam_mount_top"
+        pos="0 0 0.1885"
+        euler="1.5707963 0 0"
+        material="galaxy_black"
+        class="visual"
+      />
+      <geom
+        name="left_arm_plate"
+        type="mesh"
+        mesh="arm_base_mount"
+        pos="0.0753 0.0626 0.005"
+        euler="1.5707963 0 0"
+        material="galaxy_black"
+        class="visual"
+      />
+      <geom
+        name="right_arm_plate"
+        type="mesh"
+        mesh="arm_base_mount"
+        pos="0.0753 -0.1695 0.005"
+        euler="1.5707963 0 0"
+        material="galaxy_black"
+        class="visual"
+      />
+      <geom
+        name="overhead_cam_module"
+        type="mesh"
+        mesh="XLeRobot_camera2"
+        pos="0.07769 -0.00373 0.54222"
+        quat="0.50562 -0.50324 0.4922 0.49884"
+        material="motor"
+        class="visual"
+      />
+      <camera
+        name="overhead_cam"
+        pos="0.0374 0 0.5338"
+        xyaxes="0 -1 0 0.9 0 0.435"
+        resolution="1280 720"
+        fovy="74.5"
+      />
+      <site
+        name="overhead_cam_optical_frame"
+        pos="0.0374 0 0.5338"
+        xyaxes="0 -1 0 0.9 0 0.435"
+        size="0.003"
+        group="4"
+      />
+    </body>
+
+    <body name="Base_2" pos="-0.0013 -0.11605 0.0072" euler="0 0 1.5707963">
+      <inertial
+        pos="0.0137179 -5.19711e-05 0.0334843"
+        mass="0.147"
+        fullinertia="0.000114686 0.000136117 0.000130364 -4.59787e-07 4.97151e-06 9.75275e-08"
+      />
+      <geom type="mesh" mesh="Base" material="galaxy_black" class="visual" />
+      <geom type="mesh" mesh="Base_Motor" material="motor" class="visual" />
+      <geom type="mesh" mesh="Base" class="collision" />
+      <geom type="mesh" mesh="Base_Motor" class="collision" />
+
+      <body name="Rotation_Pitch_2" pos="0 -0.0452 0.0165" euler="1.5708 0 0">
+        <inertial
+          pos="-0.0307604 -1.66727e-05 -0.0252713"
+          mass="0.100006"
+          fullinertia="8.3759e-05 8.10403e-05 2.39783e-05 7.55525e-08 -1.16342e-06 1.54663e-07"
+        />
+        <joint
+          name="Rotation_R"
+          type="hinge"
+          axis="0 -1 0"
+          range="-2.16 2.16"
+          class="sts3215"
+        />
+        <geom
+          type="mesh"
+          mesh="Rotation_Pitch"
+          material="galaxy_black"
+          class="visual"
+        />
+        <geom
+          type="mesh"
+          mesh="Rotation_Pitch_Motor"
+          material="motor"
+          class="visual"
+        />
+        <geom type="mesh" mesh="Rotation_Pitch" class="collision" />
+        <geom type="mesh" mesh="Rotation_Pitch_Motor" class="collision" />
+
+        <body name="Upper_Arm_2" pos="0 0.1025 0.0306" euler="1.5708 0 0">
+          <inertial
+            pos="-0.0898471 -0.00838224 0.0184089"
+            mass="0.103"
+            fullinertia="4.08002e-05 0.000147318 0.000142487 -1.97819e-05 -4.03016e-08 8.97326e-09"
+          />
+          <joint
+            name="Pitch_R"
+            type="hinge"
+            axis="-1 0 0"
+            range="-0.24 3.56"
+            class="sts3215"
+          />
+          <geom
+            type="mesh"
+            mesh="Upper_Arm"
+            material="galaxy_black"
+            class="visual"
+          />
+          <geom
+            type="mesh"
+            mesh="Upper_Arm_Motor"
+            material="motor"
+            class="visual"
+          />
+          <geom type="mesh" mesh="Upper_Arm" class="collision" />
+          <geom type="mesh" mesh="Upper_Arm_Motor" class="collision" />
+
+          <body name="Lower_Arm_2" pos="0 0.11257 0.028" euler="-1.5708 0 0">
+            <inertial
+              pos="-0.0980701 0.00324376 0.0182831"
+              mass="0.104"
+              fullinertia="2.87438e-05 0.000159844 0.00014529 7.41152e-06 1.26409e-06 -4.90188e-08"
+            />
+            <joint
+              name="Elbow_R"
+              type="hinge"
+              axis="1 0 0"
+              range="-0.47 3.40"
+              class="sts3215"
+            />
+            <geom
+              type="mesh"
+              mesh="Lower_Arm"
+              material="galaxy_black"
+              class="visual"
+            />
+            <geom
+              type="mesh"
+              mesh="Lower_Arm_Motor"
+              material="motor"
+              class="visual"
+            />
+            <geom type="mesh" mesh="Lower_Arm" class="collision" />
+            <geom type="mesh" mesh="Lower_Arm_Motor" class="collision" />
+
+            <body
+              name="Wrist_Pitch_Roll_2"
+              pos="0 0.0052 0.1349"
+              euler="-1.5708 0 0"
+            >
+              <inertial
+                pos="-0.000103312 -0.0386143 0.0281156"
+                mass="0.079"
+                fullinertia="3.68263e-05 2.5391e-05 2.1e-05 1.7893e-08 -5.28128e-08 3.6412e-06"
+              />
+              <joint
+                name="Wrist_Pitch_R"
+                type="hinge"
+                axis="1 0 0"
+                range="-1.86 1.94"
+                class="sts3215"
+              />
+              <geom
+                type="mesh"
+                mesh="Wrist_Pitch_Roll"
+                material="galaxy_black"
+                class="visual"
+              />
+              <geom
+                type="mesh"
+                mesh="Wrist_Pitch_Roll_Motor"
+                material="motor"
+                class="visual"
+              />
+              <geom type="mesh" mesh="Wrist_Pitch_Roll" class="collision" />
+              <geom
+                type="mesh"
+                mesh="Wrist_Pitch_Roll_Motor"
+                class="collision"
+              />
+
+              <body name="Norma_Gripper_R" pos="0 -0.0601 0" euler="0 1.5708 0">
+                <inertial
+                  pos="0 -0.028 0"
+                  mass="0.22"
+                  diaginertia="0.00028 0.00022 0.0002"
+                />
+                <joint
+                  name="Wrist_Roll_R"
+                  type="hinge"
+                  axis="0 -1 0"
+                  range="-3.15 3.15"
+                  class="sts3215"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Gripper_Base"
+                  pos="0 -0.027975 -0.03525"
+                  quat="0.70710678 0 0 -0.70710678"
+                  material="cream_white"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Gripper_Shield"
+                  pos="-0.02325 -0.023375 -0.01525"
+                  quat="0.70710678 0 0 0.70710678"
+                  material="cream_white"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Gripper_Shield"
+                  pos="0.023146893 -0.023375 0.01525"
+                  quat="0 0.70710678 0.70710678 0"
+                  material="cream_white"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Gripper_Wiring"
+                  pos="0 -0.00925 -0.03275"
+                  quat="0 0 0.70710678 0.70710678"
+                  material="cream_white"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Camera_Mount_27mm"
+                  pos="0 -0.015785372 0.01525"
+                  quat="0.70710678 0 0 -0.70710678"
+                  material="cream_white"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_ST3215_Servo"
+                  material="motor"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_Gripper_Hardware"
+                  material="pgripper_hardware"
+                  class="visual"
+                />
+                <geom
+                  type="mesh"
+                  mesh="Norma_U20_Camera"
+                  material="motor"
+                  class="visual"
+                />
+
+                <site
+                  name="gripper_mount_R"
+                  pos="0 0 0"
+                  size="0.003"
+                  group="4"
+                />
+                <site
+                  name="gripper_R"
+                  pos="0 -0.08145 0"
+                  size="0.005"
+                  group="4"
+                />
+                <site
+                  name="right_wrist_cam_optical_frame"
+                  pos="0 -0.022269 0.060999"
+                  xyaxes="-1 0 0 0 -0.422618 0.906308"
+                  size="0.003"
+                  group="4"
+                />
+                <camera
+                  name="right_wrist_cam"
+                  pos="0 -0.022269 0.060999"
+                  xyaxes="-1 0 0 0 -0.422618 0.906308"
+                  resolution="1280 720"
+                  fovy="74.5"
+                />
+
+                <body name="Norma_Gear_R" pos="0 -0.04845 0">
+                  <inertial
+                    pos="0 0 0"
+                    mass="0.006"
+                    diaginertia="0.000001 0.000002 0.000001"
+                  />
+                  <joint
+                    name="Norma_Gear_R"
+                    type="hinge"
+                    axis="0 -1 0"
+                    range="-0.18 2.18"
+                    damping="0.02"
+                  />
+                  <geom
+                    type="mesh"
+                    mesh="Norma_Gripper_Gear"
+                    pos="0 0 -0.01370322"
+                    quat="0.70710678 0 0 -0.70710678"
+                    material="cream_white"
+                    class="visual"
+                  />
+                </body>
+
+                <body name="Norma_Jaw_Pos_R" pos="-0.011 -0.10345 0">
+                  <inertial
+                    pos="0 0.029 0"
+                    mass="0.025"
+                    diaginertia="0.000012 0.00002 0.000015"
+                  />
+                  <joint
+                    name="Jaw_R"
+                    type="slide"
+                    axis="1 0 0"
+                    range="0 0.027"
+                    class="pgripper_slide"
+                  />
+                  <geom
+                    type="mesh"
+                    mesh="Norma_Gripper_Jaw"
+                    quat="0.70710678 -0.70710678 0 0"
+                    material="cream_white"
+                    class="visual"
+                  />
+                  <geom
+                    name="jaw_pad_collision_pos_R"
+                    type="box"
+                    pos="0.015 0.022 0"
+                    size="0.004 0.022 0.011"
+                    class="collision"
+                    friction="3 0.2 0.1"
+                    condim="6"
+                  />
+                </body>
+
+                <body name="Norma_Jaw_Neg_R" pos="0.011 -0.10345 0">
+                  <inertial
+                    pos="0 0.029 0"
+                    mass="0.025"
+                    diaginertia="0.000012 0.00002 0.000015"
+                  />
+                  <joint
+                    name="Jaw_Mate_R"
+                    type="slide"
+                    axis="-1 0 0"
+                    range="0 0.027"
+                    class="pgripper_slide"
+                  />
+                  <geom
+                    type="mesh"
+                    mesh="Norma_Gripper_Jaw"
+                    quat="0 0 0.70710678 0.70710678"
+                    material="cream_white"
+                    class="visual"
+                  />
+                  <geom
+                    name="jaw_pad_collision_neg_R"
+                    type="box"
+                    pos="-0.015 0.022 0"
+                    size="0.004 0.022 0.011"
+                    class="collision"
+                    friction="3 0.2 0.1"
+                    condim="6"
+                  />
+                </body>
+
+                <body name="gripper_tip" pos="0 -0.08145 0">
+                  <site name="gripper_tip_site" size="0.002" group="4" />
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <contact>
+    <exclude body1="Base_2" body2="Rotation_Pitch_2" />
+    <exclude body1="Rotation_Pitch_2" body2="Upper_Arm_2" />
+    <exclude body1="Upper_Arm_2" body2="Lower_Arm_2" />
+    <exclude body1="Lower_Arm_2" body2="Wrist_Pitch_Roll_2" />
+    <exclude body1="Wrist_Pitch_Roll_2" body2="Norma_Gripper_R" />
+    <exclude body1="Norma_Jaw_Pos_R" body2="Norma_Gripper_R" />
+    <exclude body1="Norma_Jaw_Neg_R" body2="Norma_Gripper_R" />
+    <exclude body1="Norma_Jaw_Pos_R" body2="Norma_Jaw_Neg_R" />
+    <exclude body1="Rotation_Pitch_2" body2="Lower_Arm_2" />
+    <exclude body1="Rotation_Pitch_2" body2="Wrist_Pitch_Roll_2" />
+    <exclude body1="Upper_Arm_2" body2="Wrist_Pitch_Roll_2" />
+    <exclude body1="Upper_Arm_2" body2="Base_2" />
+    <exclude body1="Norma_Jaw_Pos_R" body2="Wrist_Pitch_Roll_2" />
+    <exclude body1="Norma_Jaw_Neg_R" body2="Wrist_Pitch_Roll_2" />
+  </contact>
+
+  <equality>
+    <joint
+      name="norma_jaw_coupling_R"
+      joint1="Jaw_Mate_R"
+      joint2="Jaw_R"
+      polycoef="0 1 0 0 0"
+    />
+    <joint
+      name="norma_gear_coupling_R"
+      joint1="Norma_Gear_R"
+      joint2="Jaw_R"
+      polycoef="2.173913 -86.956522 0 0 0"
+    />
+  </equality>
+
+  <actuator>
+    <position
+      class="sts3215"
+      name="Rotation_R"
+      joint="Rotation_R"
+      forcerange="-3.35 3.35"
+      ctrlrange="-2.16 2.16"
+    />
+    <position
+      class="sts3215"
+      name="Pitch_R"
+      joint="Pitch_R"
+      forcerange="-3.35 3.35"
+      ctrlrange="-0.24 3.56"
+    />
+    <position
+      class="sts3215"
+      name="Elbow_R"
+      joint="Elbow_R"
+      forcerange="-3.35 3.35"
+      ctrlrange="-0.47 3.40"
+    />
+    <position
+      class="sts3215"
+      name="Wrist_Pitch_R"
+      joint="Wrist_Pitch_R"
+      forcerange="-3.35 3.35"
+      ctrlrange="-1.86 1.94"
+    />
+    <position
+      class="sts3215"
+      name="Wrist_Roll_R"
+      joint="Wrist_Roll_R"
+      forcerange="-3.35 3.35"
+      ctrlrange="-3.15 3.15"
+    />
+    <position
+      class="pgripper_slide"
+      name="Jaw_R"
+      joint="Jaw_R"
+      forcerange="-25 25"
+      ctrlrange="0 0.027"
+    />
+  </actuator>
+
+  <keyframe>
+    <key
+      name="home"
+      qpos="0 1.575 1.46 0 1.5707963267948966 -0.173913094 0.027 0.027"
+      ctrl="0 1.575 1.46 0 1.5707963267948966 0.027"
+    />
+  </keyframe>
+</mujoco>

--- a/src/so101_moveit_config/launch/runtime.launch.xml
+++ b/src/so101_moveit_config/launch/runtime.launch.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<launch>
+  <arg
+    name="infer_url"
+    default="$(env INFER_URL 'http://127.0.0.1:8973/infer')"
+  />
+  <include
+    file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
+  />
+  <node
+    pkg="vla_sim"
+    exec="get_action_chunk_adapter.py"
+    name="get_action_chunk_adapter"
+    output="both"
+    emulate_tty="true"
+  >
+    <param name="infer_url" value="$(var infer_url)" />
+  </node>
+</launch>

--- a/src/so101_moveit_config/objectives/README.md
+++ b/src/so101_moveit_config/objectives/README.md
@@ -1,0 +1,28 @@
+# SO-101 Objectives
+
+The SO-101 has five arm degrees of freedom, so arbitrary six-dimensional
+Cartesian poses are not generally reachable. Use position-only or
+orientation-sampled workflows when adding Cartesian Objectives.
+
+`Move Live SO101 to Waypoint` and the standard Teleoperate workflow execute
+through `/joint_trajectory_controller/follow_joint_trajectory`. The Pi owns
+that controller and the physical command interfaces.
+
+`Execute SO101 VLA Policy` switches to
+`joint_trajectory_admittance_controller`, executes camera-conditioned chunks,
+then restores the standard trajectory controller. MoveIt Pro 10.0 requires
+JTAC's `FollowJointTrajectoryWithAdmittance` contract for policy chunk
+stitching; a standard JTC cannot replace it. If an Objective is cancelled
+during the handoff, run `Restore SO101 Planning Controller` before another
+motion workflow.
+
+Bring up a policy in this order:
+
+1. Verify the checkpoint's joint order, units, frame rate, and two-camera
+   observation contract.
+2. Confirm the inference server health reports the expected model and
+   accelerator.
+3. Run the policy in simulation.
+4. Confirm the Pi lists JTAC and the launcher reports VLA readiness.
+5. Run on hardware only with explicit motion authorization and physical power
+   isolation available.

--- a/src/so101_moveit_config/objectives/execute_so101_vla_policy.xml
+++ b/src/so101_moveit_config/objectives/execute_so101_vla_policy.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Execute SO101 VLA Policy">
+  <BehaviorTree
+    ID="Execute SO101 VLA Policy"
+    _description="Execute a camera-conditioned policy through the SO-101 trajectory-admittance controller. Requires an explicitly selected live-compatible checkpoint."
+  >
+    <Control ID="Sequence" name="SO101Vla">
+      <Action ID="Script" code="policy_succeeded := 0" />
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_admittance_controller"
+        deactivate_controllers="joint_trajectory_controller;velocity_force_controller;joint_velocity_controller"
+        automatic_deactivation="true"
+        strictness="2"
+        timeout="-1.0"
+        controller_list_action_name="/controller_manager/list_controllers"
+        controller_switch_action_name="/controller_manager/switch_controller"
+      />
+      <Control ID="Fallback" name="RunPolicyAndRememberResult">
+        <Control ID="Sequence">
+          <Action
+            ID="ExecutePolicy"
+            policy_service_name="{policy_service_name}"
+            joint_group_name="manipulator"
+            prompt="{prompt}"
+            total_action_steps="{total_action_steps}"
+            dt="{dt}"
+            committed_action_steps="{committed_action_steps}"
+            num_interpolation_points="100"
+            link_padding="0.01"
+            goal_path_tolerance="0.15"
+            policy_tracking_weight="300.0"
+            policy_uses_real_time_chunking="{policy_uses_real_time_chunking}"
+            guidance_horizon="{guidance_horizon}"
+            policy_call_timeout="{policy_call_timeout}"
+            controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+            image_topics="{image_topics}"
+            image_names="{image_names}"
+            joint_states_topic="/joint_states"
+            absolute_force_torque_threshold="1000;1000;1000;1000;1000;1000"
+            gripper_command_action_name="/gripper_controller/gripper_cmd"
+            gripper_joint_name="Jaw_R"
+          />
+          <Action ID="Script" code="policy_succeeded = 1" />
+        </Control>
+        <Action ID="AlwaysSuccess" />
+      </Control>
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+        deactivate_controllers="joint_trajectory_admittance_controller"
+        automatic_deactivation="true"
+        strictness="2"
+        timeout="-1.0"
+        controller_list_action_name="/controller_manager/list_controllers"
+        controller_switch_action_name="/controller_manager/switch_controller"
+      />
+      <Decorator ID="Precondition" if="policy_succeeded == 1" else="FAILURE">
+        <Action ID="AlwaysSuccess" />
+      </Decorator>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Execute SO101 VLA Policy">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="SO-101 / VLA" />
+      </MetadataFields>
+      <input_port
+        name="policy_service_name"
+        default="/get_action_chunk"
+        type="std::string"
+      />
+      <input_port name="prompt" default="perform the task" type="std::string" />
+      <input_port name="total_action_steps" default="20" type="int" />
+      <input_port name="dt" default="0.1" type="double" />
+      <input_port name="committed_action_steps" default="8" type="int" />
+      <input_port
+        name="policy_uses_real_time_chunking"
+        default="false"
+        type="bool"
+      />
+      <input_port name="guidance_horizon" default="0" type="int" />
+      <input_port name="policy_call_timeout" default="10.0" type="double" />
+      <input_port
+        name="image_topics"
+        default="/so101/cameras/overhead/image_raw;/so101/cameras/wrist/image_raw"
+        type="std::vector&lt;std::string&gt;"
+      />
+      <input_port
+        name="image_names"
+        default="overhead;wrist"
+        type="std::vector&lt;std::string&gt;"
+      />
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/so101_moveit_config/objectives/restore_so101_planning_controller.xml
+++ b/src/so101_moveit_config/objectives/restore_so101_planning_controller.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Restore SO101 Planning Controller">
+  <BehaviorTree
+    ID="Restore SO101 Planning Controller"
+    _description="Return the SO-101 to its standard trajectory controller after a cancelled or interrupted policy run."
+  >
+    <Action
+      ID="SwitchController"
+      activate_controllers="joint_trajectory_controller"
+      deactivate_controllers="joint_trajectory_admittance_controller;velocity_force_controller;joint_velocity_controller"
+      automatic_deactivation="true"
+      strictness="2"
+      timeout="-1.0"
+      controller_list_action_name="/controller_manager/list_controllers"
+      controller_switch_action_name="/controller_manager/switch_controller"
+    />
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Restore SO101 Planning Controller">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="SO-101 / Safety" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/so101_moveit_config/package.xml
+++ b/src/so101_moveit_config/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<package format="3">
+  <name>so101_moveit_config</name>
+  <version>0.1.0</version>
+  <description>
+    MoveIt Pro and MuJoCo configuration for the SO-101 follower arm.
+  </description>
+
+  <maintainer email="noah-wardlow@users.noreply.github.com">Noah</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>moveit_pro_behavior</exec_depend>
+  <exec_depend>moveit_studio_agent</exec_depend>
+  <exec_depend>picknik_mujoco_ros</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>rmw_cyclonedds_cpp</exec_depend>
+  <exec_depend>vla_sim</exec_depend>
+  <exec_depend>velocity_force_controller</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/so101_moveit_config/simulation_objectives/move_simulated_so101_to_waypoint.xml
+++ b/src/so101_moveit_config/simulation_objectives/move_simulated_so101_to_waypoint.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Move Simulated SO101 to Waypoint">
+  <BehaviorTree
+    ID="Move Simulated SO101 to Waypoint"
+    _description="Plan and execute a conservative joint-space move to a named waypoint in the SO-101 MuJoCo simulation through the standard Joint Trajectory Controller. Defaults to Ready."
+    _favorite="true"
+  >
+    <SubTree
+      ID="Move to Waypoint"
+      _collapsed="true"
+      waypoint_name="{waypoint_name}"
+      joint_group_name="manipulator"
+      velocity_scale_factor="{velocity_scale_factor}"
+      acceleration_scale_factor="{acceleration_scale_factor}"
+      link_padding="0.01"
+      seed="0"
+      keep_orientation="false"
+      controller_names="joint_trajectory_controller"
+      controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+      execution_pipeline="jtc"
+    />
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Move Simulated SO101 to Waypoint">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="SO-101 / Simulation" />
+      </MetadataFields>
+      <input_port name="waypoint_name" default="Ready" type="std::string">
+        Named SO-101 waypoint to plan and execute.
+      </input_port>
+      <input_port name="velocity_scale_factor" default="0.50" type="double">
+        Fraction of the configured joint velocity limit.
+      </input_port>
+      <input_port name="acceleration_scale_factor" default="0.50" type="double">
+        Fraction of the configured joint acceleration limit.
+      </input_port>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/so101_moveit_config/waypoints/so101_waypoints.yaml
+++ b/src/so101_moveit_config/waypoints/so101_waypoints.yaml
@@ -1,0 +1,76 @@
+- name: Home
+  description: Folded, collision-free simulation start pose.
+  favorite: true
+  joint_group_names:
+    - manipulator
+    - gripper
+  joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    name:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
+      - Jaw_R
+    position:
+      - 0.0
+      - 3.1
+      - 2.9
+      - 1.4
+      - 1.5707963267948966
+      - 0.027
+    velocity: []
+    effort: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []
+- name: Ready
+  description: Bent-arm center pose with Cartesian jogging clearance.
+  favorite: true
+  joint_group_names:
+    - manipulator
+    - gripper
+  joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    name:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
+      - Jaw_R
+    position:
+      - 0.0
+      - 2.0
+      - 2.0
+      - 0.0
+      - 1.5707963267948966
+      - 0.027
+    velocity: []
+    effort: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []

--- a/src/so101_moveit_hardware_config/CMakeLists.txt
+++ b/src/so101_moveit_hardware_config/CMakeLists.txt
@@ -3,7 +3,7 @@ project(so101_moveit_hardware_config)
 
 find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY config launch objectives DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config launch objectives waypoints DESTINATION share/${PROJECT_NAME})
 install(
   PROGRAMS
     scripts/external_driver_contract.py
@@ -20,6 +20,10 @@ if(BUILD_TESTING)
   ament_add_pytest_test(
     test_teleoperation_contract
     test/test_teleoperation_contract.py
+  )
+  ament_add_pytest_test(
+    test_hardware_motion_contract
+    test/test_hardware_motion_contract.py
   )
 endif()
 

--- a/src/so101_moveit_hardware_config/CMakeLists.txt
+++ b/src/so101_moveit_hardware_config/CMakeLists.txt
@@ -4,5 +4,19 @@ project(so101_moveit_hardware_config)
 find_package(ament_cmake REQUIRED)
 
 install(DIRECTORY config launch objectives DESTINATION share/${PROJECT_NAME})
+install(
+  PROGRAMS
+    scripts/external_driver_contract.py
+    scripts/external_driver_watchdog.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(
+    test_external_driver_contract
+    test/test_external_driver_contract.py
+  )
+endif()
 
 ament_package()

--- a/src/so101_moveit_hardware_config/CMakeLists.txt
+++ b/src/so101_moveit_hardware_config/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(so101_moveit_hardware_config)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY config launch objectives DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/src/so101_moveit_hardware_config/CMakeLists.txt
+++ b/src/so101_moveit_hardware_config/CMakeLists.txt
@@ -17,6 +17,10 @@ if(BUILD_TESTING)
     test_external_driver_contract
     test/test_external_driver_contract.py
   )
+  ament_add_pytest_test(
+    test_teleoperation_contract
+    test/test_teleoperation_contract.py
+  )
 endif()
 
 ament_package()

--- a/src/so101_moveit_hardware_config/config/config.yaml
+++ b/src/so101_moveit_hardware_config/config/config.yaml
@@ -5,6 +5,9 @@ runtime_launch_file:
 hardware:
   launch_control_node: false
   launch_robot_state_publisher: true
+  additional_driver_launch_file:
+    package: "so101_moveit_hardware_config"
+    path: "launch/external_driver_watchdog.launch.py"
   robot_description:
     urdf:
       package: "so101_moveit_config"

--- a/src/so101_moveit_hardware_config/config/config.yaml
+++ b/src/so101_moveit_hardware_config/config/config.yaml
@@ -27,7 +27,7 @@ moveit_params:
     package: "so101_moveit_config"
     path: "config/moveit/pose_ik.yaml"
   joint_limits:
-    package: "so101_moveit_config"
+    package: "so101_moveit_hardware_config"
     path: "config/moveit/joint_limits.yaml"
   pose_jog:
     package: "so101_moveit_config"
@@ -76,5 +76,5 @@ objectives:
       package_name: "so101_moveit_hardware_config"
       relative_path: "objectives"
   waypoints_file:
-    package_name: "so101_moveit_config"
-    relative_path: "waypoints/so101_waypoints.yaml"
+    package_name: "so101_moveit_hardware_config"
+    relative_path: "waypoints/so101_hardware_waypoints.yaml"

--- a/src/so101_moveit_hardware_config/config/config.yaml
+++ b/src/so101_moveit_hardware_config/config/config.yaml
@@ -1,0 +1,77 @@
+runtime_launch_file:
+  package: "so101_moveit_hardware_config"
+  path: "launch/runtime.launch.xml"
+
+hardware:
+  launch_control_node: false
+  launch_robot_state_publisher: true
+  robot_description:
+    urdf:
+      package: "so101_moveit_config"
+      path: "description/so101_follower.urdf.xacro"
+    srdf:
+      package: "so101_moveit_config"
+      path: "config/moveit/so101_follower.srdf"
+    urdf_params:
+      - hardware_interface: "external"
+
+ros_global_params:
+  use_sim_time: false
+
+moveit_params:
+  joint_group_name: "manipulator"
+  kinematics:
+    package: "so101_moveit_config"
+    path: "config/moveit/pose_ik.yaml"
+  joint_limits:
+    package: "so101_moveit_config"
+    path: "config/moveit/joint_limits.yaml"
+  pose_jog:
+    package: "so101_moveit_config"
+    path: "config/moveit/pose_jog.yaml"
+  joint_jog:
+    package: "so101_moveit_config"
+    path: "config/moveit/joint_jog.yaml"
+  publish:
+    planning_scene: true
+    geometry_updates: true
+    state_updates: true
+    transforms_updates: true
+
+ros2_control:
+  config:
+    package: "so101_moveit_config"
+    path: "config/control/so101.ros2_control.yaml"
+  controllers_active_at_startup: []
+  controllers_inactive_at_startup: []
+  controllers_not_managed:
+    - "joint_state_broadcaster"
+    - "joint_trajectory_controller"
+    - "joint_trajectory_admittance_controller"
+    - "gripper_controller"
+    - "velocity_force_controller"
+    - "joint_velocity_controller"
+  controller_shared_topics: []
+
+objectives:
+  behavior_loader_plugins:
+    core:
+      - "moveit_pro::behaviors::CoreBehaviorsLoader"
+      - "moveit_pro::behaviors::MTCCoreBehaviorsLoader"
+      - "moveit_pro::behaviors::ConverterBehaviorsLoader"
+  objective_library_paths:
+    core_objectives:
+      package_name: "moveit_pro_objectives"
+      relative_path: "objectives/core"
+    motion_objectives:
+      package_name: "moveit_pro_objectives"
+      relative_path: "objectives/motion"
+    so101_objectives:
+      package_name: "so101_moveit_config"
+      relative_path: "objectives"
+    so101_hardware_objectives:
+      package_name: "so101_moveit_hardware_config"
+      relative_path: "objectives"
+  waypoints_file:
+    package_name: "so101_moveit_config"
+    relative_path: "waypoints/so101_waypoints.yaml"

--- a/src/so101_moveit_hardware_config/config/moveit/joint_limits.yaml
+++ b/src/so101_moveit_hardware_config/config/moveit/joint_limits.yaml
@@ -1,0 +1,52 @@
+# Physical SO-101 limits. Keep these separate from simulation: low-cost
+# STS3215 servos and an external controller host need conservative defaults,
+# while MuJoCo can use the model's broader dynamic envelope.
+joint_limits:
+  Rotation_R:
+    has_position_limits: true
+    min_position: -2.16
+    max_position: 2.16
+    has_velocity_limits: true
+    max_velocity: 0.50
+    has_acceleration_limits: true
+    max_acceleration: 0.50
+  Pitch_R:
+    has_position_limits: true
+    min_position: -0.24
+    max_position: 3.56
+    has_velocity_limits: true
+    max_velocity: 0.50
+    has_acceleration_limits: true
+    max_acceleration: 0.50
+  Elbow_R:
+    has_position_limits: true
+    min_position: -0.47
+    max_position: 3.40
+    has_velocity_limits: true
+    max_velocity: 0.50
+    has_acceleration_limits: true
+    max_acceleration: 0.50
+  Wrist_Pitch_R:
+    has_position_limits: true
+    min_position: -1.86
+    max_position: 1.94
+    has_velocity_limits: true
+    max_velocity: 0.50
+    has_acceleration_limits: true
+    max_acceleration: 0.50
+  Wrist_Roll_R:
+    has_position_limits: true
+    min_position: -3.15
+    max_position: 3.15
+    has_velocity_limits: true
+    max_velocity: 0.50
+    has_acceleration_limits: true
+    max_acceleration: 0.50
+  Jaw_R:
+    has_position_limits: true
+    min_position: 0.0
+    max_position: 0.027
+    has_velocity_limits: true
+    max_velocity: 0.01
+    has_acceleration_limits: true
+    max_acceleration: 0.02

--- a/src/so101_moveit_hardware_config/launch/external_driver_watchdog.launch.py
+++ b/src/so101_moveit_hardware_config/launch/external_driver_watchdog.launch.py
@@ -1,0 +1,17 @@
+"""Keep MoveIt Pro's drivers sidecar aligned with the external Pi driver."""
+
+from launch import LaunchDescription
+from moveit_studio_utils_py.launch_common import (
+    fail_launch_on_process_exit,
+    NodeWithAnsiLogging,
+)
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Monitor the read-only joint-state heartbeat published by the Pi."""
+    watchdog = NodeWithAnsiLogging(
+        package="so101_moveit_hardware_config",
+        executable="external_driver_watchdog.py",
+        name="so101_external_driver_watchdog",
+    )
+    return LaunchDescription([watchdog, fail_launch_on_process_exit(watchdog)])

--- a/src/so101_moveit_hardware_config/launch/runtime.launch.xml
+++ b/src/so101_moveit_hardware_config/launch/runtime.launch.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<launch>
+  <arg
+    name="head_url"
+    default="$(env SO101_HEAD_RTSP_URL 'rtsp://so101-pi.tail337068.ts.net:8554/head')"
+  />
+  <arg
+    name="gripper_url"
+    default="$(env SO101_GRIPPER_RTSP_URL 'rtsp://so101-pi.tail337068.ts.net:8554/gripper')"
+  />
+  <arg
+    name="infer_url"
+    default="$(env INFER_URL 'http://127.0.0.1:8973/infer')"
+  />
+  <include
+    file="$(find-pkg-share moveit_studio_agent)/launch/studio_agent_bridge.launch.xml"
+  />
+  <!-- The ROS publishers remain on demand for policy inference and recording.
+       Camera panes use MoveIt Pro's direct RTSP passthrough configured by the
+       launcher, avoiding an unnecessary decode/re-encode cycle. -->
+  <node
+    pkg="so101_camera_bridge"
+    exec="rtsp_camera_bridge"
+    name="so101_rtsp_camera_bridge"
+    output="both"
+    emulate_tty="true"
+  >
+    <param name="head_url" value="$(var head_url)" />
+    <param name="gripper_url" value="$(var gripper_url)" />
+  </node>
+  <node
+    pkg="vla_sim"
+    exec="get_action_chunk_adapter.py"
+    name="get_action_chunk_adapter"
+    output="both"
+    emulate_tty="true"
+  >
+    <param name="infer_url" value="$(var infer_url)" />
+  </node>
+</launch>

--- a/src/so101_moveit_hardware_config/objectives/move_live_so101_to_waypoint.xml
+++ b/src/so101_moveit_hardware_config/objectives/move_live_so101_to_waypoint.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Move Live SO101 to Waypoint">
+  <BehaviorTree
+    ID="Move Live SO101 to Waypoint"
+    _description="Plan and execute a joint-space move on the Pi-managed standard Joint Trajectory Controller. Defaults to Ready."
+    _favorite="true"
+  >
+    <SubTree
+      ID="Move to Waypoint"
+      _collapsed="true"
+      waypoint_name="{waypoint_name}"
+      joint_group_name="manipulator"
+      velocity_scale_factor="{velocity_scale_factor}"
+      acceleration_scale_factor="{acceleration_scale_factor}"
+      link_padding="0.01"
+      seed="0"
+      keep_orientation="false"
+      controller_names="joint_trajectory_controller"
+      controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
+      execution_pipeline="jtc"
+    />
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Move Live SO101 to Waypoint">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="SO-101 / Hardware" />
+      </MetadataFields>
+      <input_port name="waypoint_name" default="Ready" type="std::string">
+        Named SO-101 waypoint to plan and execute.
+      </input_port>
+      <input_port name="velocity_scale_factor" default="0.75" type="double">
+        Fraction of the configured joint velocity limit.
+      </input_port>
+      <input_port name="acceleration_scale_factor" default="0.75" type="double">
+        Fraction of the configured joint acceleration limit.
+      </input_port>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/so101_moveit_hardware_config/objectives/move_live_so101_to_waypoint.xml
+++ b/src/so101_moveit_hardware_config/objectives/move_live_so101_to_waypoint.xml
@@ -2,7 +2,7 @@
 <root BTCPP_format="4" main_tree_to_execute="Move Live SO101 to Waypoint">
   <BehaviorTree
     ID="Move Live SO101 to Waypoint"
-    _description="Plan and execute a joint-space move on the Pi-managed standard Joint Trajectory Controller. Defaults to Ready."
+    _description="Plan and execute a conservative joint-space move on the Pi-managed standard Joint Trajectory Controller. Defaults to the commissioned Home pose."
     _favorite="true"
   >
     <SubTree
@@ -26,13 +26,13 @@
         <Metadata runnable="true" />
         <Metadata subcategory="SO-101 / Hardware" />
       </MetadataFields>
-      <input_port name="waypoint_name" default="Ready" type="std::string">
+      <input_port name="waypoint_name" default="Home" type="std::string">
         Named SO-101 waypoint to plan and execute.
       </input_port>
-      <input_port name="velocity_scale_factor" default="0.75" type="double">
+      <input_port name="velocity_scale_factor" default="0.25" type="double">
         Fraction of the configured joint velocity limit.
       </input_port>
-      <input_port name="acceleration_scale_factor" default="0.75" type="double">
+      <input_port name="acceleration_scale_factor" default="0.25" type="double">
         Fraction of the configured joint acceleration limit.
       </input_port>
     </SubTree>

--- a/src/so101_moveit_hardware_config/objectives/request_teleoperation.xml
+++ b/src/so101_moveit_hardware_config/objectives/request_teleoperation.xml
@@ -15,7 +15,7 @@
         waypoint parameter cannot race the first UI feedback message and leave
         a planning subtree with an unresolved blackboard input.
       -->
-      <Action ID="Script" code="velocity_scale_factor := 0.75" />
+      <Action ID="Script" code="velocity_scale_factor := 0.25" />
       <Control ID="Parallel" success_count="1" failure_count="1">
         <Action
           ID="DoTeleoperateAction"

--- a/src/so101_moveit_hardware_config/objectives/request_teleoperation.xml
+++ b/src/so101_moveit_hardware_config/objectives/request_teleoperation.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Request Teleoperation">
+  <!--The integer value used here for teleoperation mode comes from the moveit_studio_sdk_msgs/TeleoperationMode ROS message.-->
+  <BehaviorTree
+    ID="Request Teleoperation"
+    _description="Handles the different variations of teleoperation from the web UI, with the option of interactive user prompts and choosing the initial mode. Should be used as a subtree with port remapping as part of an another Objective."
+    _favorite="false"
+    _hardcoded="false"
+  >
+    <Control ID="Sequence">
+      <Action ID="Script" code="teleop_mode := 0" />
+      <!--
+        DoTeleoperateAction publishes the operator's velocity scaling through
+        feedback. Seed the UI default first so an immediately available
+        waypoint parameter cannot race the first UI feedback message and leave
+        a planning subtree with an unresolved blackboard input.
+      -->
+      <Action ID="Script" code="velocity_scale_factor := 0.75" />
+      <Control ID="Parallel" success_count="1" failure_count="1">
+        <Action
+          ID="DoTeleoperateAction"
+          enable_user_interaction="{enable_user_interaction}"
+          user_interaction_prompt="{user_interaction_prompt}"
+          initial_teleop_mode="{initial_teleop_mode}"
+          current_teleop_mode="{teleop_mode}"
+          planning_groups="{planning_groups}"
+          controllers="{controllers}"
+          tip_links="{tip_links}"
+          skip_collision_checks="{skip_collision_checks}"
+          velocity_scale_factor="{velocity_scale_factor}"
+          require_user_approval="{require_user_approval}"
+        />
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
+          <Control ID="Sequence">
+            <!--Closing and opening the gripper-->
+            <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 7">
+              <SubTree ID="Close Gripper" />
+            </Decorator>
+            <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 6">
+              <SubTree ID="Open Gripper" />
+            </Decorator>
+            <!--Joint sliders interpolate to joint state-->
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
+              <Control ID="Sequence">
+                <Control ID="Fallback" name="root">
+                  <Control ID="Sequence">
+                    <Action
+                      ID="RetrieveRobotStateParameter"
+                      timeout_sec="-1"
+                      joint_state="{target_joint_state}"
+                    />
+                    <SubTree
+                      ID="Interpolate to Joint State"
+                      _collapsed="false"
+                      target_joint_state="{target_joint_state}"
+                      controller_names="{joint_trajectory_controller_name}"
+                      controller_action_server="{controller_action_server}"
+                      planning_group_name="{default_planning_group}"
+                      velocity_scale_factor="{velocity_scale_factor}"
+                      execution_pipeline="{execution_pipeline}"
+                    />
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                  </Control>
+                  <Control ID="Sequence">
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                    <Action ID="AlwaysFailure" />
+                  </Control>
+                </Control>
+              </Control>
+            </Decorator>
+            <!--Interactive markers move to pose-->
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 4">
+              <Control ID="Sequence">
+                <Control ID="Fallback" name="root">
+                  <Control ID="Sequence">
+                    <Action
+                      ID="RetrievePoseParameter"
+                      timeout_sec="-1"
+                      pose="{target_pose}"
+                    />
+                    <Decorator
+                      ID="ForEach"
+                      index="{index}"
+                      out="{planning_group}"
+                      vector_in="{planning_groups}"
+                    >
+                      <Action ID="AlwaysSuccess" />
+                    </Decorator>
+                    <Decorator
+                      ID="ForEach"
+                      index="{index}"
+                      out="{tip_link}"
+                      vector_in="{tip_links}"
+                    >
+                      <Action ID="AlwaysSuccess" />
+                    </Decorator>
+                    <SubTree
+                      ID="Move to Pose"
+                      _collapsed="false"
+                      target_pose="{target_pose}"
+                      controller_names="{joint_trajectory_controller_name}"
+                      controller_action_name="{controller_action_server}"
+                      execution_pipeline="{execution_pipeline}"
+                      link_padding="{link_padding}"
+                      ik_frame="{tip_link}"
+                      planning_group_name="{planning_group}"
+                      max_mtc_solutions="{max_mtc_solutions}"
+                      max_ik_solutions="{max_ik_solutions}"
+                      require_user_approval="{require_user_approval}"
+                      velocity_scale_factor="{velocity_scale_factor}"
+                    />
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                  </Control>
+                  <Control ID="Sequence">
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                    <Action ID="AlwaysFailure" />
+                  </Control>
+                </Control>
+              </Control>
+            </Decorator>
+            <!--Waypoint buttons move to joint state-->
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 3">
+              <Control ID="Sequence">
+                <Control ID="Fallback" name="root">
+                  <Control ID="Sequence">
+                    <Action
+                      ID="RetrieveRobotStateParameter"
+                      timeout_sec="-1"
+                      joint_state="{target_joint_state}"
+                    />
+                    <SubTree
+                      ID="Move to Joint State"
+                      _collapsed="false"
+                      target_joint_state="{target_joint_state}"
+                      acceleration_scale_factor="1.0"
+                      velocity_scale_factor="{velocity_scale_factor}"
+                      controller_action_server="{controller_action_server}"
+                      controller_names="{joint_trajectory_controller_name}"
+                      joint_group_name="{default_planning_group}"
+                      link_padding="{link_padding}"
+                      execution_pipeline="{execution_pipeline}"
+                    />
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                  </Control>
+                  <Control ID="Sequence">
+                    <Action
+                      ID="PublishEmpty"
+                      topic="/moveit_pro_ui/motion_ended"
+                      queue_size="1"
+                      use_best_effort="false"
+                    />
+                    <Action ID="AlwaysFailure" />
+                  </Control>
+                </Control>
+              </Control>
+            </Decorator>
+            <!--Cartesian jogging-->
+            <Control ID="Sequence" _while="teleop_mode == 2">
+              <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
+                <Control ID="Sequence">
+                  <Action
+                    ID="SwitchController"
+                    activate_controllers="{controllers}"
+                    automatic_deactivation="true"
+                    strictness="2"
+                  />
+                  <Decorator ID="ForceSuccess">
+                    <Action
+                      ID="PoseJog"
+                      controller_names="{controllers}"
+                      link_padding="{link_padding}"
+                      planning_group_names="{planning_groups}"
+                      stop_safety_factor="1.500000"
+                      include_octomap="false"
+                    />
+                  </Decorator>
+                </Control>
+              </Decorator>
+            </Control>
+            <!--Joint jogging-->
+            <Control ID="Sequence" _while="teleop_mode == 1">
+              <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
+                <Control ID="Sequence">
+                  <Action
+                    ID="SwitchController"
+                    activate_asap="true"
+                    automatic_deactivation="true"
+                    controller_list_action_name="/controller_manager/list_controllers"
+                    controller_switch_action_name="/controller_manager/switch_controller"
+                    strictness="1"
+                    timeout="-1.000000"
+                    activate_controllers="{controllers}"
+                  />
+                  <Decorator ID="ForceSuccess">
+                    <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
+                      <Control
+                        ID="Parallel"
+                        success_count="1"
+                        failure_count="1"
+                      >
+                        <Decorator
+                          ID="RepeatUnlessFailureEachTick"
+                          num_cycles="-1"
+                        >
+                          <Action
+                            ID="GetElementOfVector"
+                            vector_in="{controllers}"
+                            index="0"
+                            element="{first_controller}"
+                          />
+                        </Decorator>
+                        <Action
+                          ID="JointJog"
+                          controller_name="{first_controller}"
+                          link_padding="0.00000"
+                          stop_safety_factor="1.500000"
+                          skip_collision_checks="{skip_collision_checks}"
+                        />
+                      </Control>
+                    </Decorator>
+                  </Decorator>
+                </Control>
+              </Decorator>
+            </Control>
+          </Control>
+        </Decorator>
+      </Control>
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Request Teleoperation">
+      <MetadataFields>
+        <Metadata subcategory="User Input" />
+        <Metadata runnable="false" />
+      </MetadataFields>
+      <input_port
+        name="controller_action_server"
+        default="/joint_trajectory_controller/follow_joint_trajectory"
+        type="std::string"
+      />
+      <input_port name="enable_user_interaction" default="false" type="bool">
+        Enable interactive user prompts during teleoperation mode selection
+      </input_port>
+      <inout_port name="max_ik_solutions" default="8" type="unsigned int">
+        Maximum number of IK solutions PlanToPose will try to produce for a
+        given pose
+      </inout_port>
+      <inout_port name="max_mtc_solutions" default="1" type="unsigned long">
+        Maximum number of MTC solutions to find before returning early (0 to
+        find all solutions)
+      </inout_port>
+      <input_port name="initial_teleop_mode" default="3" type="int" />
+      <input_port
+        name="joint_trajectory_controller_name"
+        default="joint_trajectory_controller"
+        type="std::string"
+      />
+      <input_port
+        name="user_interaction_prompt"
+        default="Press Abort to return FAILURE, Continue for SUCCESS"
+        type="std::string"
+      />
+      <input_port
+        name="default_planning_group"
+        default="manipulator"
+        type="std::string"
+      />
+      <input_port
+        name="default_ik_frame"
+        default="grasp_link"
+        type="std::string"
+      />
+      <input_port name="link_padding" default="0.01" type="double" />
+      <input_port name="execution_pipeline" default="jtc" type="std::string" />
+      <input_port name="require_user_approval" default="true" type="bool">
+        Whether trajectory previews from Interactive Marker teleop must be
+        approved before execution. Set to false to skip the approval prompt.
+      </input_port>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/so101_moveit_hardware_config/package.xml
+++ b/src/so101_moveit_hardware_config/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>vla_sim</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-yaml</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/so101_moveit_hardware_config/package.xml
+++ b/src/so101_moveit_hardware_config/package.xml
@@ -11,9 +11,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>moveit_studio_utils_py</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>so101_camera_bridge</exec_depend>
   <exec_depend>so101_moveit_config</exec_depend>
   <exec_depend>vla_sim</exec_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/so101_moveit_hardware_config/package.xml
+++ b/src/so101_moveit_hardware_config/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<package format="3">
+  <name>so101_moveit_hardware_config</name>
+  <version>0.1.0</version>
+  <description>
+    MoveIt Pro live-hardware configuration for the SO-101 follower arm.
+  </description>
+
+  <maintainer email="noah-wardlow@users.noreply.github.com">Noah</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>so101_camera_bridge</exec_depend>
+  <exec_depend>so101_moveit_config</exec_depend>
+  <exec_depend>vla_sim</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/so101_moveit_hardware_config/scripts/external_driver_contract.py
+++ b/src/so101_moveit_hardware_config/scripts/external_driver_contract.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Dependency-free SO-101 external-driver heartbeat checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence
+
+
+REQUIRED_JOINTS = frozenset(
+    {
+        "Rotation_R",
+        "Pitch_R",
+        "Elbow_R",
+        "Wrist_Pitch_R",
+        "Wrist_Roll_R",
+        "Jaw_R",
+    }
+)
+
+
+def validate_joint_sample(
+    names: Sequence[str], positions: Sequence[float]
+) -> str | None:
+    """Return a diagnostic for an invalid sample, or ``None`` when valid."""
+    if len(names) != len(positions):
+        return "joint-state names and positions have different lengths"
+    missing = sorted(REQUIRED_JOINTS.difference(names))
+    if missing:
+        return f"joint-state sample is missing: {', '.join(missing)}"
+    if not all(math.isfinite(position) for position in positions):
+        return "joint-state sample contains a non-finite position"
+    return None
+
+
+@dataclass
+class DriverHeartbeat:
+    """Track whether valid external-driver samples arrive on time."""
+
+    started_at: float
+    startup_timeout: float
+    stale_after: float
+    last_valid_at: float | None = None
+
+    def record_valid_sample(self, received_at: float) -> None:
+        """Record the monotonic arrival time of a validated sample."""
+        self.last_valid_at = received_at
+
+    def failure_reason(self, now: float) -> str | None:
+        """Return why the driver is unavailable, or ``None`` while healthy."""
+        if self.last_valid_at is None:
+            if now - self.started_at > self.startup_timeout:
+                return (
+                    "no valid SO-101 joint state arrived within "
+                    f"{self.startup_timeout:g} seconds"
+                )
+            return None
+        if now - self.last_valid_at > self.stale_after:
+            return (
+                "SO-101 joint states stopped for more than "
+                f"{self.stale_after:g} seconds"
+            )
+        return None

--- a/src/so101_moveit_hardware_config/scripts/external_driver_watchdog.py
+++ b/src/so101_moveit_hardware_config/scripts/external_driver_watchdog.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail the drivers sidecar if the Pi's read-only joint-state stream stops."""
+
+from __future__ import annotations
+
+import math
+import time
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import JointState
+
+from external_driver_contract import DriverHeartbeat, validate_joint_sample
+
+
+class ExternalDriverWatchdog(Node):
+    """Track the Pi driver through valid joint states without publishing commands."""
+
+    def __init__(self) -> None:
+        super().__init__("so101_external_driver_watchdog")
+        self.declare_parameter("startup_timeout_seconds", 30.0)
+        self.declare_parameter("stale_after_seconds", 5.0)
+        startup_timeout = float(self.get_parameter("startup_timeout_seconds").value)
+        stale_after = float(self.get_parameter("stale_after_seconds").value)
+        if not math.isfinite(startup_timeout) or startup_timeout <= 0.0:
+            raise ValueError("startup_timeout_seconds must be finite and positive")
+        if not math.isfinite(stale_after) or stale_after <= 0.0:
+            raise ValueError("stale_after_seconds must be finite and positive")
+
+        self._heartbeat = DriverHeartbeat(
+            started_at=time.monotonic(),
+            startup_timeout=startup_timeout,
+            stale_after=stale_after,
+        )
+        self._announced_ready = False
+        self._last_invalid_reason: str | None = None
+        self._subscription = self.create_subscription(
+            JointState,
+            "/joint_states",
+            self._on_joint_state,
+            qos_profile_sensor_data,
+        )
+        self._timer = self.create_timer(0.25, self._check_liveness)
+        self.get_logger().info(
+            "Waiting for the Pi's read-only SO-101 joint-state heartbeat"
+        )
+
+    def _on_joint_state(self, message: JointState) -> None:
+        reason = validate_joint_sample(message.name, message.position)
+        if reason is not None:
+            if reason != self._last_invalid_reason:
+                self.get_logger().error(
+                    f"Ignoring invalid SO-101 joint state: {reason}"
+                )
+                self._last_invalid_reason = reason
+            return
+        self._last_invalid_reason = None
+        self._heartbeat.record_valid_sample(time.monotonic())
+        if not self._announced_ready:
+            self.get_logger().info(
+                "Pi ros2_control joint-state heartbeat is live; this watchdog "
+                "does not publish robot commands"
+            )
+            self._announced_ready = True
+
+    def _check_liveness(self) -> None:
+        reason = self._heartbeat.failure_reason(time.monotonic())
+        if reason is None:
+            return
+        self.get_logger().fatal(f"External Pi driver unavailable: {reason}")
+        raise RuntimeError(reason)
+
+
+def main(args: list[str] | None = None) -> None:
+    """Run the watchdog until launch requests a clean shutdown."""
+    rclpy.init(args=args)
+    node: ExternalDriverWatchdog | None = None
+    try:
+        node = ExternalDriverWatchdog()
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        if node is not None:
+            node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/so101_moveit_hardware_config/test/test_external_driver_contract.py
+++ b/src/so101_moveit_hardware_config/test/test_external_driver_contract.py
@@ -1,0 +1,38 @@
+"""Tests for the external Pi driver heartbeat contract."""
+
+from pathlib import Path
+import sys
+
+
+SCRIPTS_DIR = Path(__file__).parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from external_driver_contract import (  # noqa: E402
+    DriverHeartbeat,
+    REQUIRED_JOINTS,
+    validate_joint_sample,
+)
+
+
+def test_complete_finite_joint_sample_is_valid() -> None:
+    names = sorted(REQUIRED_JOINTS)
+
+    assert validate_joint_sample(names, [0.0] * len(names)) is None
+
+
+def test_invalid_joint_sample_reports_missing_and_non_finite_values() -> None:
+    assert "missing" in validate_joint_sample(["Rotation_R"], [0.0])
+    names = sorted(REQUIRED_JOINTS)
+
+    assert "non-finite" in validate_joint_sample(names, [float("nan")] * len(names))
+
+
+def test_heartbeat_distinguishes_startup_from_stale_driver() -> None:
+    heartbeat = DriverHeartbeat(started_at=10.0, startup_timeout=30.0, stale_after=5.0)
+
+    assert heartbeat.failure_reason(40.0) is None
+    assert "no valid" in heartbeat.failure_reason(40.01)
+
+    heartbeat.record_valid_sample(50.0)
+    assert heartbeat.failure_reason(55.0) is None
+    assert "stopped" in heartbeat.failure_reason(55.01)

--- a/src/so101_moveit_hardware_config/test/test_hardware_motion_contract.py
+++ b/src/so101_moveit_hardware_config/test/test_hardware_motion_contract.py
@@ -1,0 +1,66 @@
+"""Tests for fail-closed physical SO-101 motion defaults."""
+
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+import yaml
+
+
+PACKAGE_DIR = Path(__file__).parents[1]
+CONFIG_PATH = PACKAGE_DIR / "config" / "config.yaml"
+LIMITS_PATH = PACKAGE_DIR / "config" / "moveit" / "joint_limits.yaml"
+OBJECTIVE_PATH = PACKAGE_DIR / "objectives" / "move_live_so101_to_waypoint.xml"
+WAYPOINTS_PATH = PACKAGE_DIR / "waypoints" / "so101_hardware_waypoints.yaml"
+ARM_JOINTS = {
+    "Rotation_R",
+    "Pitch_R",
+    "Elbow_R",
+    "Wrist_Pitch_R",
+    "Wrist_Roll_R",
+}
+
+
+def test_hardware_config_uses_hardware_specific_limits_and_waypoints() -> None:
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+
+    assert config["moveit_params"]["joint_limits"] == {
+        "package": "so101_moveit_hardware_config",
+        "path": "config/moveit/joint_limits.yaml",
+    }
+    assert config["objectives"]["waypoints_file"] == {
+        "package_name": "so101_moveit_hardware_config",
+        "relative_path": "waypoints/so101_hardware_waypoints.yaml",
+    }
+
+
+def test_hardware_waypoints_contain_only_commissioned_poses() -> None:
+    waypoints = yaml.safe_load(WAYPOINTS_PATH.read_text())
+
+    assert [waypoint["name"] for waypoint in waypoints] == ["Home"]
+
+
+def test_live_waypoint_objective_defaults_to_slow_home_motion() -> None:
+    root = ET.parse(OBJECTIVE_PATH).getroot()
+    model = root.find("./TreeNodesModel/SubTree[@ID='Move Live SO101 to Waypoint']")
+    assert model is not None
+    defaults = {
+        port.attrib["name"]: port.attrib["default"]
+        for port in model
+        if port.tag.endswith("_port") and "default" in port.attrib
+    }
+
+    assert defaults["waypoint_name"] == "Home"
+    assert defaults["velocity_scale_factor"] == "0.25"
+    assert defaults["acceleration_scale_factor"] == "0.25"
+
+
+def test_physical_arm_limits_are_conservative() -> None:
+    limits = yaml.safe_load(LIMITS_PATH.read_text())["joint_limits"]
+
+    assert ARM_JOINTS <= limits.keys()
+    for joint_name in ARM_JOINTS:
+        joint_limits = limits[joint_name]
+        assert joint_limits["has_velocity_limits"] is True
+        assert joint_limits["max_velocity"] <= 0.50
+        assert joint_limits["has_acceleration_limits"] is True
+        assert joint_limits["max_acceleration"] <= 0.50

--- a/src/so101_moveit_hardware_config/test/test_teleoperation_contract.py
+++ b/src/so101_moveit_hardware_config/test/test_teleoperation_contract.py
@@ -1,0 +1,79 @@
+"""Tests for the SO-101 teleoperation controller contract."""
+
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+OBJECTIVE_PATH = Path(__file__).parents[1] / "objectives" / "request_teleoperation.xml"
+JTC_ACTION = "/joint_trajectory_controller/follow_joint_trajectory"
+JTC_NAME = "joint_trajectory_controller"
+JTC_PIPELINE = "jtc"
+
+
+def _objective_root() -> ET.Element:
+    return ET.parse(OBJECTIVE_PATH).getroot()
+
+
+def _port_defaults(root: ET.Element) -> dict[str, str]:
+    model = root.find("./TreeNodesModel/SubTree[@ID='Request Teleoperation']")
+    assert model is not None
+    return {
+        port.attrib["name"]: port.attrib["default"]
+        for port in model
+        if port.tag.endswith("_port") and "default" in port.attrib
+    }
+
+
+def test_velocity_scale_is_seeded_before_parallel_teleoperation() -> None:
+    root = _objective_root()
+    sequence = root.find(
+        "./BehaviorTree[@ID='Request Teleoperation']/Control[@ID='Sequence']"
+    )
+    assert sequence is not None
+
+    children = list(sequence)
+    assert children[0].attrib == {"ID": "Script", "code": "teleop_mode := 0"}
+    assert children[1].attrib == {
+        "ID": "Script",
+        "code": "velocity_scale_factor := 0.75",
+    }
+    assert children[2].attrib["ID"] == "Parallel"
+
+    teleoperate_action = sequence.find(".//Action[@ID='DoTeleoperateAction']")
+    assert teleoperate_action is not None
+    assert teleoperate_action.attrib["velocity_scale_factor"] == (
+        "{velocity_scale_factor}"
+    )
+
+
+def test_all_planned_teleoperation_motion_uses_seeded_scale_and_jtc_ports() -> None:
+    root = _objective_root()
+    expected_controller_attributes = {
+        "Interpolate to Joint State": "controller_action_server",
+        "Move to Pose": "controller_action_name",
+        "Move to Joint State": "controller_action_server",
+    }
+
+    for subtree_id, action_attribute in expected_controller_attributes.items():
+        subtree = root.find(f".//SubTree[@ID='{subtree_id}']")
+        assert subtree is not None
+        assert subtree.attrib["velocity_scale_factor"] == "{velocity_scale_factor}"
+        assert subtree.attrib["controller_names"] == (
+            "{joint_trajectory_controller_name}"
+        )
+        assert subtree.attrib[action_attribute] == "{controller_action_server}"
+        assert subtree.attrib["execution_pipeline"] == "{execution_pipeline}"
+
+
+def test_so101_defaults_planned_teleoperation_to_jtc() -> None:
+    root = _objective_root()
+    defaults = _port_defaults(root)
+
+    assert defaults["controller_action_server"] == JTC_ACTION
+    assert defaults["joint_trajectory_controller_name"] == JTC_NAME
+    assert defaults["execution_pipeline"] == JTC_PIPELINE
+
+    objective_text = OBJECTIVE_PATH.read_text()
+    assert "joint_trajectory_admittance_controller" not in objective_text
+    assert "RetrieveJointStateParameter" not in objective_text
+    assert len(root.findall(".//Action[@ID='RetrieveRobotStateParameter']")) == 2

--- a/src/so101_moveit_hardware_config/test/test_teleoperation_contract.py
+++ b/src/so101_moveit_hardware_config/test/test_teleoperation_contract.py
@@ -35,7 +35,7 @@ def test_velocity_scale_is_seeded_before_parallel_teleoperation() -> None:
     assert children[0].attrib == {"ID": "Script", "code": "teleop_mode := 0"}
     assert children[1].attrib == {
         "ID": "Script",
-        "code": "velocity_scale_factor := 0.75",
+        "code": "velocity_scale_factor := 0.25",
     }
     assert children[2].attrib["ID"] == "Parallel"
 

--- a/src/so101_moveit_hardware_config/waypoints/so101_hardware_waypoints.yaml
+++ b/src/so101_moveit_hardware_config/waypoints/so101_hardware_waypoints.yaml
@@ -1,0 +1,38 @@
+- name: Home
+  description: Measured folded pose commissioned for the physical SO-101.
+  favorite: true
+  joint_group_names:
+    - manipulator
+    - gripper
+  joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    name:
+      - Rotation_R
+      - Pitch_R
+      - Elbow_R
+      - Wrist_Pitch_R
+      - Wrist_Roll_R
+      - Jaw_R
+    position:
+      - 0.0
+      - 3.1
+      - 2.9
+      - 1.4
+      - 1.5707963267948966
+      - 0.027
+    velocity: []
+    effort: []
+  multi_dof_joint_state:
+    header:
+      frame_id: ''
+      stamp:
+        sec: 0
+        nanosec: 0
+    joint_names: []
+    transforms: []
+    twist: []
+    wrench: []

--- a/src/vla_sim/README.md
+++ b/src/vla_sim/README.md
@@ -8,11 +8,15 @@ and serving instructions live.
 
 ## Hardware requirements
 
-An NVIDIA GPU is recommended. When one is present, MoveIt Pro makes it
-available to the inference server automatically. The stack still runs without
-one, but inference moves to the CPU, where the default pi0.5 checkpoint might
-be too slow to run at all. A smaller model such as SmolVLA might be the better
-fit there. AMD GPUs are not passed through yet, so those machines run inference
-on the CPU as well.
+A supported NVIDIA CUDA or AMD ROCm GPU is recommended. No accelerator setting
+is needed: MoveIt Pro detects supported host hardware, selects the matching
+torch distribution, and exposes the GPU to the inference server. An explicit
+`MOVEIT_TARGET` remains authoritative; an explicit empty value forces CPU.
+
+The policy still names its device `cuda` on AMD because that is PyTorch's
+supported ROCm API; `GET /health` reports `accelerator: rocm` so the backend
+remains unambiguous. The stack also runs without a GPU, but the default pi0.5
+checkpoint may be too slow on CPU. A smaller model such as SmolVLA is a better
+fit there.
 
 For detailed documentation see: [MoveIt Pro Documentation](https://docs.picknik.ai/)

--- a/src/vla_sim/docker/Dockerfile.vla_inference_server
+++ b/src/vla_sim/docker/Dockerfile.vla_inference_server
@@ -1,39 +1,65 @@
-FROM python:3.12-slim
+# Keep the default base multi-architecture for CPU, NVIDIA, and Jetson. ROCm
+# needs AMD's matching userspace libraries in addition to the Python wheels, so
+# its product target selects AMD's release image by immutable digest.
+ARG MOVEIT_TARGET=
+FROM python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65 AS vla-base
+FROM vla-base AS vla-base-cuda13.2-cudnn9
+FROM vla-base AS vla-base-cuda-cudnn9
+FROM vla-base AS vla-base-jetson-cuda13.2-cudnn9
+FROM rocm/pytorch@sha256:73136312e61ea15af04e89a9df3830bd3fa91c14aad755cde0e426e707f493ff AS vla-base-rocm7.2.2
+
+ARG MOVEIT_TARGET
+# All possible values resolve to the versioned local stages declared above.
+# hadolint ignore=DL3006
+FROM vla-base${MOVEIT_TARGET}
 
 # opencv needs libGL/glib at import time even headless-adjacent; install once here
 # rather than debugging ImportErrors inside a slim image.
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      libgl1 libglib2.0-0 \
+      libgl1 libglib2.0-0 libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# TORCH_INDEX pre-installs torch from a specific wheel index before lerobot
-# resolves it. Empty (default) lets lerobot pull the standard build, which is
-# CUDA-enabled on Linux and also runs on CPU; set it to
-# https://download.pytorch.org/whl/cpu for a much smaller CPU-only image on
-# machines without an NVIDIA GPU (VLA_TORCH_INDEX in the workspace .env).
-# torch/torchvision are pinned (within lerobot 0.6.0's >=2.7,<2.12 range) so
-# builds are reproducible and the CPU-only pre-install cannot be re-resolved
-# to a CUDA build by the lerobot install.
+# The serving contract is accelerator-neutral; only the torch distribution is
+# hardware-specific. The ROCm base already contains AMD's tested binary set,
+# while CUDA and CPU retain the existing PyPI/TORCH_INDEX path.
+ARG MOVEIT_TARGET
 ARG TORCH_INDEX=
 ARG TORCH_VERSION=2.11.0
 ARG TORCHVISION_VERSION=0.26.0
-RUN if [ -n "$TORCH_INDEX" ]; then \
-      pip install --no-cache-dir --index-url "$TORCH_INDEX" \
-        --extra-index-url https://pypi.org/simple \
-        "torch==$TORCH_VERSION" "torchvision==$TORCHVISION_VERSION"; \
-    fi \
-    && pip install --no-cache-dir "lerobot[pi,smolvla]==0.6.0" \
-      "torch==$TORCH_VERSION" "torchvision==$TORCHVISION_VERSION"
+ARG ROCM_TORCH_VERSION=2.10.0+rocm7.2.2.git23d69b29
+ARG ROCM_TORCH_PACKAGE_VERSION=2.10.0+rocm7.2.2.lw.git23d69b29
+ARG ROCM_TORCHVISION_VERSION=0.25.0+rocm7.2.2.git82df5f59
+ARG ROCM_TRITON_VERSION=3.6.0+rocm7.2.2.git4ed88892
+RUN set -eu; \
+    case "$MOVEIT_TARGET" in \
+      *rocm*) \
+        selected_torch="$ROCM_TORCH_PACKAGE_VERSION"; \
+        selected_torchvision="$ROCM_TORCHVISION_VERSION"; \
+        test "$(python -c 'import torch; print(torch.__version__)')" = "$ROCM_TORCH_VERSION"; \
+        test "$(python -c 'import torchvision; print(torchvision.__version__)')" = "$ROCM_TORCHVISION_VERSION"; \
+        test "$(python -c 'import triton; print(triton.__version__)')" = "$ROCM_TRITON_VERSION"; \
+        ;; \
+      *) \
+        selected_torch="$TORCH_VERSION"; \
+        selected_torchvision="$TORCHVISION_VERSION"; \
+        if [ -n "$TORCH_INDEX" ]; then \
+          pip install --no-cache-dir --index-url "$TORCH_INDEX" \
+            --extra-index-url https://pypi.org/simple \
+            "torch==$selected_torch" "torchvision==$selected_torchvision"; \
+        fi; \
+        ;; \
+    esac; \
+    pip install --no-cache-dir "lerobot[pi,smolvla]==0.6.0" \
+      "torch==$selected_torch" "torchvision==$selected_torchvision"
 
 COPY vla_inference_server.py /app/vla_inference_server.py
 WORKDIR /app
 
 # Non-root default for a bare `docker run` (the compose service overrides the
-# user anyway); a real passwd entry keeps getpass.getuser() working in torch's
-# import-time cache-dir setup.
-RUN useradd --create-home --uid 1000 vla
-USER vla
+# user anyway). AMD's base already owns UID 1000; the slim base does not.
+RUN getent passwd 1000 >/dev/null || useradd --create-home --uid 1000 vla
+USER 1000
 
 EXPOSE 8973
 ENTRYPOINT ["python", "vla_inference_server.py"]

--- a/src/vla_sim/docker/README.md
+++ b/src/vla_sim/docker/README.md
@@ -9,14 +9,19 @@ this directory's image. Model and device selection live in
 ## Running it
 
 The default checkpoint resolves the gated `google/paligemma` tokenizer on first
-load, so export a token from an account that has accepted the
+load, so sign in with an account that has accepted the
 [PaliGemma license](https://huggingface.co/google/paligemma-3b-pt-224):
 
 ```bash
-export HF_TOKEN=hf_your_token_here
+hf auth login
+export HF_TOKEN="$(hf auth token)"
 moveit_pro build
 moveit_pro run -c vla_sim --with-inference-server
 ```
+
+MoveIt Pro automatically selects CPU, NVIDIA, Jetson, or AMD from the host;
+there is no accelerator option to set. Existing `hf` CLI credentials are used
+by the command above without putting the token in shell history.
 
 The first run builds the image and downloads the checkpoint into `../hf_cache/`;
 later runs reuse both. Then run **Stack Cubes with the VLA Policy** in the web
@@ -54,6 +59,12 @@ Set these in the workspace `.env`; all are optional.
 | `VLA_MODELS_DIR` | Host folder mounted at `/models`, for checkpoints stored outside the workspace. Defaults to `../models`. |
 | `VLA_TORCH_INDEX` | Package index the image installs torch from, for example `https://download.pytorch.org/whl/cpu` on a machine with no NVIDIA GPU. Defaults to PyPI. |
 
+On a MoveIt Pro ROCm target, the image ignores `VLA_TORCH_INDEX` and installs
+LeRobot on AMD's immutable ROCm 7.2.2 PyTorch release image, then verifies the
+exact Torch, torchvision, and Triton versions. PyTorch exposes both NVIDIA and
+AMD devices as `cuda`; check `/health`'s `accelerator` field to distinguish the
+binary backend.
+
 ## The HTTP contract
 
 `GET /health` reports `loading` / `ready` / `error` and needs no token.
@@ -62,6 +73,7 @@ token. The server speaks plain HTTP and publishes on `127.0.0.1` only, which is
 what keeps that token off the network. Two settings decide what code and weights
 the container runs, so point both only at sources you trust: `checkpoint`
 chooses the robot's actions, and `VLA_TORCH_INDEX` supplies the torch build.
+The ROCm target instead pins the complete AMD base image by digest.
 
 ## Running the image outside compose
 
@@ -79,6 +91,11 @@ docker run --rm --user "$(id -u):$(id -g)" \
   -p 127.0.0.1:8973:8973 vla_inference_server
 ```
 
+For AMD, build with `--build-arg MOVEIT_TARGET=-rocm7.2.2` and replace
+`--gpus all` with `--device /dev/kfd --device /dev/dri`; add the numeric group
+that owns `/dev/kfd` with `--group-add "$(stat -c %g /dev/kfd)"` when the host
+user does not already have a matching device ACL.
+
 `--user` keeps bind-mounted files from being written as uid 1000, which means
 the image's own passwd entry no longer applies, so `HOME` and `USER` have to be
 set for torch's import-time cache setup. `--gpus all` exposes the GPU to the
@@ -91,9 +108,27 @@ server, so anything after the image name is appended as arguments to it, and
 
 ## Tests
 
-`test_vla_inference_server.py` needs `lerobot` and `torch`, so it runs in the
-container, which mounts this directory at `/app`:
+The server and benchmark tests run in the container, which mounts this
+directory at `/app`:
 
 ```bash
-docker exec "$(docker ps -qf name=inference_server)" python -m unittest -v test_vla_inference_server
+docker exec "$(docker ps -qf name=inference_server)" \
+  python -m unittest -v test_vla_inference_server test_benchmark_vla_inference
 ```
+
+After `/health` reports `ready`, collect a repeatable synthetic-input latency
+report with the checkpoint's exact camera names and state width:
+
+```bash
+docker exec "$(docker ps -qf name=inference_server)" \
+  python benchmark_vla_inference.py \
+    --camera scene --camera wrist --camera overview --state-dim 8 \
+    --warmups 1 --samples 5 \
+    --json /tmp/vla-benchmark.json --html /tmp/vla-benchmark.html
+```
+
+The harness validates every returned action and records backend provenance,
+warmup budget, request latency, output shape, and action digests. Synthetic
+images measure serving throughput, not task success. Pass `--payload` with a
+recorded request JSON for representative-input comparisons. Copy the two
+reports out with `docker cp` before removing the container.

--- a/src/vla_sim/docker/benchmark_vla_inference.py
+++ b/src/vla_sim/docker/benchmark_vla_inference.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Benchmark a live VLA inference server and emit JSON plus static HTML.
+
+The synthetic mode measures the complete HTTP, image decode/preprocess, policy,
+and postprocess path with deterministic 224x224 JPEG inputs. It verifies the
+response contract and finite actions on every sample. It does not measure task
+success; use a recorded or simulation-derived payload for representative model
+quality experiments.
+"""
+
+import argparse
+import base64
+import hashlib
+import html
+import json
+import math
+import os
+import statistics
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def nearest_rank_percentile(values: list[float], percentile: float) -> float:
+    """Return a nearest-rank percentile for a non-empty sample."""
+    if not values:
+        raise ValueError("cannot compute a percentile of an empty sample")
+    if not 0.0 < percentile <= 100.0:
+        raise ValueError("percentile must be in (0, 100]")
+    ordered = sorted(values)
+    rank = max(1, math.ceil(percentile / 100.0 * len(ordered)))
+    return ordered[rank - 1]
+
+
+def validate_response(body: dict) -> tuple[int, int, float]:
+    """Validate the serving contract and return (steps, width, dt)."""
+    chunk = body.get("action_chunk")
+    if not isinstance(chunk, list) or not chunk:
+        raise ValueError("response action_chunk must be a non-empty list")
+    if not all(isinstance(row, list) and row for row in chunk):
+        raise ValueError("response action_chunk rows must be non-empty lists")
+    width = len(chunk[0])
+    if any(len(row) != width for row in chunk):
+        raise ValueError("response action_chunk must be rectangular")
+    if not all(
+        isinstance(value, (int, float)) and math.isfinite(value)
+        for row in chunk
+        for value in row
+    ):
+        raise ValueError("response action_chunk must contain finite numbers")
+    dt = body.get("dt")
+    if not isinstance(dt, (int, float)) or not math.isfinite(dt) or dt <= 0.0:
+        raise ValueError("response dt must be a positive finite number")
+    return len(chunk), width, float(dt)
+
+
+def synthetic_payload(camera_names: list[str], state_dim: int, task: str) -> dict:
+    """Create deterministic, full-resolution inputs for a throughput benchmark."""
+    if not camera_names or any(not name for name in camera_names):
+        raise ValueError("synthetic mode needs at least one non-empty camera name")
+    if state_dim <= 0:
+        raise ValueError("synthetic mode needs a positive state dimension")
+
+    # Keep OpenCV and NumPy optional for JSON-payload mode and pure unit tests.
+    import cv2
+    import numpy as np
+
+    axis = np.arange(224, dtype=np.uint8)
+    horizontal = np.broadcast_to(axis, (224, 224))
+    vertical = horizontal.T
+    images = {}
+    for index, name in enumerate(camera_names):
+        blue = (horizontal + index * 37).astype(np.uint8)
+        green = (vertical + index * 53).astype(np.uint8)
+        red = ((horizontal // 2 + vertical // 2) + index * 71).astype(np.uint8)
+        ok, encoded = cv2.imencode(".jpg", np.dstack((blue, green, red)))
+        if not ok:
+            raise RuntimeError(f"failed to encode synthetic camera '{name}'")
+        images[name] = base64.b64encode(encoded.tobytes()).decode("ascii")
+    return {"state": [0.0] * state_dim, "task": task, "images": images}
+
+
+def health_url(infer_url: str) -> str:
+    """Derive the sibling health endpoint without changing authority."""
+    parts = urlsplit(infer_url)
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        raise ValueError("inference URL must be an absolute HTTP(S) URL")
+    if parts.path != "/infer":
+        raise ValueError("inference URL path must be exactly /infer")
+    return urlunsplit((parts.scheme, parts.netloc, "/health", "", ""))
+
+
+def request_json(
+    method: str,
+    url: str,
+    timeout: float,
+    token: str = "",
+    payload: dict | None = None,
+) -> dict:
+    """Issue one JSON request and preserve a server error body's detail."""
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Accept": "application/json"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"{method} {url} returned HTTP {exc.code}: {detail}"
+        ) from exc
+
+
+def action_digest(body: dict) -> str:
+    """Hash normalized model output for comparison without bloating the report."""
+    value = body.get("action_chunk_raw", body["action_chunk"])
+    encoded = json.dumps(value, separators=(",", ":"), allow_nan=False).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def summarize(samples: list[dict], health: dict) -> dict:
+    """Summarize validated samples and relate latency to the server budget."""
+    durations = [sample["seconds"] for sample in samples]
+    shapes = {(sample["chunk_steps"], sample["action_width"]) for sample in samples}
+    summary = {
+        "sample_count": len(samples),
+        "mean_seconds": statistics.fmean(durations),
+        "median_seconds": statistics.median(durations),
+        "p95_seconds": nearest_rank_percentile(durations, 95.0),
+        "min_seconds": min(durations),
+        "max_seconds": max(durations),
+        "median_chunks_per_second": 1.0 / statistics.median(durations),
+        "response_shapes": [
+            {"chunk_steps": steps, "action_width": width}
+            for steps, width in sorted(shapes)
+        ],
+        "unique_action_digests": len({sample["action_sha256"] for sample in samples}),
+    }
+    budget = health.get("warmup", {}).get("realtime_budget_seconds")
+    if isinstance(budget, (int, float)) and math.isfinite(budget):
+        summary["realtime_budget_seconds"] = float(budget)
+        summary["median_budget_margin_seconds"] = (
+            float(budget) - summary["median_seconds"]
+        )
+        summary["median_within_realtime_budget"] = summary["median_seconds"] <= budget
+    return summary
+
+
+def run_benchmark(
+    infer_url: str,
+    token: str,
+    payload: dict,
+    warmups: int,
+    samples: int,
+    timeout: float,
+) -> dict:
+    """Run warmups and measured requests against a ready server."""
+    if warmups < 0 or samples <= 0:
+        raise ValueError("warmups must be non-negative and samples must be positive")
+    health = request_json("GET", health_url(infer_url), timeout)
+    if health.get("status") != "ready":
+        raise RuntimeError(f"inference server is not ready: {health}")
+
+    for _ in range(warmups):
+        validate_response(request_json("POST", infer_url, timeout, token, payload))
+
+    measured = []
+    for index in range(samples):
+        start = time.perf_counter()
+        body = request_json("POST", infer_url, timeout, token, payload)
+        elapsed = time.perf_counter() - start
+        steps, width, dt = validate_response(body)
+        measured.append(
+            {
+                "index": index,
+                "seconds": elapsed,
+                "chunk_steps": steps,
+                "action_width": width,
+                "dt": dt,
+                "action_sha256": action_digest(body),
+            }
+        )
+
+    report = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "endpoint": infer_url,
+        "health": health,
+        "request": {
+            "camera_names": list(payload.get("images", {}).keys()),
+            "state_dim": len(payload.get("state", [])),
+            "task": payload.get("task", ""),
+            "json_bytes": len(json.dumps(payload).encode("utf-8")),
+        },
+        "benchmark": {"warmups": warmups, "samples": samples, "timeout": timeout},
+        "samples": measured,
+    }
+    report["summary"] = summarize(measured, health)
+    return report
+
+
+def render_html(report: dict) -> str:
+    """Render a dependency-free report that can be opened from disk."""
+    summary = report["summary"]
+    health = report["health"]
+    request = report["request"]
+    rows = "\n".join(
+        "<tr>"
+        f"<td>{sample['index']}</td>"
+        f"<td>{sample['seconds']:.4f}</td>"
+        f"<td>{sample['chunk_steps']} × {sample['action_width']}</td>"
+        f"<td><code>{sample['action_sha256'][:12]}</code></td>"
+        "</tr>"
+        for sample in report["samples"]
+    )
+    margin = summary.get("median_budget_margin_seconds")
+    margin_text = "not reported by server" if margin is None else f"{margin:.3f} s"
+    raw_json = html.escape(json.dumps(report, indent=2, sort_keys=True))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MoveIt Pro VLA inference benchmark</title>
+  <style>
+    :root {{ color-scheme: light dark; font-family: system-ui, sans-serif; }}
+    body {{ max-width: 960px; margin: 2rem auto; padding: 0 1rem; line-height: 1.45; }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; }}
+    .card {{ border: 1px solid #8886; border-radius: .5rem; padding: 1rem; }}
+    .value {{ font-size: 1.5rem; font-weight: 650; }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th, td {{ border-bottom: 1px solid #8886; padding: .55rem; text-align: left; }}
+    pre {{ overflow: auto; padding: 1rem; border-radius: .5rem; background: #8881; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>MoveIt Pro VLA inference benchmark</h1>
+  <p>Created {html.escape(report['created_at'])}. Backend:
+    <strong>{html.escape(str(health.get('accelerator', 'unknown')))}</strong>,
+    device <code>{html.escape(str(health.get('device', 'unknown')))}</code>,
+    Torch <code>{html.escape(str(health.get('torch_version', 'unknown')))}</code>.
+  </p>
+  <div class="cards">
+    <div class="card"><div>Median</div><div class="value">{summary['median_seconds']:.3f} s</div></div>
+    <div class="card"><div>P95</div><div class="value">{summary['p95_seconds']:.3f} s</div></div>
+    <div class="card"><div>Budget margin</div><div class="value">{margin_text}</div></div>
+    <div class="card"><div>Samples</div><div class="value">{summary['sample_count']}</div></div>
+  </div>
+  <h2>Request</h2>
+  <p>{request['state_dim']}-dimensional state; cameras
+    <code>{html.escape(', '.join(request['camera_names']))}</code>; task
+    <code>{html.escape(str(request['task']))}</code>.</p>
+  <h2>Samples</h2>
+  <table><thead><tr><th>#</th><th>Seconds</th><th>Action shape</th><th>Action digest</th></tr></thead>
+  <tbody>{rows}</tbody></table>
+  <h2>Raw JSON</h2>
+  <pre>{raw_json}</pre>
+</body>
+</html>
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://127.0.0.1:8973/infer")
+    parser.add_argument("--payload", type=Path)
+    parser.add_argument("--camera", action="append", default=[])
+    parser.add_argument("--state-dim", type=int, default=0)
+    parser.add_argument("--task", default="stack the blue cube on the green cube")
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--json", type=Path, required=True)
+    parser.add_argument("--html", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    token = os.environ.get("MOVEIT_FRONTEND_KEY", "").strip()
+    if not token:
+        raise SystemExit("MOVEIT_FRONTEND_KEY must be set for /infer authentication")
+    if args.payload:
+        payload = json.loads(args.payload.read_text(encoding="utf-8"))
+    else:
+        payload = synthetic_payload(args.camera, args.state_dim, args.task)
+    report = run_benchmark(
+        args.url, token, payload, args.warmups, args.samples, args.timeout
+    )
+    args.json.parent.mkdir(parents=True, exist_ok=True)
+    args.html.parent.mkdir(parents=True, exist_ok=True)
+    args.json.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    args.html.write_text(render_html(report), encoding="utf-8")
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vla_sim/docker/test_benchmark_vla_inference.py
+++ b/src/vla_sim/docker/test_benchmark_vla_inference.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for the dependency-light VLA benchmark report helpers."""
+
+import unittest
+
+from benchmark_vla_inference import (
+    health_url,
+    nearest_rank_percentile,
+    render_html,
+    summarize,
+    validate_response,
+)
+
+
+class TestNearestRankPercentile(unittest.TestCase):
+    def test_uses_nearest_rank(self) -> None:
+        self.assertEqual(nearest_rank_percentile([4.0, 1.0, 3.0, 2.0], 95), 4.0)
+        self.assertEqual(nearest_rank_percentile([4.0, 1.0, 3.0, 2.0], 50), 2.0)
+
+    def test_rejects_empty_sample(self) -> None:
+        with self.assertRaisesRegex(ValueError, "empty"):
+            nearest_rank_percentile([], 95)
+
+
+class TestValidateResponse(unittest.TestCase):
+    def test_accepts_rectangular_finite_chunk(self) -> None:
+        self.assertEqual(
+            validate_response({"action_chunk": [[1.0, 2.0], [3.0, 4.0]], "dt": 0.1}),
+            (2, 2, 0.1),
+        )
+
+    def test_rejects_ragged_chunk(self) -> None:
+        with self.assertRaisesRegex(ValueError, "rectangular"):
+            validate_response({"action_chunk": [[1.0], [2.0, 3.0]], "dt": 0.1})
+
+    def test_rejects_non_finite_action(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            validate_response({"action_chunk": [[float("nan")]], "dt": 0.1})
+
+    def test_rejects_non_positive_dt(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positive"):
+            validate_response({"action_chunk": [[1.0]], "dt": 0.0})
+
+
+class TestHealthUrl(unittest.TestCase):
+    def test_preserves_scheme_and_authority(self) -> None:
+        self.assertEqual(
+            health_url("http://127.0.0.1:8973/infer"),
+            "http://127.0.0.1:8973/health",
+        )
+
+    def test_rejects_an_unexpected_path(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly"):
+            health_url("http://127.0.0.1:8973/other")
+
+
+class TestReport(unittest.TestCase):
+    def _report(self) -> dict:
+        samples = [
+            {
+                "index": 0,
+                "seconds": 1.0,
+                "chunk_steps": 50,
+                "action_width": 8,
+                "dt": 0.1,
+                "action_sha256": "a" * 64,
+            },
+            {
+                "index": 1,
+                "seconds": 1.5,
+                "chunk_steps": 50,
+                "action_width": 8,
+                "dt": 0.1,
+                "action_sha256": "b" * 64,
+            },
+        ]
+        health = {
+            "status": "ready",
+            "device": "cuda",
+            "accelerator": "rocm",
+            "torch_version": "2.10.0+rocm7.2.2",
+            "warmup": {"realtime_budget_seconds": 2.5},
+        }
+        return {
+            "created_at": "2026-08-15T00:00:00+00:00",
+            "health": health,
+            "request": {
+                "state_dim": 8,
+                "camera_names": ["scene", "wrist"],
+                "task": "stack <blue>",
+            },
+            "samples": samples,
+            "summary": summarize(samples, health),
+        }
+
+    def test_summary_relates_median_to_realtime_budget(self) -> None:
+        summary = self._report()["summary"]
+        self.assertEqual(summary["median_seconds"], 1.25)
+        self.assertEqual(summary["median_budget_margin_seconds"], 1.25)
+        self.assertTrue(summary["median_within_realtime_budget"])
+        self.assertEqual(summary["unique_action_digests"], 2)
+
+    def test_html_is_static_and_escapes_request_text(self) -> None:
+        rendered = render_html(self._report())
+        self.assertIn("MoveIt Pro VLA inference benchmark", rendered)
+        self.assertIn("rocm", rendered)
+        self.assertIn("stack &lt;blue&gt;", rendered)
+        self.assertNotIn("stack <blue>", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vla_sim/docker/test_vla_inference_server.py
+++ b/src/vla_sim/docker/test_vla_inference_server.py
@@ -69,6 +69,7 @@ from vla_inference_server import (
     resolve_fps,
     resolve_rtc_horizon,
     resolve_rtc_schedule,
+    torch_accelerator_backend,
 )
 
 
@@ -97,6 +98,33 @@ class TestResolveDevice(unittest.TestCase):
     def test_explicit_cpu_always_honored(self) -> None:
         """An explicit cpu request is honored even when a GPU exists."""
         self.assertEqual(resolve_device("cpu", cuda_available=True), "cpu")
+
+
+class TestTorchAcceleratorBackend(unittest.TestCase):
+    """torch_accelerator_backend: build provenance, independent of device spelling."""
+
+    @staticmethod
+    def _torch_version(*, hip=None, cuda=None):
+        return type(
+            "FakeTorch",
+            (),
+            {"version": type("Version", (), {"hip": hip, "cuda": cuda})()},
+        )()
+
+    def test_rocm_build_wins_even_though_device_is_cuda(self) -> None:
+        """ROCm is identified from build metadata, not torch's shared cuda API."""
+        module = self._torch_version(hip="7.2.2", cuda=None)
+        self.assertEqual(torch_accelerator_backend(module), "rocm")
+
+    def test_cuda_build_is_identified(self) -> None:
+        """A CUDA-only distribution reports the NVIDIA backend."""
+        module = self._torch_version(hip=None, cuda="13.0")
+        self.assertEqual(torch_accelerator_backend(module), "cuda")
+
+    def test_cpu_build_is_identified(self) -> None:
+        """A distribution with neither GPU build marker reports CPU."""
+        module = self._torch_version(hip=None, cuda=None)
+        self.assertEqual(torch_accelerator_backend(module), "cpu")
 
 
 class TestLoadServingConfig(unittest.TestCase):
@@ -619,6 +647,21 @@ class TestHttpStateMachine(unittest.TestCase):
 
         self.assertEqual(resp.status, 200)
         self.assertEqual(json.loads(resp.read())["status"], "ready")
+
+    def test_health_reports_accelerator_provenance_and_warmup(self) -> None:
+        """A ready health response proves which binary backend ran the model."""
+        state = self._ready_state()
+        state.accelerator = "rocm"
+        state.torch_version = "2.10.0+rocm7.2.2"
+        state.warmup_metrics = {"steady_seconds": 1.25, "chunk_steps": 50}
+        conn = self._start(state)
+        conn.request("GET", "/health")
+        body = json.loads(conn.getresponse().read())
+
+        self.assertEqual(body["device"], "cpu")
+        self.assertEqual(body["accelerator"], "rocm")
+        self.assertEqual(body["torch_version"], "2.10.0+rocm7.2.2")
+        self.assertEqual(body["warmup"]["chunk_steps"], 50)
 
     def test_infer_malformed_json_is_400(self) -> None:
         """A body that isn't valid JSON is rejected before it reaches the policy."""

--- a/src/vla_sim/docker/vla_inference_server.py
+++ b/src/vla_sim/docker/vla_inference_server.py
@@ -208,6 +208,20 @@ def resolve_fps(checkpoint: str, fps: float) -> float:
     )
 
 
+def torch_accelerator_backend(torch_module=torch) -> str:
+    """Name the binary backend without changing torch's public device API.
+
+    PyTorch intentionally exposes ROCm devices through ``torch.cuda``. The
+    build metadata is the supported way to distinguish a ROCm distribution
+    from CUDA for diagnostics and benchmark provenance.
+    """
+    if getattr(torch_module.version, "hip", None):
+        return "rocm"
+    if getattr(torch_module.version, "cuda", None):
+        return "cuda"
+    return "cpu"
+
+
 def resolve_device(requested: str, cuda_available: bool) -> str:
     """Resolve the torch device, failing loudly when an explicit request can't be honored.
 
@@ -221,8 +235,8 @@ def resolve_device(requested: str, cuda_available: bool) -> str:
     if requested.startswith("cuda") and not cuda_available:
         raise ValueError(
             f"device '{requested}' was requested but this torch build reports "
-            "no usable GPU; run the container with the NVIDIA runtime "
-            "(GPU serving is automatic on NVIDIA machines under the launcher) "
+            "no usable GPU; expose the accelerator to the container "
+            "(the NVIDIA runtime for CUDA, or /dev/kfd and /dev/dri for ROCm) "
             "or set device: auto in vla_serving.yaml"
         )
     return requested
@@ -452,6 +466,9 @@ class ServerState:
         self.runner: PolicyRunner | None = None
         # Resolved by the loader thread; meaningful once status is "ready".
         self.fps = 0.0
+        self.accelerator = torch_accelerator_backend()
+        self.torch_version = str(torch.__version__)
+        self.warmup_metrics: dict = {}
         # Shared secret /infer requests must present; set from
         # MOVEIT_FRONTEND_KEY in main() before serve_forever() accepts any
         # request.
@@ -525,7 +542,7 @@ def load_policy(state: ServerState, args: argparse.Namespace) -> None:
             )
         log(
             f"loading {policy_type} checkpoint '{args.checkpoint}' on '{device}' "
-            f"(torch {torch.__version__}) ..."
+            f"({state.accelerator}, torch {state.torch_version}) ..."
         )
         runner = PolicyRunner(
             args.checkpoint,
@@ -557,14 +574,20 @@ def load_policy(state: ServerState, args: argparse.Namespace) -> None:
             # least latency/dt steps yet leave at least as many uncommitted,
             # capping tolerable latency at (chunk/2)*dt.
             budget_s = (chunk_steps / 2.0) / state.fps
+            state.warmup_metrics = {
+                "cold_seconds": cold_s,
+                "steady_seconds": steady_s,
+                "chunk_steps": chunk_steps,
+                "realtime_budget_seconds": budget_s,
+            }
             if steady_s > budget_s:
                 log(
                     f"WARNING: inference takes {steady_s:.2f}s per "
                     f"{chunk_steps}-step chunk on '{device}', over the "
                     f"{budget_s:.2f}s real-time budget at {state.fps:g} fps; "
                     "execution will starve at chunk seams. Serve on a faster "
-                    "device (the launcher uses the GPU automatically on NVIDIA "
-                    "machines) or use a policy this machine can serve in time. The "
+                    "device (the launcher exposes supported NVIDIA and AMD GPUs "
+                    "automatically) or use a policy this machine can serve in time. The "
                     "objective's committed_action_steps x dt sets the "
                     "tighter per-run budget."
                 )
@@ -719,6 +742,10 @@ def make_handler(state: ServerState):
                 health["detail"] = state.detail
             elif state.status == "ready":
                 health["device"] = state.runner.device
+                health["accelerator"] = state.accelerator
+                health["torch_version"] = state.torch_version
+                if state.warmup_metrics:
+                    health["warmup"] = state.warmup_metrics
             self._send(200, health)
 
         def _authorized(self) -> bool:


### PR DESCRIPTION
## Summary

Adds a self-contained SO-101 example workspace for simulation and a physical robot whose Raspberry Pi owns `ros2_control`. The MoveIt Pro Runtime, Desktop App connection, camera display, and optional VLA inference run on the workstation.

## Architecture

- `so101_moveit_config` owns the shared robot model, MuJoCo scene, planning contract, simulation Objective, and VLA execution Objective.
- `so101_moveit_hardware_config` adapts that model to the Pi-hosted controller boundary. The Runtime does not launch or switch the Pi controller manager. It validates the remote standard JTC, gripper controller, and broadcaster before accepting live use.
- `so101_camera_bridge` decodes RTSP only when ROS image subscribers need frames for inference or recording. MoveIt Pro camera panes use built-in WebRTC passthrough directly.
- `scripts/run-so101.bash` detects the workstation target, establishes the directional ROS2DDS bridge, checks the external controller contract, and starts Runtime plus optional inference.
- Planned waypoint and teleoperation motion use `joint_trajectory_controller`; `joint_trajectory_admittance_controller` is reserved for `ExecutePolicy` trajectory chunks.

## Physical motion safety

The physical configuration has its own conservative velocity and acceleration limits and exposes only the measured folded `Home` pose. The simulation-authored `Ready` pose is intentionally unavailable on hardware: it substantially increases static shoulder and elbow load, and this robot has demonstrated insufficient elbow load-bearing authority. A load-bearing hardware pose must be commissioned after the joint is repaired rather than making a stalled motion pass by widening tolerances.

## Why the diff is large

The 96-file diff is predominantly one self-contained robot integration: 39 robot-description/model asset files and 41 files across the three SO-101 packages. Seven files extend the existing VLA example service, two document the host boundary, and the remaining launcher/root files expose the config. The branch is four commits ahead of current `main` and is not carrying base-branch drift.

## Validation

- Built `vla_sim`, `so101_camera_bridge`, `so101_moveit_config`, and `so101_moveit_hardware_config` in the MoveIt Pro 10.0 Runtime image on the Framework Desktop.
- Passed the external-driver, teleoperation-controller, and physical-motion contract tests: 10 tests, 0 failures.
- Verified direct ROCm device passthrough on the Framework Desktop after reboot.
- Verified the Pi MoveIt profile reports the expected active JTC, gripper controller, and joint-state broadcaster.

No physical `Ready` motion was attempted after identifying the load-bearing fault.