### PR TITLE
Fix: AddBottlesToPlanningScene builds its offset as a generic vector instead of a Vector3

### DIFF
--- a/src/lab_sim/objectives/addbottlestoplanningscene.xml
+++ b/src/lab_sim/objectives/addbottlestoplanningscene.xml
@@ -95,36 +95,19 @@
               z="{z}"
             />
           </Control>
-          <Control ID="Sequence">
-            <Action ID="ResetVector" vector="{vector}" />
-            <Action
-              ID="InsertInVector"
-              index="0"
-              output_vector="{vector}"
-              element="{z}"
-              input_vector="{vector}"
-            />
-            <Action
-              ID="InsertInVector"
-              index="0"
-              output_vector="{vector}"
-              element="{y}"
-              input_vector="{vector}"
-            />
-            <Action
-              ID="InsertInVector"
-              index="0"
-              output_vector="{vector}"
-              element="{x}"
-              input_vector="{vector}"
-            />
-          </Control>
+          <Action
+            ID="CreateVector3Message"
+            x="{x}"
+            y="{y}"
+            z="{z}"
+            vector3="{offset}"
+          />
           <Action ID="Script" code="object_id:='bottle'..index" />
           <SubTree
             ID="AddCollisionBoxInFrontOfEndEffector"
             _collapsed="true"
             dimensions="0.15;0.15;0.15"
-            offset="{vector}"
+            offset="{offset}"
             object_id="{object_id}"
           />
         </Control>

--- a/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
+++ b/src/lab_sim/objectives/addcollisionboxinfrontofendeffector.xml
@@ -41,7 +41,7 @@
       <inout_port
         name="offset"
         default="0;0;0.1"
-        type="std::vector&lt;double, std::allocator&lt;double&gt; &gt;"
+        type="geometry_msgs::msg::Vector3"
       />
     </SubTree>
   </TreeNodesModel>


### PR DESCRIPTION
[written by AI]

MoveIt Pro 10.0 types the pose Behaviors' position ports as `geometry_msgs::msg::Vector3`. `AddBottlesToPlanningScene` still builds its offset with `ResetVector` + `InsertInVector`, so `CreatePoseStamped` fails at tick with `[Any::convert]: no known safe conversion`. This was the only Objective in the workspace building one of these values on the blackboard; literal `x;y;z` wirings still parse.

- Replace the vector block with a single `CreateVector3Message` fed by the existing `UnpackPointMessage` outputs.
- Correct the `AddCollisionBoxInFrontOfEndEffector` subtree's `offset` port type from `std::vector<double>` to `geometry_msgs::msg::Vector3` (this Objective is its only caller; the `0;0;0.1` default still parses).

Verified in lab_sim simulation: the unfixed XML reproduces the error, the fixed Objective succeeds and adds `bottle0`..`bottle2` collision boxes. CI does not run this Objective (integration-test skip list).
