### PR TITLE
Fetch colcon mixins via git clone instead of raw.githubusercontent.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,20 +74,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Set up colcon defaults for the new user
 USER ${USERNAME}
-# Clone the colcon mixin/metadata repositories over git rather than letting colcon
-# fetch each file from raw.githubusercontent.com. The CDN rate-limits (HTTP 429),
-# colcon's load_url() only retries 503 and socket timeouts, and `colcon mixin update`
-# fails if any single file in the index fails -- so one throttled request out of 19
-# breaks the whole image build. Cloning is one request per repository.
-RUN git clone --depth 1 \
-      https://github.com/colcon/colcon-mixin-repository /tmp/cmr && \
-    colcon mixin add default file:///tmp/cmr/index.yaml && \
-    colcon mixin update && \
+# Vendor the colcon mixin/metadata repositories into the image over git rather than
+# letting colcon fetch each file from raw.githubusercontent.com. The CDN rate-limits
+# (HTTP 429), colcon's load_url() only retries 503 and socket timeouts, and
+# `colcon mixin update` fails if any single file in the index fails -- so one throttled
+# request out of 19 breaks the whole image build.
+#
+# The clones are kept rather than deleted: `colcon mixin add` persists the index URL, and
+# a later unqualified `colcon mixin update` re-reads every registered source. Keeping them
+# also takes the CDN off the build path entirely. Combined size is ~164 KB without .git.
+RUN mkdir -p /home/${USERNAME}/.colcon/repositories && \
     git clone --depth 1 \
-      https://github.com/colcon/colcon-metadata-repository /tmp/cmdr && \
-    colcon metadata add default file:///tmp/cmdr/index.yaml && \
-    colcon metadata update && \
-    rm -rf /tmp/cmr /tmp/cmdr
+      https://github.com/colcon/colcon-mixin-repository /home/${USERNAME}/.colcon/repositories/mixin && \
+    git clone --depth 1 \
+      https://github.com/colcon/colcon-metadata-repository /home/${USERNAME}/.colcon/repositories/metadata && \
+    rm -rf /home/${USERNAME}/.colcon/repositories/mixin/.git /home/${USERNAME}/.colcon/repositories/metadata/.git && \
+    colcon mixin add default file:///home/${USERNAME}/.colcon/repositories/mixin/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default file:///home/${USERNAME}/.colcon/repositories/metadata/index.yaml && \
+    colcon metadata update
 COPY colcon-defaults.yaml /home/${USERNAME}/.colcon/defaults.yaml
 
 # hadolint ignore=DL3002

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,12 +74,20 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Set up colcon defaults for the new user
 USER ${USERNAME}
-RUN colcon mixin add default \
-    https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+# Clone the colcon mixin/metadata repositories over git rather than letting colcon
+# fetch each file from raw.githubusercontent.com. The CDN rate-limits (HTTP 429),
+# colcon's load_url() only retries 503 and socket timeouts, and `colcon mixin update`
+# fails if any single file in the index fails -- so one throttled request out of 19
+# breaks the whole image build. Cloning is one request per repository.
+RUN git clone --depth 1 \
+      https://github.com/colcon/colcon-mixin-repository /tmp/cmr && \
+    colcon mixin add default file:///tmp/cmr/index.yaml && \
     colcon mixin update && \
-    colcon metadata add default \
-    https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
-    colcon metadata update
+    git clone --depth 1 \
+      https://github.com/colcon/colcon-metadata-repository /tmp/cmdr && \
+    colcon metadata add default file:///tmp/cmdr/index.yaml && \
+    colcon metadata update && \
+    rm -rf /tmp/cmr /tmp/cmdr
 COPY colcon-defaults.yaml /home/${USERNAME}/.colcon/defaults.yaml
 
 # hadolint ignore=DL3002


### PR DESCRIPTION
## Motivation

`moveit_pro run` could not build the user Docker images at all during the GitHub incident on
2026-08-17 (started 13:40 UTC; "repository content downloads are experiencing an approximate 50%
error rate"). Four consecutive attempts failed at the colcon mixin step, each on a different
subset of files. Refs PickNikRobotics/moveit_pro#21607.

`colcon mixin update` fetches 19 individual files from `raw.githubusercontent.com` and fails the
whole `RUN` layer if **any one** of them fails, and colcon's `load_url()`
(`colcon_mixin/mixin/repository.py:78`) retries only on HTTP 503 and socket timeouts — never on
429. At ~50% per-request errors that is roughly a 1-in-500,000 chance of a clean build, and
BuildKit caches nothing from a failed layer, so each retry re-fires all 19 requests.

This is not cosmetic: `colcon-defaults.yaml` in this repo requires the `ccache`, `lld`, and
`compile-commands` mixins, so a build that skipped them would fail later at `colcon build` with an
unknown-mixin error.

## Brief description

Clone the colcon mixin and metadata repositories over git from `github.com` and point
`colcon mixin/metadata add` at `file://` indexes — one git request per repository instead of 19
CDN round-trips.

## How it was tested

Applied to a real 10.0.0-rc5 (jazzy) CUDA build on Ubuntu 24.04 / RTX 4060, **during the incident**,
after three unpatched attempts had failed at this exact step:

- `moveit_pro build user_image` succeeded on the first attempt with the patch, exit code 0.
- The colcon step went from 133-173 s **and failing** to **0.9 s** with all 19 mixins fetched
  (`+ /home/…/.colcon/mixin/default/…` for every one) and all metadata files fetched.
- All three images built: `moveit-pro-{base,runtime,drivers}:10.0.0-rc5-jazzy-moveit_pro_example_ws`.

Preconditions verified inside the Pro image rather than assumed:

- `git` is present (2.43.0).
- `urlopen` accepts `file://` — colcon uses `urllib.request.urlopen`, not `requests`.
- colcon resolves relative index entries as `os.path.dirname(index_url) + '/' + name`
  (`colcon_mixin/subverb/update.py`), so a `file://` index resolves correctly.
- Both `colcon-mixin-repository` and `colcon-metadata-repository` clone cleanly from `github.com`
  while the raw CDN was returning errors.

## Release notes

- Bug Fix: Fixed user Docker image builds failing when GitHub's raw content CDN is unavailable or
  rate-limiting.

## Notes for review

- `--depth 1` on `master` is unpinned, but the current code already fetches `master/index.yaml`, so
  this is not a regression. Pinning to a commit is a separate, worthwhile change.
- This shrinks the exposure window rather than removing the GitHub dependency — during a full
  `github.com` outage the clone fails too. It needs one success instead of nineteen.
- The same block exists in `moveit_pro`'s own `Dockerfile` and in the docs' overlay template that
  customers copy; those are handled in a companion PR.
- The durable fix (vendoring) and the upstream fix (teaching colcon's `load_url()` to retry 429)
  are both discussed in PickNikRobotics/moveit_pro#21607.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR.*

- [ ] `code-reviewer`
- [ ] `documentation-bot`
- [ ] `licensing-privacy-bot`
- [ ] `platform-architect-bot`
- [ ] `roboticist-bot`
- [ ] `frontend-noah-bot`
- [ ] `security-auditor`
- [ ] `compatibility-bot`
- [ ] `test-runner`

> Boxes are intentionally left unticked: this PR was authored via the GitHub API from outside a
> repo checkout, so none of the delegation agents were run against the diff. The pre-push gate is
> incomplete and must be resolved before merge.


---

## Update after review (revision 2)

The first revision deleted the clones after use. That was wrong: `colcon mixin add` only
*registers* the index URL, so `default` was left pointing at deleted paths and the `cacher`
stage's **unqualified** `colcon mixin update` failed with
`<urlopen error [Errno 2] No such file or directory: /tmp/cmr/index.yaml>`. CI caught it; CodeRabbit
flagged it independently.

Revision 2 clones to stable paths and keeps them (`.git` stripped, ~164 KB total):

- `Dockerfile` (root, `ros-common`): `/opt/colcon-{mixin,metadata}-repository`
- overlay template / example workspace (runs as `${USERNAME}`): `$HOME/.colcon/repositories/{mixin,metadata}`

Re-verified by rebuilding the real image and running the previously-failing scenario as the
workspace user — unqualified `colcon mixin update` and `colcon metadata update` both exit 0,
reading from the vendored copies.

**Behavior change worth a reviewer's opinion:** a later `colcon mixin update` now re-reads the
vendored snapshot instead of fetching fresh from GitHub. Since the mixin files were already frozen
into the image, that reads as more reproducible — but restoring the remote URLs after the update is
a one-line alternative if live updates are preferred there.