### PR TITLE
Ci: Bump moveit_pro_ci to v0.9.1 for the license hardware identity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,7 +243,10 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@a0e3b30c9aa8f8f82f95c91e5a34989d01caa046 # v0.9.0
+    # v0.9.1 adds the synthetic host NIC the integration container licenses against.
+    # From MoveIt Pro 9.4.2 the fingerprint needs a TPM or a permanent NIC and fails
+    # closed with neither, which is every runner this job lands on.
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@2eff8c8aa644ed07acaaebc9eb15af4af7169e79 # v0.9.1
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#21596

Paired with [moveit_pro#21596](https://github.com/PickNikRobotics/moveit_pro/pull/21596), which backports the licensing hardware fingerprint tier ladder to 9.4.2.

## Motivation

`workspace_integration_test` runs MoveIt Pro inside a bridge-networked container on an ephemeral runner. That machine has no TPM, and no interface the licensing fingerprint will accept — a container veth is rejected by design (`addr_assign_type=3`, no sysfs `device` link).

Through 9.4.1 that did not matter: the fingerprint hashed `eth0`'s MAC and happily took the veth's. From 9.4.2 it resolves a TPM endorsement key, else a permanent hardware NIC, and **fails closed** with neither. This job would stop activating a license the moment it pulls a 9.4.2 image, and the failure surfaces as an unlicensed stack rather than anything naming CI.

## Brief description

Bumps the pin from `v0.9.0` to `v0.9.1`. That is a single commit on top of the pinned SHA, adding only the step that builds a synthetic sysfs tree with a fixed MAC and points `MOVEIT_HOST_SYSFS` at it — additions only, no change to the reusable workflow's input signature, so nothing else in this call site moves.

The MAC is fixed deliberately: the runner fleet presents one identity, rather than each ephemeral runner registering as a distinct machine and consuming its own activation against the floating license.

`v10.0` already pins `v0.9.1` (both of its call sites). This brings the 9.4 line into the same state ahead of 9.4.2 shipping.

## Merge order

Land moveit_pro#21596 first. Until then this branch's own CI runs against the released 9.4.1 base image, where the bump is a harmless no-op — the `needs:` line above is what points its run at the paired branch.
