### PR TITLE
Fix: Allow link_4 collision with the attached suction gripper in factory_sim tool change

### DIFF
--- a/src/factory_sim/objectives/pick_up_tool_from_holder.xml
+++ b/src/factory_sim/objectives/pick_up_tool_from_holder.xml
@@ -29,6 +29,13 @@
       />
       <Action
         ID="SetupMTCSetCollisionRule"
+        name_a="link_4"
+        name_b="suction_gripper"
+        allow_collision="true"
+        task="{mtc_task}"
+      />
+      <Action
+        ID="SetupMTCSetCollisionRule"
         name_a="link_5"
         name_b="suction_gripper"
         allow_collision="true"
@@ -79,7 +86,7 @@
         ID="AttachURDF"
         parent_link_name="tool0"
         urdf_name="{tool_name}"
-        allowed_collision_links="link_5;link_6"
+        allowed_collision_links="link_4;link_5;link_6"
       />
       <SubTree ID="Retract" _collapsed="true" distance="0.35" />
     </Control>

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -29,6 +29,13 @@
           />
           <Action
             ID="SetupMTCSetCollisionRule"
+            name_a="link_4"
+            name_b="{tool_object_name}"
+            allow_collision="true"
+            task="{mtc_task}"
+          />
+          <Action
+            ID="SetupMTCSetCollisionRule"
             name_a="link_5"
             name_b="{tool_object_name}"
             allow_collision="true"


### PR DESCRIPTION
[written by AI]

## Problem

The weekly objective integration suite's 2026-08-16 `factory_sim` leg failed three objectives (`Automated Tool Changing Example`, `Tool Attachment Example`, `Pick and Place Brackets from Left Bin`) with the same MTC error:

```
move to pose (0/6): The initial joint positions are not valid: 'Found a self-collision
involving the bodies 'link_4 <-> suction_gripper'. Colliding bodies define a padding value of 0.02 m.'
```

`tool0` on the Fanuc LR Mate 200iD is a geometry-less frame link (`fanuc_lrmate200id_support/urdf/lrmate200id_macro.xacro:174`). moveit_pro PR PickNikRobotics/moveit_pro#21383 changed `CollisionEnv` from `getLinkModelsWithCollisionGeometry()` to `getLinkModels()`, so every link now carries a padding entry and attached bodies inherit their attach link's padding. The `suction_gripper` attached to `tool0` therefore now inherits the `link_padding="0.020000"` set on `place_tool_in_tool_holder.xml`'s `SetupMTCPlanToPose` — the exact 0.02 m in the message.

These objectives' allowed-collision set covers only `link_5<->link_6`, `link_5<->suction_gripper`, and `link_6<->suction_gripper`. `link_4` was never listed, so the newly-padded tool trips ProRRT's start-state validity check and every IK solution is rejected before planning starts.

The upstream padding change is correct; the gap is here — these objectives were silently relying on attached bodies receiving zero padding.

## Change

Add `link_4` to the suction gripper's allowed-collision set in the two objectives on the tool-change path:

- `pick_up_tool_from_holder.xml` — a `SetupMTCSetCollisionRule` for `link_4 <-> suction_gripper`, and `link_4` in the `AttachURDF` `allowed_collision_links`. The `AttachURDF` entry is the load-bearing one: it writes the planning-scene ACM that stays in effect for the whole time the tool is attached, which is what the failing `Place Tool` start-state check reads.
- `place_tool_in_tool_holder.xml` — the matching per-task `SetupMTCSetCollisionRule` for `link_4 <-> {tool_object_name}`.

Allowing `link_4` is a modest extension of the rationale already applied to `link_5` and `link_6`: the tool is rigidly attached at the wrist, so proximal wrist links sit inside its padded envelope in folded configurations. Reducing the stage's `link_padding` was the alternative, but that padding buys real clearance while inserting the tool into its holder, so narrowing the collision exemption is the safer lever.

## Scope

`vacuum_pick_bracket_part_subtree.xml` and `pick_bracket_part_from_jig_subtree.xml` also use `allowed_collision_links="link_5;link_6"`, but they attach the bracket part, not the suction tool, and have not failed. Left alone.

This does **not** fix the earlier `factory_sim` regression visible in the 2026-08-09 through 2026-08-14 runs (`retract / Cartesian Motion (0/1): Partial path IK found, and no collisions detected`), which is a separate moveit_pro-side change. See PickNikRobotics/moveit_pro#21059 for that analysis; expect it to re-surface in the weekly suite once this start-state failure stops masking it.

Refs PickNikRobotics/moveit_pro#21059
