### PR TITLE
Fix: Give the factory_sim tool-change retract a tolerance band

### DIFF
--- a/src/factory_sim/objectives/pick_up_tool_from_holder.xml
+++ b/src/factory_sim/objectives/pick_up_tool_from_holder.xml
@@ -88,7 +88,12 @@
         urdf_name="{tool_name}"
         allowed_collision_links="link_4;link_5;link_6"
       />
-      <SubTree ID="Retract" _collapsed="true" distance="0.35" />
+      <SubTree
+        ID="Retract"
+        _collapsed="true"
+        min_distance="0.15"
+        max_distance="0.35"
+      />
     </Control>
   </BehaviorTree>
   <TreeNodesModel>

--- a/src/factory_sim/objectives/place_tool_in_tool_holder.xml
+++ b/src/factory_sim/objectives/place_tool_in_tool_holder.xml
@@ -95,7 +95,8 @@
       <SubTree
         ID="Retract"
         _collapsed="true"
-        distance="0.35"
+        min_distance="0.15"
+        max_distance="0.35"
         ignore_environment_collisions="true"
       />
     </Control>

--- a/src/factory_sim/objectives/retract.xml
+++ b/src/factory_sim/objectives/retract.xml
@@ -3,7 +3,8 @@
   <BehaviorTree
     ID="Retract"
     _description="Move back a distance in the tool frame"
-    distance="0.1"
+    min_distance="0.1"
+    max_distance="0.15"
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <Action ID="InitializeMTCTask" task_id="retract" task="{mtc_task}" />
@@ -12,8 +13,8 @@
         ID="SetupMTCMoveAlongFrameAxis"
         axis_frame="tool0"
         axis_z="-1"
-        max_distance="{distance}"
-        min_distance="{distance}"
+        max_distance="{max_distance}"
+        min_distance="{min_distance}"
         hand_frame="tool0"
         acceleration_scale="0.5"
         axis_x="0.000000"
@@ -37,7 +38,8 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Motion - Execute" />
       </MetadataFields>
-      <inout_port name="distance" default="0.1" />
+      <inout_port name="min_distance" default="0.1" />
+      <inout_port name="max_distance" default="0.15" />
       <inout_port name="ignore_environment_collisions" default="false" />
     </SubTree>
   </TreeNodesModel>


### PR DESCRIPTION
[written by AI]

## Problem

`factory_sim`'s `Tool Attachment Example` and `Automated Tool Changing Example` fail the weekly objective integration suite in the `Retract` subtree:

```
retract / Cartesian Motion (0/1): Partial path IK found, and no collisions detected
failed to move full distance
```

`Retract` wires its single `distance` port into both `min_distance` and `max_distance`, so the tool-change objectives demand an exact 0.35 m straight-line retreat with zero tolerance. How far the arm can actually retreat depends on the posture it reaches the holder in, and from the approach posture currently selected only ~0.185 m is reachable, so the demand fails.

## Change

- `retract.xml`: replace the `distance` port with `min_distance` / `max_distance` (defaults 0.1 / 0.15, keeping the old guaranteed minimum).
- Both call sites (`pick_up_tool_from_holder.xml`, `place_tool_in_tool_holder.xml`): `min_distance="0.15" max_distance="0.35"`. The retract exists for clearance, so it still aims for the original 0.35 m but succeeds once past the 0.15 m approach standoff.

The other exact-distance Cartesian moves in factory_sim are insertion or contact motions that must reach full depth; audited and left alone.

## Validation

On a 10.0.0 runtime: both objectives fail with the above signature on stock XML, and pass with this change, both from a fresh sim and chained back-to-back without a reset.
