### PR TITLE
Fix: Malformed quaternion literal breaks three Kinova Move Along Path Objectives

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_gen3_base_config/objectives/move_along_path.xml
@@ -17,7 +17,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action ID="ResetVector" vector="{pose_stamped_vector}" />
@@ -31,7 +31,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -44,7 +44,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -57,7 +57,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path.xml
@@ -22,7 +22,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action ID="ResetVector" vector="{pose_stamped_vector}" />
@@ -36,7 +36,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -49,7 +49,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -62,7 +62,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action

--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
@@ -17,7 +17,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action ID="ResetVector" vector="{pose_stamped_vector}" />
@@ -31,7 +31,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -44,7 +44,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.5;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action
@@ -57,7 +57,7 @@
           ID="CreatePoseStamped"
           reference_frame="base_link"
           position_xyz="0.3;-0.1;0.5"
-          orientation_xyzw="0.707;0.707;0.0;.0.0"
+          orientation_xyzw="0.707;0.707;0.0;0.0"
           pose_stamped="{pose_stamped}"
         />
         <Action


### PR DESCRIPTION
Fixes https://github.com/PickNikRobotics/BCR_platform_mirror/issues/21

The `w` component of `orientation_xyzw` was written as `.0.0` instead of `0.0` at 12 sites across three Objectives:

- `kinova_sim/objectives/move_along_path.xml`
- `kinova_sim/objectives/move_along_path_admittance.xml`
- `kinova_gen3_base_config/objectives/move_along_path.xml`

In 10.0 the port is typed as `geometry_msgs::msg::Quaternion` rather than `vector<double>`, so the value no longer parses and the Objectives fail to load:

```
The port with name "orientation_xyzw" and value "0.707;0.707;0.0;.0.0"
can not be converted to geometry_msgs::msg::Quaternion_
```

`kinova_gen3_base_config` is the hardware-facing config, so this affects the real arm as well as sim.

Tested: all three Objectives load and run in `kinova_sim`.
