### PR TITLE
fix(hangar_sim): make robot_state_publisher the sole publisher of the ridgeback_base_link transform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,7 +243,10 @@ jobs:
       # can assume the LFS S3 cache IAM role via OIDC (moveit_pro_ci v0.5.x).
       contents: read
       id-token: write
-    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@a0e3b30c9aa8f8f82f95c91e5a34989d01caa046 # v0.9.0
+    # v0.9.1 adds the synthetic host NIC the integration container licenses against.
+    # From MoveIt Pro 9.4.2 the fingerprint needs a TPM or a permanent NIC and fails
+    # closed with neither, which is every runner this job lands on.
+    uses: PickNikRobotics/moveit_pro_ci/.github/workflows/workspace_integration_test.yaml@2eff8c8aa644ed07acaaebc9eb15af4af7169e79 # v0.9.1
     with:
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       image_ref: ${{ needs.resolve.outputs.image_ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ ARG USERNAME
 ARG USER_UID
 ARG USER_GID
 
+# Ubuntu 24.04 images include user `ubuntu` with UID/GID 1000.
+# Remove it before creating the workspace user with the host UID/GID.
+RUN if id -u ubuntu > /dev/null 2>&1; then userdel -r ubuntu; fi
+
 # Copy source code from the workspace's ROS 2 packages to a workspace inside the container
 ARG USER_WS=/home/${USERNAME}/user_ws
 ENV USER_WS=${USER_WS}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG USER_GID
 
 # Ubuntu 24.04 images include user `ubuntu` with UID/GID 1000.
 # Remove it before creating the workspace user with the host UID/GID.
-RUN if id -u ubuntu > /dev/null 2>&1; then userdel -r ubuntu; fi
+RUN if id -u ubuntu > /dev/null 2>&1; then userdel -r ubuntu || userdel ubuntu; fi
 
 # Copy source code from the workspace's ROS 2 packages to a workspace inside the container
 ARG USER_WS=/home/${USERNAME}/user_ws

--- a/src/hangar_sim/config/config.yaml
+++ b/src/hangar_sim/config/config.yaml
@@ -21,7 +21,10 @@ hardware:
           path: "config/moveit/joint_limits.yaml"
       - mujoco_model: "description/hangar_scene.xml"
       - mujoco_viewer: false  # set to true locally to open the MuJoCo viewer window
-      # Set to false when use_fuse:=true so fuse is the sole odom -> ridgeback_base_link publisher.
+      # Publishes /odom messages for Nav2. The odom -> ridgeback_base_link TF edge is NOT
+      # published by MuJoCo (odom_publish_tf is false in the ros2_control xacro);
+      # robot_state_publisher owns the live transform to ridgeback_base_link via
+      # the virtual-rail joint chain, so this can stay true with fuse enabled.
       # Rebuild hangar_sim after changing this value.
       - publish_odom: true
 

--- a/src/hangar_sim/config/fuse/fuse.yaml
+++ b/src/hangar_sim/config/fuse/fuse.yaml
@@ -87,7 +87,11 @@ state_estimator:
       base_link_output_frame_id: 'ridgeback_base_link'
       odom_frame_id: 'odom'
       map_frame_id: 'map'
+      # robot_state_publisher owns the live TF to ridgeback_base_link via the
+      # virtual-rail joint chain; fuse must not publish a competing parent.
+      # Its estimate stays available on odom_filtered. On real hardware, feed
+      # the estimate into the virtual-rail joint states instead of TF.
       world_frame_id: 'odom'
-      publish_tf: true
+      publish_tf: false
       publish_frequency: 10.0
       predict_to_current_time: true

--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -23,9 +23,22 @@
           <param name="publish_odom">${publish_odom}</param>
           <param name="odom_child_frame">ridgeback_base_link</param>
           <param name="odom_rate">150</param>
-          <param name="odom_zero_z">true</param>
+          <!-- Zero z/roll/pitch in /odom for this planar base. The previous tag here,
+               odom_zero_z, is not a recognized odom publisher parameter and was silently
+               ignored; odom_planar is the real one. -->
+          <param name="odom_planar">true</param>
+          <!-- robot_state_publisher owns the live TF to ridgeback_base_link via the
+               virtual-rail joint chain (driven by MuJoCo's own joint states), so the
+               odom publisher must not broadcast a competing odom -> ridgeback_base_link
+               edge. /odom messages keep flowing for Nav2. -->
+          <param name="odom_publish_tf">false</param>
           <param name="odom_frame">odom</param>
           <param name="publish_mj_world_tf">false</param>
+          <!-- Stop the lidar TF fill-in chain at the robot's base instead of walking to
+               the MJCF worldbody. Without this, MuJoCo broadcasts
+               base_platform -> ridgeback_base_link, a second parent for a frame that
+               robot_state_publisher already publishes. -->
+          <param name="base_link_name">ridgeback_base_link</param>
           <param name="mujoco_viewer">${mujoco_viewer}</param>
           <param name="mujoco_keyframe">default</param>
       </hardware>

--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -19,7 +19,9 @@
   <xacro:arg name="initial_positions_file" default="$(find picknik_ur_base_config)/config/initial_positions.yaml"/>
   <xacro:arg name="mujoco_model" default="description/bar_scene.xml"/>
   <xacro:arg name="mujoco_viewer" default="false" />
-  <!-- Set to false when use_fuse:=true so fuse is the sole odom → ridgeback_base_link publisher. -->
+  <!-- Publishes /odom messages for Nav2. The odom → ridgeback_base_link TF edge is never
+       broadcast by MuJoCo (odom_publish_tf is false in the ros2_control macro), so this can
+       stay true regardless of use_fuse. -->
   <xacro:arg name="publish_odom" default="true"/>
 
   <!-- Import UR and environment macros -->
@@ -76,7 +78,11 @@
     <axis xyz="1 0 0"/>
     <parent link="world" />
     <child link="virtual_rail_link_1" />
-    <origin xyz="0 0 0" rpy="0 0 0" />
+    <!-- z matches the MJCF base_platform_rotation anchor (pos 0 0 -0.048), which is tuned
+         so the wheels contact the floor (the sim base has no z DOF). Without this offset
+         the robot_state_publisher chain renders the robot 48 mm above where the physics
+         (and every sensor frame) actually put it. -->
+    <origin xyz="0 0 -0.048" rpy="0 0 0" />
     <limit effort="1000.0" lower="-25.0" upper="25.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>

--- a/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
+++ b/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
@@ -804,11 +804,18 @@ static_tf_world_to_map = Node(
     arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "map"],
 )
 
-# Static transform: map to odometry frame
+# Static map->odom TF fallback: only used when neither SLAM nor AMCL is publishing it
 static_tf_map_to_odom = Node(
     package="tf2_ros",
     executable="static_transform_publisher",
     arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "map", "odom"],
+)
+
+# Static transform anchoring MoveIt's planning root under the odometry frame
+static_tf_odom_to_world = Node(
+    package="tf2_ros",
+    executable="static_transform_publisher",
+    arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "odom", "world"],
 )
 ```
 
@@ -821,15 +828,17 @@ mj_world (MuJoCo simulation root)
   │
   ├─ [static] → map
   │    │
-  │    └─ [static] → odom
+  │    └─ [beluga_amcl | static fallback] → odom
   │         │
-  │         └─ [robot_state_publisher] → ridgeback_base_link
-  │              (via virtual joint chain)
+  │         └─ [static] → world
+  │              │
+  │              └─ [robot_state_publisher] → ridgeback_base_link
+  │                   (via world → virtual_rail_link_1 → virtual_rail_link_2 chain)
   │
   └─ [Other scene elements]
 ```
 
-In production deployments with active localization, the static `map` to `odom` transform would be replaced with a dynamic transform published by the localization system (e.g., AMCL), representing the estimated pose correction between odometry and the global map frame.
+With `localization:=True` (the default), beluga_amcl publishes the dynamic `map` → `odom` correction and the static fallback is suppressed; its correction shifts the entire robot subtree (everything under `odom`), which is exactly the REP-105 localization semantics.
 
 ---
 
@@ -864,14 +873,22 @@ The `enable_odom_tf: false` parameter prevents the mecanum drive controllers fro
 | Transform | Publishing Node | Mechanism |
 |-----------|----------------|-----------|
 | `mj_world` → `map` | `static_transform_publisher` | Launch file configuration |
-| `map` → `odom` | `static_transform_publisher` | Launch file configuration (simulation only) |
-| `odom` → `ridgeback_base_link` | `robot_state_publisher` | URDF virtual joint chain with joint state feedback |
+| `map` → `odom` | `beluga_amcl` (or `static_transform_publisher` fallback) | Localization when `localization:=True`; static identity otherwise |
+| `odom` → `world` | `static_transform_publisher` | Launch file configuration (anchors the URDF root under the odometry frame) |
+| `world` → … → `ridgeback_base_link` | `robot_state_publisher` | URDF virtual joint chain with joint state feedback |
+| `ridgeback_base_link` → lidar mounts | MuJoCo hardware plugin | Lidar fill-in chain, stopped at the base by the `base_link_name` hardware parameter |
+
+`robot_state_publisher` is the **sole owner** of the live transform into `ridgeback_base_link`. Every other subsystem that knows the base pose expresses it as data, not as a competing TF parent:
+
+- The MuJoCo odom publisher emits `/odom` messages for Nav2 but not TF (`odom_publish_tf: false`).
+- The MuJoCo lidar fill-in chain stops at `ridgeback_base_link` (`base_link_name` hardware parameter) instead of broadcasting the ground-truth body chain (`base_platform` → `ridgeback_base_link`) up to the MJCF worldbody.
+- fuse keeps `publish_tf: false`; its estimate stays on `odom_filtered`. On real hardware the estimate feeds the virtual-rail joint states (odometry-to-joint-state bridge) rather than TF.
 
 ### Transform Source Analysis
 
-The `robot_state_publisher` node computes and publishes the `odom` to `ridgeback_base_link` transform based on:
+The `robot_state_publisher` node computes and publishes the transform into `ridgeback_base_link` based on:
 1. The URDF virtual joint chain definition (`world` → `virtual_rail_link_1` → `virtual_rail_link_2` → `ridgeback_base_link`)
-2. Current joint state values received on `/joint_states` (populated by the odometry bridge)
+2. Current joint state values received on `/joint_states` — in simulation these come straight from the MuJoCo virtual-rail joints via `joint_state_broadcaster` (ground truth); on real hardware they come from an odometry-to-joint-state bridge fed by the state estimator
 
 If the mecanum drive controllers were configured with `enable_odom_tf: true`, they would publish the same transform based on wheel odometry integration. This would result in multiple publishers for the same transform, violating the ROS 2 transform system's requirement for unique transform publishers.
 
@@ -881,10 +898,10 @@ Enabling odometry transform publication on the controllers would produce the fol
 
 **Multiple Transform Publishers**
 ```
-Transform odom → ridgeback_base_link published by:
-1. robot_state_publisher (from virtual joint states)
-2. platform_velocity_controller (from wheel odometry)
-3. platform_velocity_controller_nav2 (from wheel odometry)
+Transforms into ridgeback_base_link published by:
+1. robot_state_publisher (world → … → ridgeback_base_link, from virtual joint states)
+2. platform_velocity_controller (odom → ridgeback_base_link, from wheel odometry)
+3. platform_velocity_controller_nav2 (odom → ridgeback_base_link, from wheel odometry)
 ```
 
 **System-Level Effects**
@@ -927,7 +944,7 @@ In real-world systems with active localization:
 - Remove the static `map` → `odom` transform publisher
 - Configure the localization system (AMCL, Cartographer, etc.) to publish the dynamic `map` → `odom` transform
 - Maintain `enable_odom_tf: false` on platform controllers
-- The `odom` → `base_link` transform continues to be published by `robot_state_publisher` via virtual joints
+- The `world` → … → `ridgeback_base_link` chain continues to be published by `robot_state_publisher` via virtual joints; `odom` → `world` stays a static link. On hardware, the state estimate feeds the virtual-rail joint states (odometry-to-joint-state bridge) rather than TF
 - Localization system consumes odometry messages to estimate drift and publish correction transforms
 
 ---
@@ -1029,7 +1046,7 @@ For implementing whole body planning on mobile manipulator platforms:
 | Mobile base unresponsive during whole body planning | Trajectory controller not activated | Query controller manager state: `ros2 control list_controllers` | Verify controller activates when executing trajectories; check action server connection |
 | Base motion in incorrect direction | Frame transformation error | Verify yaw joint in `/joint_states`; check `body_frame_yaw_joint` parameter | Confirm `odometry_joint_state_publisher.py` is running; verify parameter configuration |
 | Nav2 commands not executed | Incorrect controller active state | Check controller manager state; verify command topic remapping | Activate `platform_velocity_controller_nav2`; verify `/cmd_vel` remapping |
-| Virtual joints absent from state | Odometry bridge failure | Monitor `/joint_states` for virtual joint messages; check node status | Restart `odometry_joint_state_publisher.py`; verify `/odom` topic publication |
+| Virtual joints absent from state | Joint state source failure | Monitor `/joint_states` for virtual joint messages; check node status | In simulation the virtual-rail joints come from MuJoCo via `joint_state_broadcaster` — check `ros2 control list_controllers`. On hardware, restart the odometry-to-joint-state bridge and verify odometry publication |
 | Planning failures for whole body group | Incorrect planning group configuration | Examine SRDF planning group definition; verify joint names | Use `manipulator` group for whole body; confirm SRDF includes virtual joints |
 | TF_REPEATED_DATA warnings | Multiple transform publishers | Execute `ros2 run tf2_tools view_frames`; identify duplicate publishers | Set `enable_odom_tf: false` in both platform controllers; verify single source per transform |
 | Discontinuous position in visualization | Transform tree inconsistency | Monitor `/tf` for conflicting transforms; check timing | Verify transform publication sources; ensure consistent timestamp sources |

--- a/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
+++ b/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
@@ -846,7 +846,7 @@ mj_world (MuJoCo simulation root)
 
 In this configuration `map` → `odom` is a static identity: AMCL is commented out in `localization_launch.py` (`nav2_params.yaml` states "amcl is not used because odom is received directly from MuJoCo"), and `static_tf_map_to_odom` is published whenever `slam:=False` (the default). Only `slam:=True` replaces it, with `slam_toolbox` owning the correction. Whichever node owns it, the correction applies above `odom` and therefore shifts the entire robot subtree, which is the REP-105 localization semantics.
 
-> Note: this section diverges from the same doc on `main` (PR #756), which describes a beluga_amcl-driven `map` → `odom`. The v9.4 branch has no AMCL/localization wiring and no `localization` launch argument, so the static identity described above is what actually runs here.
+> Note: this configuration has no active AMCL-based localization — `localization_launch.py` includes no live `amcl`/`beluga_amcl` node, so nothing estimates a `map` → `odom` correction unless `slam:=True` starts `slam_toolbox`. Newer releases do run beluga_amcl for that correction; here the transform is the static identity described above.
 
 ---
 

--- a/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
+++ b/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
@@ -828,7 +828,7 @@ mj_world (MuJoCo simulation root)
   │
   ├─ [static] → map
   │    │
-  │    └─ [beluga_amcl | static fallback] → odom
+  │    └─ [static identity | slam_toolbox when slam:=True] → odom
   │         │
   │         └─ [static] → world
   │              │
@@ -838,7 +838,9 @@ mj_world (MuJoCo simulation root)
   └─ [Other scene elements]
 ```
 
-With `localization:=True` (the default), beluga_amcl publishes the dynamic `map` → `odom` correction and the static fallback is suppressed; its correction shifts the entire robot subtree (everything under `odom`), which is exactly the REP-105 localization semantics.
+In this configuration `map` → `odom` is a static identity: AMCL is commented out in `localization_launch.py` (`nav2_params.yaml` states "amcl is not used because odom is received directly from MuJoCo"), and `static_tf_map_to_odom` is published whenever `slam:=False` (the default). Only `slam:=True` replaces it, with `slam_toolbox` owning the correction. Whichever node owns it, the correction applies above `odom` and therefore shifts the entire robot subtree, which is the REP-105 localization semantics.
+
+> Note: this section diverges from the same doc on `main` (PR #756), which describes a beluga_amcl-driven `map` → `odom`. The v9.4 branch has no AMCL/localization wiring and no `localization` launch argument, so the static identity described above is what actually runs here.
 
 ---
 
@@ -873,7 +875,7 @@ The `enable_odom_tf: false` parameter prevents the mecanum drive controllers fro
 | Transform | Publishing Node | Mechanism |
 |-----------|----------------|-----------|
 | `mj_world` → `map` | `static_transform_publisher` | Launch file configuration |
-| `map` → `odom` | `beluga_amcl` (or `static_transform_publisher` fallback) | Localization when `localization:=True`; static identity otherwise |
+| `map` → `odom` | `static_transform_publisher` (or `slam_toolbox` when `slam:=True`) | Static identity by default; AMCL is not launched on v9.4 |
 | `odom` → `world` | `static_transform_publisher` | Launch file configuration (anchors the URDF root under the odometry frame) |
 | `world` → … → `ridgeback_base_link` | `robot_state_publisher` | URDF virtual joint chain with joint state feedback |
 | `ridgeback_base_link` → lidar mounts | MuJoCo hardware plugin | Lidar fill-in chain, stopped at the base by the `base_link_name` hardware parameter |

--- a/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
+++ b/src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md
@@ -69,17 +69,20 @@ The whole body planning capability requires **custom modifications** to the `cle
                         │ MuJoCo Sim    │
                         └───────────────┘
                                 │
-                                ▼
-                        ┌───────────────┐
-                        │  Odometry     │
-                        │  Publisher    │
-                        └───────────────┘
-                                │
-                                ▼
+                    ┌───────────┴───────────┐
+                    │                       │
+                    ▼                       ▼
+        ┌───────────────────────┐           │
+        │   Odometry Publisher  │           │
+        │   → /odom (Nav2 only, │           │
+        │     no TF broadcast)  │           │
+        └───────────────────────┘           │
+                                            ▼
                 ┌───────────────────────────────────┐
-                │ odometry_joint_state_publisher.py│
+                │      joint_state_broadcaster      │
                 │                                   │
-                │ Converts /odom → /joint_states   │
+                │ Publishes /joint_states for the   │
+                │ MuJoCo virtual-rail joints:       │
                 │ - linear_x_joint                  │
                 │ - linear_y_joint                  │
                 │ - rotational_yaw_joint            │
@@ -230,7 +233,7 @@ These modifications follow the same architectural pattern regardless of drive co
 The mobile base's three planar degrees of freedom (translation in X and Y, rotation about Z) are represented as joints within the URDF kinematic tree. This abstraction allows MoveIt to treat the mobile base as additional articulated joints, enabling unified trajectory planning across the combined arm-base system.
 
 ### Implementation Details
-**Location**: `src/hangar_sim/description/ur5e_ridgeback.xacro:73-100`
+**Location**: `src/hangar_sim/description/ur5e_ridgeback.xacro:75-108`
 
 ```xml
 <link name="virtual_rail_link_1"/>
@@ -239,8 +242,10 @@ The mobile base's three planar degrees of freedom (translation in X and Y, rotat
   <axis xyz="1 0 0"/>
   <parent link="world" />
   <child link="virtual_rail_link_1" />
-  <origin xyz="0 0 0" rpy="0 0 0" />
-  <limit effort="1000.0" lower="-20.0" upper="20.0"
+  <!-- z matches the MJCF base_platform_rotation anchor (pos 0 0 -0.048) so the
+       rendered base sits where the physics puts it; the sim base has no z DOF. -->
+  <origin xyz="0 0 -0.048" rpy="0 0 0" />
+  <limit effort="1000.0" lower="-25.0" upper="25.0"
          velocity="0.175" acceleration="10.0"/>
   <dynamics damping="20.0" friction="500.0" />
 </joint>
@@ -271,7 +276,7 @@ The mobile base's three planar degrees of freedom (translation in X and Y, rotat
 The virtual joints establish the following kinematic chain: `world` → `virtual_rail_link_1` → `virtual_rail_link_2` → `ridgeback_base_link`. This chain represents the mobile base's pose in the global reference frame through three sequential transformations corresponding to planar motion.
 
 ### Control Characteristics
-These joints lack direct physical actuators. Instead, their commanded velocities are transformed into mecanum wheel commands through inverse kinematics performed by the platform velocity controller. Joint state feedback is derived from odometry integration via the odometry-to-joint-state bridge.
+These joints lack direct physical actuators. Instead, their commanded velocities are transformed into mecanum wheel commands through inverse kinematics performed by the platform velocity controller. In simulation, joint state feedback comes straight from the MuJoCo virtual-rail joints via `joint_state_broadcaster`; on hardware it is derived from odometry integration via the odometry-to-joint-state bridge (Component 3).
 
 ---
 
@@ -323,6 +328,8 @@ The `manipulator` group defines a kinematic chain originating from `ridgeback_ba
 ### System Requirements
 MoveIt requires joint state information for all joints in the planning group to maintain an accurate robot state representation. For virtual joints representing the mobile base, these states must be derived from the platform's odometry.
 
+**In this simulation the bridge below is not launched.** The virtual-rail joints are real MuJoCo joints, so `joint_state_broadcaster` publishes their ground-truth positions on `/joint_states` directly. `odometry_joint_state_publisher.py` is installed by `CMakeLists.txt` and documented here as the hardware pattern: on a real base the state estimate is converted into virtual-rail joint states this way rather than broadcast as TF (see "Transform Publishing Ownership").
+
 ### Implementation
 **Location**: `src/hangar_sim/script/odometry_joint_state_publisher.py`
 
@@ -353,21 +360,19 @@ class OdometryJointStateRepublisher(Node):
 
 ### Data Flow Architecture
 ```
-MuJoCo Simulation → /odom (nav_msgs/Odometry) → odometry_joint_state_publisher.py
+# Hardware (bridge active):
+State estimate → /odom (nav_msgs/Odometry) → odometry_joint_state_publisher.py
+    → /joint_states (sensor_msgs/JointState) → MoveIt Robot State
+
+# Simulation (what runs here):
+MuJoCo virtual-rail joints → joint_state_broadcaster
     → /joint_states (sensor_msgs/JointState) → MoveIt Robot State
 ```
 
 ### Node Configuration
-**Location**: `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:274-280`
-
-```python
-odom_to_joint_state_repub = Node(
-    package="hangar_sim",
-    executable="odometry_joint_state_publisher.py",
-    name="odometry_joint_state_publisher",
-    output="log",
-)
-```
+No launch file instantiates this node; it would be added to the driver launch on a real
+base. Running it in simulation would put a second publisher of the virtual-rail joint
+positions on `/joint_states`, competing with `joint_state_broadcaster`.
 
 ### Functional Description
 This node subscribes to odometry messages published by the mecanum drive controller and converts the pose information into joint states for the three virtual joints. The conversion extracts the X and Y positions directly and computes the yaw angle from the quaternion orientation. These joint states are then published on the `/joint_states` topic, where they are consumed by `robot_state_publisher` and MoveIt's planning scene monitor.
@@ -705,8 +710,8 @@ Wheel velocity commands are written to the MuJoCo simulation interfaces, causing
 **Step 10: Odometry Integration**
 The simulation integrates wheel velocities to compute platform motion and publishes odometry messages on `/odom`.
 
-**Step 11: State Conversion**
-The `odometry_joint_state_publisher.py` node converts odometry messages to joint state messages and publishes them on `/joint_states`.
+**Step 11: State Feedback**
+`joint_state_broadcaster` publishes the MuJoCo virtual-rail joint positions on `/joint_states`. (On hardware this step is the odometry-to-joint-state bridge instead — see Component 3.)
 
 **Step 12: State Update**
 MoveIt's planning scene monitor receives the joint state updates, updating the robot state representation. The `joint_trajectory_controller` uses this feedback for closed-loop trajectory tracking and error correction.
@@ -717,22 +722,23 @@ MoveIt's planning scene monitor receives the joint state updates, updating the r
 
 ### Initial Configuration
 
-**Location**: `src/hangar_sim/config/config.yaml:94-105`
+**Location**: `src/hangar_sim/config/config.yaml:98-111`
 
 ```yaml
-ros2_control:
+ros2_control:  # config.yaml:89
   controllers_active_at_startup:
     - "force_torque_sensor_broadcaster"
+    - "imu_sensor_broadcaster"
     - "joint_state_broadcaster"
     - "platform_velocity_controller"
     - "vacuum_gripper"
-
   controllers_inactive_at_startup:
-    - "joint_trajectory_controller"
-    - "servo_controller"
     - "platform_velocity_controller_nav2"
+    - "joint_trajectory_controller"
     - "velocity_force_controller"
     - "arm_only_velocity_force_controller"
+    - "joint_velocity_controller"
+    - "arm_only_joint_velocity_controller"
 ```
 
 ### State Transition Model
@@ -780,7 +786,7 @@ The trajectory and navigation controllers are activated on-demand when their res
 
 ### Command Routing Configuration
 
-**Location**: `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:81-85`
+**Location**: `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:86-90`
 
 ```python
 remappings = [
@@ -794,7 +800,7 @@ Nav2's velocity commands are remapped to the `platform_velocity_controller_nav2`
 
 ### Transform Tree Configuration
 
-**Location**: `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:256-272`
+**Location**: `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:260-297`
 
 ```python
 # Static transform: MuJoCo world to map frame
@@ -922,13 +928,12 @@ The controllers continue to publish odometry data as messages despite disabled t
 | `platform_velocity_controller` | No (`enable_odom_tf: false`) | Yes (to `/platform_velocity_controller/odom`) |
 | `platform_velocity_controller_nav2` | No (`enable_odom_tf: false`) | Yes (to `/platform_velocity_controller_nav2/odom`) |
 | `robot_state_publisher` | Yes (from URDF with joint states) | No |
-| `odometry_joint_state_publisher.py` | No | No (converts messages to joint states) |
+| `joint_state_broadcaster` | No | No (publishes the virtual-rail joint states) |
 
 ### Message vs Transform Distinction
 
 **Odometry Messages**: Data structures of type `nav_msgs/Odometry` published on topics, containing pose and twist estimates with covariance information. These messages are consumed by:
 - Nav2 for localization and path tracking
-- The odometry bridge for joint state conversion
 - Monitoring and diagnostic tools
 - Data logging systems
 
@@ -1046,7 +1051,7 @@ For implementing whole body planning on mobile manipulator platforms:
 | Symptom | Probable Cause | Diagnostic Steps | Resolution |
 |---------|---------------|------------------|------------|
 | Mobile base unresponsive during whole body planning | Trajectory controller not activated | Query controller manager state: `ros2 control list_controllers` | Verify controller activates when executing trajectories; check action server connection |
-| Base motion in incorrect direction | Frame transformation error | Verify yaw joint in `/joint_states`; check `body_frame_yaw_joint` parameter | Confirm `odometry_joint_state_publisher.py` is running; verify parameter configuration |
+| Base motion in incorrect direction | Frame transformation error | Verify yaw joint in `/joint_states`; check `body_frame_yaw_joint` parameter | Confirm `joint_state_broadcaster` is active (`ros2 control list_controllers`); verify parameter configuration |
 | Nav2 commands not executed | Incorrect controller active state | Check controller manager state; verify command topic remapping | Activate `platform_velocity_controller_nav2`; verify `/cmd_vel` remapping |
 | Virtual joints absent from state | Joint state source failure | Monitor `/joint_states` for virtual joint messages; check node status | In simulation the virtual-rail joints come from MuJoCo via `joint_state_broadcaster` — check `ros2 control list_controllers`. On hardware, restart the odometry-to-joint-state bridge and verify odometry publication |
 | Planning failures for whole body group | Incorrect planning group configuration | Examine SRDF planning group definition; verify joint names | Use `manipulator` group for whole body; confirm SRDF includes virtual joints |

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -28,7 +28,6 @@
 
 import os
 
-import yaml
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
@@ -36,10 +35,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
-    LogInfo,
-    OpaqueFunction,
     SetEnvironmentVariable,
-    Shutdown,
 )
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -53,52 +49,6 @@ from launch_ros.actions import PushRosNamespace
 from launch_ros.descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
 from nav2_common.launch import RewrittenYaml, ReplaceString
-
-
-def _check_fuse_publish_odom(context, *args, **kwargs):
-    """Fail fast if use_fuse:=true but MuJoCo is still configured to publish odom TF.
-
-    When fuse is enabled it is the sole authority on odom → ridgeback_base_link.
-    MuJoCo must not also publish that edge or consumers will see jittery, interleaved updates.
-    Set 'publish_odom: "false"' in config.yaml under hardware.robot_description.urdf_params.
-    """
-    if LaunchConfiguration("use_fuse").perform(context).lower() != "true":
-        return []
-
-    config_path = os.path.join(
-        get_package_share_directory("hangar_sim"), "config", "config.yaml"
-    )
-    with open(config_path) as f:
-        robot_config = yaml.safe_load(f)
-
-    urdf_params = (
-        robot_config.get("hardware", {})
-        .get("robot_description", {})
-        .get("urdf_params", [])
-    )
-    publish_odom = True  # MuJoCo default
-    for param in urdf_params:
-        if isinstance(param, dict) and "publish_odom" in param:
-            publish_odom = str(param["publish_odom"]).lower() not in (
-                "false",
-                "0",
-                "no",
-            )
-            break
-
-    if publish_odom:
-        return [
-            LogInfo(
-                msg=(
-                    "use_fuse:=true but MuJoCo is still configured to publish"
-                    " odom -> ridgeback_base_link. When fuse is enabled, fuse must be the sole"
-                    " publisher of that TF edge. Set 'publish_odom: false' in config.yaml under"
-                    " hardware.robot_description.urdf_params, then rebuild hangar_sim."
-                )
-            ),
-            Shutdown(reason="publish_odom must be false when use_fuse:=true"),
-        ]
-    return []
 
 
 def generate_launch_description():
@@ -328,15 +278,21 @@ def generate_launch_description():
         condition=IfCondition(PythonExpression(["not ", slam])),
     )
 
-    # Static TF connecting MoveIt's planning root ('world') to the simulation root ('mj_world').
-    # The UI (pose-utils.ts) hardcodes 'world' as the reference frame for all user-clicked poses,
-    # so this link is required for nav2 goals to be transformable to 'map'.
-    static_tf_mj_world_to_world = Node(
+    # Static TF anchoring MoveIt's planning root ('world') under the odometry frame.
+    # robot_state_publisher owns the only live chain into ridgeback_base_link
+    # (world -> virtual_rail_... -> ridgeback_base_link), so 'odom' must sit above
+    # 'world' for REP-105 semantics: AMCL's live map->odom correction then shifts the
+    # whole robot subtree, and its own odom->base lookups resolve through this link.
+    # (Previously this was mj_world->world, and the 'odom' frame only existed because
+    # MuJoCo broadcast a competing odom->ridgeback_base_link TF — removed in this
+    # change.) The UI (pose-utils.ts) hardcodes 'world' for user-clicked poses, so
+    # this link also keeps nav2 goals transformable to 'map'.
+    static_tf_odom_to_world = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
-        name="static_tf_mj_world_to_world",
+        name="static_tf_odom_to_world",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "mj_world", "world"],
+        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "odom", "world"],
     )
 
     # QoS relay to bridge BEST_EFFORT odom and IMU to RELIABLE for fuse
@@ -407,7 +363,7 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
 
-    # Declare the launch options — all args must be declared before the OpaqueFunction runs.
+    # Declare the launch options.
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)
@@ -419,7 +375,6 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
     ld.add_action(declare_use_fuse_cmd)
-    ld.add_action(OpaqueFunction(function=_check_fuse_publish_odom))
 
     # Add the actions to launch all of the navigation nodes
     ld.add_action(bringup_cmd_group)
@@ -430,7 +385,7 @@ def generate_launch_description():
     # ld.add_action(rviz_cmd)
 
     ld.add_action(static_tf_world_to_map)
-    ld.add_action(static_tf_mj_world_to_world)
+    ld.add_action(static_tf_odom_to_world)
     ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
     ld.add_action(laser_filter_front_node)

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -281,8 +281,9 @@ def generate_launch_description():
     # Static TF anchoring MoveIt's planning root ('world') under the odometry frame.
     # robot_state_publisher owns the only live chain into ridgeback_base_link
     # (world -> virtual_rail_... -> ridgeback_base_link), so 'odom' must sit above
-    # 'world' for REP-105 semantics: AMCL's live map->odom correction then shifts the
-    # whole robot subtree, and its own odom->base lookups resolve through this link.
+    # 'world' for REP-105 semantics: a live map->odom correction (slam_toolbox today,
+    # AMCL if it is ever enabled here) then shifts the whole robot subtree, and its
+    # own odom->base lookups resolve through this link.
     # (Previously this was mj_world->world, and the 'odom' frame only existed because
     # MuJoCo broadcast a competing odom->ridgeback_base_link TF — removed in this
     # change.) The UI (pose-utils.ts) hardcodes 'world' for user-clicked poses, so

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -34,8 +34,11 @@ from pathlib import Path
 import pytest
 import rclpy
 import tf2_ros
+from tf2_msgs.msg import TFMessage
+from nav_msgs.msg import Odometry
 import yaml
 from rclpy.time import Time
+from rclpy.qos import qos_profile_sensor_data
 from control_msgs.action import GripperCommand
 from controller_manager_msgs.srv import ListControllers
 from moveit_pro_test_utils.objective_test_fixture import (
@@ -316,6 +319,89 @@ def _expected_end_state_by_id(
     waypoint_joints = resource.get_waypoint_target(JOINT_CHECK_WAYPOINT)
     arm_target = {joint: waypoint_joints[joint] for joint in MANIPULATOR_ARM_JOINTS}
     return {objective_id: EndStateSpec(joints=JointTarget(positions=arm_target))}
+
+
+BASE_LINK_FRAME = "ridgeback_base_link"
+# Phase 1: how long to wait for the FIRST transform into the base link (and the
+# first /odom message) before declaring the stack broken. Generous on purpose:
+# it only bounds startup latency on a loaded CI runner, not the assertion.
+TF_FIRST_SIGHTING_TIMEOUT_S = 60.0
+# Phase 2: once the frame has been seen, how long to keep sampling to catch
+# additional (conflicting) parents. Competing publishers broadcast at 10-120 Hz,
+# so a second parent would appear hundreds of times within this window.
+TF_PARENT_SAMPLE_DURATION_S = 4.0
+
+
+def test_base_link_has_single_tf_parent(
+    execute_objective_resource: ExecuteObjectiveResource,
+) -> None:
+    """The live transform into ridgeback_base_link must have exactly one publisher.
+
+    Regression guard for the three-parent TF conflict (MuJoCo lidar fill-in
+    chain, MuJoCo odom TF, and robot_state_publisher all claiming the frame),
+    which made the robot oscillate below base_link in the web UI.
+    robot_state_publisher owns the edge via the virtual-rail chain; a second
+    parent appearing here means a MuJoCo TF publisher was re-enabled (check
+    base_link_name / odom_publish_tf in the ros2_control xacro) or fuse's
+    publish_tf was turned back on.
+    """
+    node = execute_objective_resource.node
+    parents: set[str] = set()
+    odom_z_samples: list[float] = []
+
+    # Watching /tf only is correct while rotational_yaw_joint (the edge into
+    # ridgeback_base_link) is a moving joint; if it ever becomes fixed the edge
+    # moves to /tf_static and this test must follow it there.
+    def collect(msg: TFMessage) -> None:
+        for transform in msg.transforms:
+            if transform.child_frame_id == BASE_LINK_FRAME:
+                parents.add(transform.header.frame_id)
+
+    def collect_odom(msg: Odometry) -> None:
+        odom_z_samples.append(msg.pose.pose.position.z)
+
+    subscription = node.create_subscription(TFMessage, "/tf", collect, 100)
+    # Piggyback an odom_planar check: odom_zero_z was a silently-ignored
+    # parameter for months, so pin the real one's effect (z zeroed in /odom)
+    # rather than trusting the spelling.
+    odom_subscription = node.create_subscription(
+        Odometry, "/odom", collect_odom, qos_profile_sensor_data
+    )
+    # Phase 1: wait for the first sighting so slow stack bring-up on a loaded
+    # CI runner cannot masquerade as "wrong publishers" (or eat into the
+    # sampling window below).
+    first_sighting_deadline = time.monotonic() + TF_FIRST_SIGHTING_TIMEOUT_S
+    while time.monotonic() < first_sighting_deadline and not (
+        parents and odom_z_samples
+    ):
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    # Distinguish "frame never seen" (a startup failure or renamed frame) from
+    # "wrong publishers" so failures read correctly.
+    assert parents, (
+        f"No transform into {BASE_LINK_FRAME} observed on /tf within "
+        f"{TF_FIRST_SIGHTING_TIMEOUT_S:.1f}s — robot_state_publisher may not "
+        f"be up, or the frame was renamed."
+    )
+
+    # Phase 2: the frame is live; sample long enough that any competing
+    # publisher (10-120 Hz) would land in `parents`.
+    sample_deadline = time.monotonic() + TF_PARENT_SAMPLE_DURATION_S
+    while time.monotonic() < sample_deadline:
+        rclpy.spin_once(node, timeout_sec=0.1)
+    node.destroy_subscription(subscription)
+    node.destroy_subscription(odom_subscription)
+    assert parents == {"virtual_rail_link_2"}, (
+        f"Expected robot_state_publisher's virtual_rail_link_2 as the sole TF "
+        f"parent of {BASE_LINK_FRAME}, saw parents: {sorted(parents)}"
+    )
+    assert (
+        odom_z_samples
+    ), "No /odom messages observed; MuJoCo odom publisher may be off."
+    assert all(abs(z) < 1e-6 for z in odom_z_samples), (
+        f"odom_planar should zero /odom pose z for this planar base; "
+        f"saw max |z| = {max(abs(z) for z in odom_z_samples):.4f}"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What Changed

- Removed the competing TF publishers into `ridgeback_base_link`: the MuJoCo `ros2_control` hardware now sets `odom_publish_tf: false` and `base_link_name: ridgeback_base_link` (stopping the lidar fill-in chain from broadcasting `base_platform -> ridgeback_base_link`), and fuse's `publish_tf` is set to `false` so its estimate stays on `odom_filtered`. `robot_state_publisher` owns the edge via the virtual-rail chain, so `publish_odom` can stay `true` for Nav2's `/odom`. Also replaced the silently-ignored `odom_zero_z` param with the real `odom_planar`, and offset the `virtual_rail_joint_1` origin to `z = -0.048` to match the MJCF `base_platform_rotation` anchor.
- Reworked the launch TF wiring in `robot_drivers_to_persist_sim.launch.py`: the static link is now `odom -> world` instead of `mj_world -> world`, and the `OpaqueFunction` that shut the stack down when `use_fuse:=true` with `publish_odom` enabled was deleted along with its now-unused imports.
- Added `test_base_link_has_single_tf_parent` to the hangar_sim objectives integration test — it waits for the first `/tf` and `/odom` sighting, then samples for additional parents and asserts `virtual_rail_link_2` is the only one and that `/odom` pose z stays zeroed. Updated `NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md` to match the new TF ownership, bumped the `moveit_pro_ci` integration-test workflow to v0.9.1, and added a `userdel` of the stock Ubuntu 24.04 `ubuntu` user in the Dockerfile to avoid the UID 1000 collision.

## Risk Assessment

✅ Low: The change is a well-bounded v9.4 backport of a TF-ownership design already reviewed and merged on main via PR #756, the fix round touched only two lines plus doc prose whose factual claims I verified against v9.4 source, and the two remaining findings are a no-op Dockerfile fallback and an inaccurate doc code quote — neither affects runtime behavior.

## Testing

Ran the hangar_sim MuJoCo stack for real in MoveIt Pro containers (v9.4, v9.4+moveit_pro#20258 backport, and main) rather than relying on config inspection: the branch's new `test_base_link_has_single_tf_parent` fails with the base-commit configuration (three publishers of `ridgeback_base_link`) and passes on this branch against the paired v9.4 core, a live TF census confirms 3 parents collapse to 1, robot_state_publisher's base pose now matches MuJoCo physics exactly (48 mm z error eliminated), `/odom` z is zeroed by the corrected `odom_planar` parameter, the `Solution - Move Forward 2m` base-motion objective still passes, and `use_fuse:=true` bring-up no longer aborts. The only gap is the change's documented core dependency: on the published v9.4 image `base_link_name` is absent from the MuJoCo plugin, so `base_platform` remains a second parent and the new test fails there — reported for a merge-ordering decision. fuse's `publish_tf:false` could not be exercised live because the container's fuse binary aborts on an unrelated ABI mismatch.

- Evidence: TF ownership summary figure (before/after, FK, dependency matrix) (local file: <code>/home/griswald/.no-mistakes/evidence/01M0DVX1N2R1XPSRCY17NWDGZR/tf_ownership_evidence.png</code>)
<details>
<summary>Evidence: TF ownership summary (rendered HTML source of the figure)</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8"><title>hangar_sim TF ownership evidence</title>
<style>
 body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;margin:28px 34px;color:#1b1f24;background:#fff;width:1400px}
 h1{font-size:21px;margin:0 0 2px} .sub{color:#5a616b;font-size:13px;margin-bottom:22px}
 .row{display:flex;gap:26px;margin-bottom:24px}
 .card{border:1px solid #d5d9e0;border-radius:8px;padding:14px 16px;flex:1;background:#fbfbfd}
 .card h2{font-size:14px;margin:0 0 10px;letter-spacing:.02em;text-transform:uppercase;color:#5a616b}
 .bad{color:#b3261e;font-weight:600} .good{color:#146c43;font-weight:600}
 table{border-collapse:collapse;width:100%;font-size:13px}
 td,th{padding:5px 8px;border-bottom:1px solid #e6e9ee;text-align:left}
 th{color:#5a616b;font-weight:600;font-size:12px}
 code,.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px}
 .tree{font-family:ui-monospace,Menlo,monospace;font-size:12.5px;line-height:1.55;white-space:pre}
 .note{font-size:12.5px;color:#5a616b;margin-top:6px}
 .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11.5px;font-weight:600}
 .pf{background:#fdecea;color:#b3261e} .pp{background:#e6f4ea;color:#146c43}
</style></head><body>
<h1>hangar_sim: robot_state_publisher as the sole owner of <code>ridgeback_base_link</code></h1>
<div class="sub">Live MuJoCo hardware (<code>picknik_mujoco_ros/MujocoSystem</code>) + <code>robot_state_publisher</code> + the sim launch file's static TFs, on the v9.4 MoveIt&nbsp;Pro image paired with moveit_pro#20258. Every <code>/tf</code> message whose <code>child_frame_id</code> is <code>ridgeback_base_link</code>, counted by the parent it names, over a 30&nbsp;s window.</div>

<div class="row">
 <div class="card">
  <h2>Before &mdash; base commit 6c51424</h2>
  <div class="tree">   odom              ──▶ ridgeback_base_link   4389 msgs  (MuJoCo odom TF)
   base_platform     ──▶ ridgeback_base_link   3510 msgs  (MuJoCo lidar fill-in chain)
   virtual_rail_link_2──▶ ridgeback_base_link   2794 msgs  (robot_state_publisher)</div>
  <p class="bad" style="margin:12px 0 0">3 competing publishers for one frame</p>
  <div class="note">Integration test <code>test_base_link_has_single_tf_parent</code>:
   <span class="pill pf">FAILED</span> &mdash; <span class="mono">saw parents: ['base_platform', 'odom', 'virtual_rail_link_2']</span></div>
 </div>
 <div class="card">
  <h2>After &mdash; this branch</h2>
  <div class="tree">   virtual_rail_link_2──▶ ridgeback_base_link   2770 msgs  (robot_state_publisher)

   odom → world → virtual_rail_link_1 → virtual_rail_link_2 → ridgeback_base_link
   (MuJoCo odom TF off: odom_publish_tf=false; lidar chain stopped: base_link_name)</div>
  <p class="good" style="margin:12px 0 0">1 publisher &mdash; robot_state_publisher owns the frame</p>
  <div class="note">Integration test <code>test_base_link_has_single_tf_parent</code>:
   <span class="pill pp">PASSED</span></div>
 </div>
</div>

<div class="row">
 <div class="card">
  <h2>URDF render vs. MuJoCo physics (<code>ridgeback_base_link</code> at the scene keyframe)</h2>
  <table>
   <tr><th></th><th>MuJoCo physics</th><th>URDF via robot_state_publisher</th><th>z error</th></tr>
   <tr><td>before</td><td class="mono">[-0.057624, -0.017205, <b>-0.048</b>]</td><td class="mono">[-0.057624, -0.017205, <b>0.000</b>]</td><td class="bad mono">48 mm</td></tr>
   <tr><td>after</td><td class="mono">[-0.057624, -0.017205, -0.048]</td><td class="mono">[-0.057624, -0.017205, -0.048]</td><td class="good mono">0 mm</td></tr>
  </table>
  <div class="note">The base has no z DOF in sim; the MJCF anchors it at <code>pos="0 0 -0.048"</code>. Before the fix the visualised robot floated 48&nbsp;mm above where physics and every sensor frame actually put it.</div>
 </div>
 <div class="card">
  <h2>Other observed effects</h2>
  <table>
   <tr><th></th><th>before</th><th>after</th></tr>
   <tr><td><code>/odom</code> pose z (<code>odom_planar</code>)</td><td class="bad mono">max |z| = 0.048</td><td class="good mono">max |z| = 0.000</td></tr>
   <tr><td>resolved <code>map → ridgeback_base_link</code> z<br><span style='font-size:11px;color:#8a9099'>100 Hz lookup, 20 s</span></td><td class="bad mono">0.000 and -0.048 both seen</td><td class="good mono">constant -0.048</td></tr>
   <tr><td><code>use_fuse:=true</code> launch</td><td class="bad mono">refuses to start (rc=1)</td><td class="good mono">starts</td></tr>
  </table>
  <div class="note"><code>odom_zero_z</code> was never a recognised parameter, so <code>/odom</code> carried the real body z; <code>odom_planar</code> zeroes it. The removed launch guard used to abort bring-up whenever <code>use_fuse:=true</code> met the shipped <code>publish_odom: true</code>.</div>
 </div>
</div>

<div class="card">
 <h2>Core dependency (moveit_pro#20258) &mdash; verified, not assumed</h2>
 <table>
  <tr><th>MoveIt Pro image</th><th><code>base_link_name</code> in core</th><th>parents of <code>ridgeback_base_link</code> with this branch</th><th>test</th></tr>
  <tr><td class="mono">v9.4-jazzy-amd64-cuda13.2-cudnn9 (published)</td><td class="bad">absent</td><td class="mono">base_platform, virtual_rail_link_2</td><td><span class="pill pf">FAILED</span></td></tr>
  <tr><td class="mono">backport_20258-mujoco-base-link-name-v9.4-…</td><td class="good">present</td><td class="mono">virtual_rail_link_2</td><td><span class="pill pp">PASSED</span></td></tr>
  <tr><td class="mono">main-jazzy-amd64</td><td class="good">present</td><td class="mono">virtual_rail_link_2</td><td>&mdash;</td></tr>
 </table>
 <div class="note">Matches the PR's stated dependency: on a v9.4 core without <code>base_link_name</code> the parameter is silently ignored and the MuJoCo lidar fill-in chain keeps publishing <code>base_platform → ridgeback_base_link</code>.</div>
</div>
</body></html>
```
</details>
<details>
<summary>Evidence: Live /tf parent census of ridgeback_base_link across three MoveIt Pro images</summary>

<code>===== BEFORE =====&#10;publishers of a /tf transform whose child is ridgeback_base_link:&#10;parent frame &#39;odom&#39; -&gt; 4389 messages&#10;parent frame &#39;base_platform&#39; -&gt; 3510 messages&#10;parent frame &#39;virtual_rail_link_2&#39; -&gt; 2794 messages&#10;distinct parents: 3&#10;/odom samples: 4389 max |pose.position.z| = 0.048000&#10;&#10;===== AFTER =====&#10;publishers of a /tf transform whose child is ridgeback_base_link:&#10;parent frame &#39;virtual_rail_link_2&#39; -&gt; 2770 messages&#10;distinct parents: 1&#10;/odom samples: 4371 max |pose.position.z| = 0.000000</code>

```text
TF ownership of ridgeback_base_link
Harness: live picknik_mujoco_ros/MujocoSystem hardware (ros2_control_node + joint_state_broadcaster)
         + robot_state_publisher on the package URDF + the sim launch file's static TFs.
Counts every /tf message whose child_frame_id is ridgeback_base_link, by the parent frame it names,
over a 30 s window, plus the max |pose.position.z| seen on /odom.

########## MoveIt Pro image: picknikciuser/moveit-studio:backport_20258-mujoco-base-link-name-v9.4-jazzy-amd64-cuda13.2-cudnn9
########## (v9.4 + the moveit_pro#20258 backport this PR depends on)

===== BEFORE =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'odom'  -> 4389 messages
    parent frame 'base_platform'  -> 3510 messages
    parent frame 'virtual_rail_link_2'  -> 2794 messages
distinct parents: 3
/odom samples: 4389  max |pose.position.z| = 0.048000

===== AFTER =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'virtual_rail_link_2'  -> 2770 messages
distinct parents: 1
/odom samples: 4371  max |pose.position.z| = 0.000000

########## MoveIt Pro image: picknikciuser/moveit-studio:v9.4-jazzy-amd64-cuda13.2-cudnn9 (published v9.4, no base_link_name in core)

===== BEFORE =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'odom'  -> 4382 messages
    parent frame 'base_platform'  -> 3504 messages
    parent frame 'virtual_rail_link_2'  -> 1387 messages
distinct parents: 3
/odom samples: 4382  max |pose.position.z| = 0.048000

===== AFTER =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'base_platform'  -> 3500 messages
    parent frame 'virtual_rail_link_2'  -> 1381 messages
distinct parents: 2
/odom samples: 4376  max |pose.position.z| = 0.000000

########## MoveIt Pro image: picknikciuser/moveit-studio:main-jazzy-amd64 (core has base_link_name)

===== BEFORE =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'odom'  -> 5888 messages
    parent frame 'base_platform'  -> 4710 messages
    parent frame 'virtual_rail_link_2'  -> 3744 messages
distinct parents: 3
/odom samples: 5889  max |pose.position.z| = 0.048000

===== AFTER =====
publishers of a /tf transform whose child is ridgeback_base_link:
    parent frame 'virtual_rail_link_2'  -> 1874 messages
distinct parents: 1
/odom samples: 5877  max |pose.position.z| = 0.000000
```
</details>
<details>
<summary>Evidence: URDF render vs MuJoCo physics for ridgeback_base_link</summary>

<code>[BEFORE] MuJoCo physics ridgeback_base_link @ world = [-0.057624, -0.017205, -0.048]&#10;[BEFORE] URDF via RSP ridgeback_base_link @ world = [-0.057624, -0.017205, 0.0]&#10;[BEFORE] error (URDF - physics) = [0.0, 0.0, 0.048] |z err| = 0.0480 m&#10;[BEFORE] VERDICT: MISMATCH (tolerance 1e-6 m)&#10;[AFTER] URDF via RSP ridgeback_base_link @ world = [-0.057624, -0.017205, -0.048]&#10;[AFTER] error (URDF - physics) = [0.0, 0.0, 0.0] |z err| = 0.0000 m&#10;[AFTER] VERDICT: MATCH (tolerance 1e-6 m)</code>

```text
Does the URDF put ridgeback_base_link where MuJoCo physics puts it?
robot_state_publisher is fed the scene keyframe's virtual-rail joint values; the resulting
world -> ridgeback_base_link transform is compared against the body pose MuJoCo computes for
the same keyframe. Image: picknikciuser/moveit-studio:v9.4-jazzy-amd64-cuda13.2-cudnn9.

[BEFORE] joint state applied : linear_x_joint=-0.057624, linear_y_joint=-0.017205, rotational_yaw_joint=-0.018552
[BEFORE] MuJoCo physics  ridgeback_base_link @ world = [-0.057624, -0.017205, -0.048]
[BEFORE] URDF via RSP    ridgeback_base_link @ world = [-0.057624, -0.017205, 0.0]
[BEFORE] error (URDF - physics)          = [0.0, 0.0, 0.048]  |z err| = 0.0480 m
[BEFORE] VERDICT: MISMATCH (tolerance 1e-6 m)
[AFTER] joint state applied : linear_x_joint=-0.057624, linear_y_joint=-0.017205, rotational_yaw_joint=-0.018552
[AFTER] MuJoCo physics  ridgeback_base_link @ world = [-0.057624, -0.017205, -0.048]
[AFTER] URDF via RSP    ridgeback_base_link @ world = [-0.057624, -0.017205, -0.048]
[AFTER] error (URDF - physics)          = [0.0, 0.0, 0.0]  |z err| = 0.0000 m
[AFTER] VERDICT: MATCH (tolerance 1e-6 m)
```
</details>
<details>
<summary>Evidence: Integration test results across configs and images</summary>

<code>=== 1. base-commit config, v9.4 + moveit_pro#20258 image -&gt; FAILS ===&#10;E AssertionError: ... saw parents: [&#39;base_platform&#39;, &#39;odom&#39;, &#39;virtual_rail_link_2&#39;]&#10;=== 2. this branch, v9.4 + moveit_pro#20258 image -&gt; PASSES ===&#10;1 passed, 67 deselected&#10;=== 3. this branch, published v9.4 image -&gt; FAILS ===&#10;E AssertionError: ... saw parents: [&#39;base_platform&#39;, &#39;virtual_rail_link_2&#39;]&#10;=== 4. objective &#39;Solution - Move Forward 2m&#39; -&gt; PASSES ===</code>

```text
hangar_sim integration test: test_base_link_has_single_tf_parent
The fixture launches the full MoveIt Pro backend (drivers + agent + bridge) for MOVEIT_CONFIG_PACKAGE=hangar_sim.

=== 1. base-commit hangar_sim config, on the v9.4 + moveit_pro#20258 backport image -> FAILS ===
E       AssertionError: Expected robot_state_publisher's virtual_rail_link_2 as the sole TF parent of ridgeback_base_link, saw parents: ['base_platform', 'odom', 'virtual_rail_link_2']
================= 1 failed, 67 deselected, 1 warning in 33.97s =================

=== 2. this branch, on the v9.4 + moveit_pro#20258 backport image -> PASSES ===
================= 1 passed, 67 deselected, 1 warning in 32.68s =================

=== 3. this branch, on the published v9.4 image (no base_link_name in core) -> FAILS ===
E       AssertionError: Expected robot_state_publisher's virtual_rail_link_2 as the sole TF parent of ridgeback_base_link, saw parents: ['base_platform', 'virtual_rail_link_2']
================= 1 failed, 67 deselected, 1 warning in 25.36s =================

=== 4. base-motion regression: objective 'Solution - Move Forward 2m' on the v9.4 + moveit_pro#20258 image ===
src/hangar_sim/test/objectives_integration_test.py::test_all_objectives[/tmp/cinstall/hangar_sim/share/hangar_sim/objectives/solution_move_forward_2m.xml]
================= 1 passed, 67 deselected, 1 warning in 30.99s =================
```
</details>
<details>
<summary>Evidence: use_fuse:=true launch behaviour before/after the removed guard</summary>

```text
hangar_sim sim driver-persist launch, use_fuse:=true, with the shipped publish_odom: true
Image: picknikciuser/moveit-studio:v9.4-jazzy-amd64-cuda13.2-cudnn9
The base commit carried an OpaqueFunction guard that shut the launch down in this combination;
this branch removes it (fuse no longer owns the odom -> ridgeback_base_link edge).

=== base commit ===
[INFO] [launch.user]: use_fuse:=true but MuJoCo is still configured to publish odom -> ridgeback_base_link.
                      When fuse is enabled, fuse must be the sole publisher of that TF edge. Set
                      'publish_odom: false' in config.yaml under hardware.robot_description.urdf_params,
                      then rebuild hangar_sim.
[BEFORE] launch still running after 45 s: False
[BEFORE] launch exited early, return code: 1

=== this branch ===
[AFTER] launch still running after 45 s: True
[AFTER] nav2 stack + static_tf_odom_to_world / static_tf_map_to_odom / static_tf_world_to_map all up

NOTE: fuse's own publish_tf:false could not be exercised live -- ros-jazzy-fuse_optimizers in this
container aborts with an undefined diagnostic_updater symbol (apt/image ABI mismatch), unrelated to
this change. use_fuse defaults to false, so CI does not launch fuse either.
```
</details>
<details>
<summary>Evidence: Resolved map-&gt;ridgeback_base_link samples (100 Hz, 20 s) before the fix</summary>

```text
t,x,y,z
0.0052,-0.057624,-0.017205,-0.048000
0.0106,-0.058926,-0.017180,-0.048000
0.0161,-0.058926,-0.017180,-0.048000
0.0214,-0.058926,-0.017180,-0.048000
0.0268,-0.058926,-0.017180,-0.048000
0.0322,-0.058926,-0.017180,-0.048000
0.0376,-0.058926,-0.017180,-0.048000
0.0429,-0.058926,-0.017180,-0.048000
0.0484,-0.058926,-0.017180,-0.048000
0.0537,-0.058926,-0.017180,-0.048000
0.0590,-0.058926,-0.017180,-0.048000
0.0643,-0.058926,-0.017180,-0.048000
0.0696,-0.058926,-0.017180,-0.048000
0.0751,-0.058926,-0.017180,-0.048000
0.0810,-0.058926,-0.017180,-0.048000
0.0866,-0.058926,-0.017180,-0.048000
0.0921,-0.058926,-0.017180,-0.048000
0.0977,-0.058926,-0.017180,-0.048000
0.1033,-0.058926,-0.017180,-0.048000
0.1088,-0.058926,-0.017180,-0.048000
0.1147,-0.058926,-0.017180,-0.048000
0.1203,-0.058926,-0.017180,-0.048000
0.1263,-0.058926,-0.017180,-0.048000
0.1326,-0.058926,-0.017180,-0.048000
0.1382,-0.058926,-0.017180,-0.048000
0.1436,-0.058926,-0.017180,-0.048000
0.1491,-0.058926,-0.017180,-0.048000
0.1546,-0.058926,-0.017180,-0.048000
0.1601,-0.058926,-0.017180,-0.048000
0.1659,-0.058926,-0.017180,-0.048000
0.1715,-0.058926,-0.017180,-0.048000
0.1771,-0.058926,-0.017180,-0.048000
0.1831,-0.058926,-0.017180,-0.048000
0.1886,-0.058926,-0.017180,-0.048000
0.1942,-0.058926,-0.017180,-0.048000
0.1999,-0.058926,-0.017180,-0.048000
0.2054,-0.058926,-0.017180,-0.048000
0.2109,-0.058926,-0.017180,-0.048000
0.2164,-0.058926,-0.017180,-0.048000
0.2219,-0.058926,-0.017180,-0.048000
0.2272,-0.058926,-0.017180,-0.048000
0.2330,-0.058926,-0.017180,-0.048000
0.2384,-0.058926,-0.017180,-0.048000
0.2439,-0.058926,-0.017180,-0.048000
0.2494,-0.058926,-0.017180,-0.048000
0.2549,-0.058926,-0.017180,-0.048000
0.2603,-0.058926,-0.017180,-0.048000
0.2657,-0.058926,-0.017180,-0.048000
0.2714,-0.058926,-0.017180,-0.048000
0.2771,-0.058926,-0.017180,-0.048000
0.2833,-0.058926,-0.017180,-0.048000
0.2888,-0.058926,-0.017180,-0.048000
0.2942,-0.058926,-0.017180,-0.048000
0.2997,-0.058926,-0.017180,-0.048000
0.3050,-0.058926,-0.017180,-0.048000
0.3104,-0.058926,-0.017180,-0.048000
0.3158,-0.058926,-0.017180,-0.048000
0.3212,-0.058926,-0.017180,-0.048000
0.3269,-0.058926,-0.017180,-0.048000
0.3330,-0.058926,-0.017180,-0.048000
0.3387,-0.058926,-0.017180,-0.048000
0.3443,-0.058926,-0.017180,-0.048000
0.3498,-0.058926,-0.017180,-0.048000
0.3552,-0.058926,-0.017180,-0.048000
0.3606,-0.058926,-0.017180,-0.048000
0.3661,-0.058926,-0.017180,-0.048000
0.3720,-0.058926,-0.017180,-0.048000
0.3782,-0.058926,-0.017180,-0.048000
0.3844,-0.058926,-0.017180,-0.048000
0.3898,-0.058926,-0.017180,-0.048000
0.3952,-0.058926,-0.017180,-0.048000
0.4005,-0.058926,-0.017180,-0.048000
0.4058,-0.058926,-0.017180,-0.048000
0.4111,-0.058926,-0.017180,-0.048000
0.4166,-0.058926,-0.017180,-0.048000
0.4223,-0.058926,-0.017180,-0.048000
0.4280,-0.058926,-0.017180,-0.048000
0.4336,-0.058926,-0.017180,-0.048000
0.4391,-0.058926,-0.017180,-0.048000
0.4446,-0.058926,-0.017180,-0.048000
0.4502,-0.058926,-0.017180,-0.048000
0.4556,-0.058926,-0.017180,-0.048000
0.4613,-0.058926,-0.017180,-0.048000
0.4668,-0.058926,-0.017180,-0.048000
0.4725,-0.058926,-0.017180,-0.048000
0.4786,-0.058926,-0.017180,-0.048000
0.4848,-0.058926,-0.017180,-0.048000
0.4903,-0.058926,-0.017180,-0.048000
0.4958,-0.058926,-0.017180,-0.048000
0.5011,-0.058926,-0.017180,-0.048000
0.5064,-0.070281,-0.016865,-0.048000
0.5117,-0.070281,-0.016865,-0.048000
0.5170,-0.070281,-0.016865,-0.048000
0.5227,-0.070357,-0.016856,-0.048000
0.5286,-0.070357,-0.016856,-0.048000
0.5342,-0.070357,-0.016856,-0.048000
0.5397,-0.070357,-0.016856,-0.048000
0.5451,-0.070357,-0.016856,-0.048000
0.5504,-0.070357,-0.016856,-0.048000
0.5558,-0.070357,-0.016856,-0.048000
0.5611,-0.070357,-0.016856,-0.048000
0.5666,-0.070357,-0.016856,-0.048000
0.5725,-0.070357,-0.016856,-0.048000
0.5789,-0.070357,-0.016856,-0.048000
0.5851,-0.070357,-0.016856,-0.048000
0.5906,-0.070357,-0.016856,-0.048000
0.5962,-0.070357,-0.016856,-0.048000
0.6016,-0.070357,-0.016856,-0.048000
0.6070,-0.070455,-0.016780,-0.048000
0.6125,-0.070455,-0.016780,-0.048000
0.6178,-0.070455,-0.016780,-0.048000
0.6234,-0.070475,-0.016765,-0.048000
0.6296,-0.070475,-0.016765,-0.048000
0.6354,-0.070475,-0.016765,-0.048000
0.6408,-0.070475,-0.016765,-0.048000
0.6463,-0.070475,-0.016765,-0.048000
0.6518,-0.070475,-0.016765,-0.048000
0.6572,-0.070475,-0.016765,-0.048000
0.6627,-0.070475,-0.016765,-0.048000
0.6682,-0.070475,-0.016765,-0.048000
0.6740,-0.070475,-0.016765,-0.048000
0.6802,-0.070475,-0.016765,-0.048000
0.6859,-0.070475,-0.016765,-0.048000
0.6915,-0.070475,-0.016765,-0.048000
0.6969,-0.070475,-0.016765,-0.048000
0.7022,-0.070475,-0.016765,-0.048000
0.7076,-0.070475,-0.016765,-0.048000
0.7133,-0.070475,-0.016765,-0.048000
0.7188,-0.070475,-0.016765,-0.048000
0.7246,-0.070475,-0.016765,-0.048000
0.7309,-0.070475,-0.016765,-0.048000
0.7365,-0.070475,-0.016765,-0.048000
0.7420,-0.070475,-0.016765,-0.048000
0.7474,-0.070475,-0.016765,-0.048000
0.7528,-0.070475,-0.016765,-0.048000
0.7581,-0.070475,-0.016765,-0.048000
0.7635,-0.070475,-0.016765,-0.048000
0.7687,-0.070475,-0.016765,-0.048000
0.7748,-0.070475,-0.016765,-0.048000
0.7811,-0.070475,-0.016765,-0.048000
0.7866,-0.070475,-0.016765,-0.048000
0.7920,-0.070475,-0.016765,-0.048000
0.7975,-0.070475,-0.016765,-0.048000
0.8030,-0.070475,-0.016765,-0.048000
0.8083,-0.070475,-0.016765,-0.048000
0.8137,-0.070475,-0.016765,-0.048000
0.8192,-0.070475,-0.016765,-0.048000
0.8249,-0.070475,-0.016765,-0.048000
0.8306,-0.070475,-0.016765,-0.048000
0.8361,-0.070475,-0.016765,-0.048000
0.8415,-0.070475,-0.016765,-0.048000
0.8473,-0.070475,-0.016765,-0.048000
0.8528,-0.070475,-0.016765,-0.048000
0.8582,-0.070475,-0.016765,-0.048000
0.8638,-0.070475,-0.016765,-0.048000
0.8693,-0.070475,-0.016765,-0.048000
0.8751,-0.070475,-0.016765,-0.048000
0.8813,-0.070475,-0.016765,-0.048000
0.8869,-0.070475,-0.016765,-0.048000
0.8924,-0.070475,-0.016765,-0.048000
0.8980,-0.070475,-0.016765,-0.048000
0.9034,-0.070475,-0.016765,-0.048000
0.9088,-0.070475,-0.016765,-0.048000
0.9144,-0.070475,-0.016765,-0.048000
0.9199,-0.070475,-0.016765,-0.048000
0.9257,-0.070475,-0.016765,-0.048000
0.9313,-0.070475,-0.016765,-0.048000
0.9369,-0.070475,-0.016765,-0.048000
0.9424,-0.070475,-0.016765,-0.048000
0.9479,-0.070475,-0.016765,-0.048000
0.9533,-0.070475,-0.016765,-0.048000
0.9587,-0.070475,-0.016765,-0.048000
0.9643,-0.070475,-0.016765,-0.048000
0.9697,-0.070475,-0.016765,-0.048000
0.9755,-0.070475,-0.016765,-0.048000
0.9814,-0.070475,-0.016765,-0.048000
0.9869,-0.070475,-0.016765,-0.048000
0.9924,-0.070475,-0.016765,-0.048000
0.9980,-0.070475,-0.016765,-0.048000
1.0034,-0.070475,-0.016765,-0.048000
1.0088,-0.070475,-0.016765,-0.048000
1.0143,-0.070475,-0.016765,-0.048000
1.0198,-0.070475,-0.016765,-0.048000
1.0252,-0.070475,-0.016765,-0.048000
1.0307,-0.070475,-0.016765,-0.048000
1.0361,-0.070475,-0.016765,-0.048000
1.0415,-0.070475,-0.016765,-0.048000
1.0468,-0.070475,-0.016765,-0.048000
1.0520,-0.070475,-0.016765,-0.048000
1.0573,-0.070813,-0.016608,-0.048000
1.0626,-0.070813,-0.016608,-0.048000
1.0679,-0.070813,-0.016608,-0.048000
1.0732,-0.070813,-0.016608,-0.048000
1.0791,-0.070813,-0.016608,-0.048000
1.0850,-0.070813,-0.016608,-0.048000
1.0904,-0.070813,-0.016608,-0.048000
1.0959,-0.070813,-0.016608,-0.048000
1.1013,-0.070813,-0.016608,-0.048000
1.1066,-0.070834,-0.016604,-0.048000
1.1120,-0.070834,-0.016604,-0.048000
1.1174,-0.070834,-0.016604,-0.048000
1.1228,-0.070845,-0.016602,-0.048000
1.1282,-0.070845,-0.016602,-0.048000
1.1336,-0.070845,-0.016602,-0.048000
1.1390,-0.070845,-0.016602,-0.048000
1.1443,-0.070845,-0.016602,-0.048000
1.1496,-0.070845,-0.016602,-0.048000
1.1549,-0.070845,-0.016602,-0.048000
1.1602,-0.070845,-0.016602,-0.048000
1.1655,-0.070845,-0.016602,-0.048000
1.1708,-0.070845,-0.016602,-0.048000
1.1762,-0.070845,-0.016602,-0.048000
1.1821,-0.070845,-0.016602,-0.048000
1.1875,-0.070845,-0.016602,-0.048000
1.1928,-0.070845,-0.016602,-0.048000
1.1982,-0.070845,-0.016602,-0.048000
1.2035,-0.070845,-0.016602,-0.048000
1.2088,-0.070845,-0.016602,-0.048000
1.2141,-0.070845,-0.016602,-0.048000
1.2194,-0.070845,-0.016602,-0.048000
1.2247,-0.070845,-0.016602,-0.048000
1.2300,

... [119695 bytes truncated] ...

4,-0.015693,-0.048000
18.7678,-0.074824,-0.015693,-0.048000
18.7730,-0.074824,-0.015693,-0.048000
18.7784,-0.074824,-0.015693,-0.048000
18.7840,-0.074824,-0.015693,-0.048000
18.7894,-0.074824,-0.015693,-0.048000
18.7947,-0.074824,-0.015693,-0.048000
18.8001,-0.074824,-0.015693,-0.048000
18.8054,-0.074898,-0.015644,-0.048000
18.8108,-0.074898,-0.015644,-0.048000
18.8162,-0.074898,-0.015644,-0.048000
18.8216,-0.074901,-0.015642,-0.048000
18.8270,-0.074901,-0.015642,-0.048000
18.8324,-0.074901,-0.015642,-0.048000
18.8378,-0.074901,-0.015642,-0.048000
18.8433,-0.074901,-0.015642,-0.048000
18.8489,-0.074901,-0.015642,-0.048000
18.8548,-0.074901,-0.015642,-0.048000
18.8605,-0.074901,-0.015642,-0.048000
18.8660,-0.074901,-0.015642,-0.048000
18.8719,-0.074901,-0.015642,-0.048000
18.8784,-0.074901,-0.015642,-0.048000
18.8849,-0.074901,-0.015642,-0.048000
18.8913,-0.074901,-0.015642,-0.048000
18.8984,-0.074901,-0.015642,-0.048000
18.9047,-0.074901,-0.015642,-0.048000
18.9114,-0.074901,-0.015642,-0.048000
18.9175,-0.074901,-0.015642,-0.048000
18.9240,-0.074901,-0.015642,-0.048000
18.9307,-0.074901,-0.015642,-0.048000
18.9370,-0.074901,-0.015642,-0.048000
18.9430,-0.074901,-0.015642,-0.048000
18.9493,-0.074901,-0.015642,-0.048000
18.9552,-0.074901,-0.015642,-0.048000
18.9606,-0.074901,-0.015642,-0.048000
18.9663,-0.074901,-0.015642,-0.048000
18.9719,-0.074901,-0.015642,-0.048000
18.9774,-0.074901,-0.015642,-0.048000
18.9830,-0.074901,-0.015642,-0.048000
18.9883,-0.074901,-0.015642,-0.048000
18.9937,-0.074901,-0.015642,-0.048000
18.9990,-0.074901,-0.015642,-0.048000
19.0043,-0.074901,-0.015642,-0.048000
19.0096,-0.074901,-0.015642,-0.048000
19.0150,-0.074901,-0.015642,-0.048000
19.0203,-0.074901,-0.015642,-0.048000
19.0257,-0.074901,-0.015642,-0.048000
19.0315,-0.074901,-0.015642,-0.048000
19.0370,-0.074901,-0.015642,-0.048000
19.0427,-0.074901,-0.015642,-0.048000
19.0481,-0.074901,-0.015642,-0.048000
19.0534,-0.074901,-0.015642,-0.048000
19.0587,-0.074901,-0.015642,-0.048000
19.0641,-0.074901,-0.015642,-0.048000
19.0695,-0.074901,-0.015642,-0.048000
19.0750,-0.074901,-0.015642,-0.048000
19.0807,-0.074901,-0.015642,-0.048000
19.0868,-0.074901,-0.015642,-0.048000
19.0925,-0.074901,-0.015642,-0.048000
19.0981,-0.074901,-0.015642,-0.048000
19.1037,-0.074901,-0.015642,-0.048000
19.1092,-0.074901,-0.015642,-0.048000
19.1148,-0.074901,-0.015642,-0.048000
19.1203,-0.074901,-0.015642,-0.048000
19.1262,-0.074901,-0.015642,-0.048000
19.1321,-0.074901,-0.015642,-0.048000
19.1376,-0.074901,-0.015642,-0.048000
19.1430,-0.074901,-0.015642,-0.048000
19.1486,-0.074901,-0.015642,-0.048000
19.1539,-0.074901,-0.015642,-0.048000
19.1592,-0.074901,-0.015642,-0.048000
19.1651,-0.074901,-0.015642,-0.048000
19.1707,-0.074901,-0.015642,-0.048000
19.1765,-0.074901,-0.015642,-0.048000
19.1824,-0.074901,-0.015642,-0.048000
19.1881,-0.074901,-0.015642,-0.048000
19.1937,-0.074901,-0.015642,-0.048000
19.1994,-0.074901,-0.015642,-0.048000
19.2064,-0.074959,-0.015603,-0.048000
19.2133,-0.074959,-0.015603,-0.048000
19.2189,-0.074962,-0.015601,-0.048000
19.2249,-0.074962,-0.015601,-0.048000
19.2306,-0.074962,-0.015601,-0.048000
19.2363,-0.074962,-0.015601,-0.048000
19.2420,-0.074962,-0.015601,-0.048000
19.2478,-0.074962,-0.015601,-0.048000
19.2539,-0.074962,-0.015601,-0.048000
19.2595,-0.074962,-0.015601,-0.048000
19.2651,-0.074962,-0.015601,-0.048000
19.2705,-0.074962,-0.015601,-0.048000
19.2761,-0.074962,-0.015601,-0.048000
19.2824,-0.074962,-0.015601,-0.048000
19.2887,-0.074962,-0.015601,-0.048000
19.2948,-0.074962,-0.015601,-0.048000
19.3004,-0.074962,-0.015601,-0.048000
19.3058,-0.074962,-0.015601,-0.048000
19.3120,-0.074962,-0.015601,-0.048000
19.3175,-0.074962,-0.015601,-0.048000
19.3234,-0.074962,-0.015601,-0.048000
19.3295,-0.074962,-0.015601,-0.048000
19.3350,-0.074962,-0.015601,-0.048000
19.3405,-0.074962,-0.015601,-0.048000
19.3462,-0.074962,-0.015601,-0.048000
19.3516,-0.074962,-0.015601,-0.048000
19.3570,-0.074962,-0.015601,-0.048000
19.3630,-0.074962,-0.015601,-0.048000
19.3692,-0.074962,-0.015601,-0.048000
19.3749,-0.074962,-0.015601,-0.048000
19.3812,-0.074962,-0.015601,-0.048000
19.3872,-0.074962,-0.015601,-0.048000
19.3928,-0.074962,-0.015601,-0.048000
19.3986,-0.074962,-0.015601,-0.048000
19.4042,-0.074962,-0.015601,-0.048000
19.4096,-0.074962,-0.015601,-0.048000
19.4150,-0.074962,-0.015601,-0.048000
19.4206,-0.074962,-0.015601,-0.048000
19.4264,-0.074962,-0.015601,-0.048000
19.4322,-0.074962,-0.015601,-0.048000
19.4381,-0.074962,-0.015601,-0.048000
19.4437,-0.074962,-0.015601,-0.048000
19.4491,-0.074962,-0.015601,-0.048000
19.4547,-0.074962,-0.015601,-0.048000
19.4601,-0.074962,-0.015601,-0.048000
19.4656,-0.074962,-0.015601,-0.048000
19.4716,-0.074962,-0.015601,-0.048000
19.4779,-0.074962,-0.015601,-0.048000
19.4842,-0.074962,-0.015601,-0.048000
19.4898,-0.074962,-0.015601,-0.048000
19.4955,-0.074962,-0.015601,-0.048000
19.5009,-0.074962,-0.015601,-0.048000
19.5062,-0.074962,-0.015601,-0.048000
19.5134,-0.074962,-0.015601,-0.048000
19.5189,-0.074962,-0.015601,-0.048000
19.5249,-0.074962,-0.015601,-0.048000
19.5315,-0.074962,-0.015601,-0.048000
19.5371,-0.074962,-0.015601,-0.048000
19.5428,-0.074962,-0.015601,-0.048000
19.5483,-0.074962,-0.015601,-0.048000
19.5538,-0.074962,-0.015601,-0.048000
19.5592,-0.074962,-0.015601,-0.048000
19.5650,-0.074962,-0.015601,-0.048000
19.5706,-0.074962,-0.015601,-0.048000
19.5775,-0.074962,-0.015601,-0.048000
19.5842,-0.074962,-0.015601,-0.048000
19.5904,-0.074962,-0.015601,-0.048000
19.5963,-0.074962,-0.015601,-0.048000
19.6018,-0.074962,-0.015601,-0.048000
19.6073,-0.074962,-0.015601,-0.048000
19.6131,-0.074962,-0.015601,-0.048000
19.6184,-0.074962,-0.015601,-0.048000
19.6237,-0.074962,-0.015601,-0.048000
19.6292,-0.074962,-0.015601,-0.048000
19.6349,-0.074962,-0.015601,-0.048000
19.6404,-0.074962,-0.015601,-0.048000
19.6464,-0.074962,-0.015601,-0.048000
19.6520,-0.074962,-0.015601,-0.048000
19.6573,-0.074962,-0.015601,-0.048000
19.6626,-0.074962,-0.015601,-0.048000
19.6681,-0.074962,-0.015601,-0.048000
19.6738,-0.074962,-0.015601,-0.048000
19.6800,-0.074962,-0.015601,-0.048000
19.6863,-0.074962,-0.015601,-0.048000
19.6930,-0.074962,-0.015601,-0.048000
19.6990,-0.074962,-0.015601,-0.048000
19.7047,-0.074962,-0.015601,-0.048000
19.7104,-0.074962,-0.015601,-0.048000
19.7164,-0.074962,-0.015601,-0.048000
19.7225,-0.074962,-0.015601,-0.048000
19.7286,-0.074962,-0.015601,-0.048000
19.7347,-0.074962,-0.015601,-0.048000
19.7406,-0.074962,-0.015601,-0.048000
19.7465,-0.074962,-0.015601,-0.048000
19.7525,-0.074962,-0.015601,-0.048000
19.7581,-0.074962,-0.015601,-0.048000
19.7636,-0.074962,-0.015601,-0.048000
19.7691,-0.074962,-0.015601,-0.048000
19.7752,-0.074962,-0.015601,-0.048000
19.7809,-0.074962,-0.015601,-0.048000
19.7866,-0.074962,-0.015601,-0.048000
19.7924,-0.074962,-0.015601,-0.048000
19.7980,-0.074962,-0.015601,-0.048000
19.8034,-0.074962,-0.015601,-0.048000
19.8088,-0.074962,-0.015601,-0.048000
19.8142,-0.074962,-0.015601,-0.048000
19.8197,-0.074962,-0.015601,-0.048000
19.8254,-0.074962,-0.015601,-0.048000
19.8316,-0.074962,-0.015601,-0.048000
19.8388,-0.074962,-0.015601,-0.048000
19.8445,-0.074962,-0.015601,-0.048000
19.8503,-0.074962,-0.015601,-0.048000
19.8557,-0.074962,-0.015601,-0.048000
19.8614,-0.074962,-0.015601,-0.048000
19.8668,-0.074962,-0.015601,-0.048000
19.8727,-0.075063,-0.015532,-0.048000
19.8790,-0.075063,-0.015532,-0.048000
19.8849,-0.075065,-0.015530,-0.048000
19.8904,-0.075065,-0.015530,-0.048000
19.8961,-0.075065,-0.015530,-0.048000
19.9017,-0.075065,-0.015530,-0.048000
19.9071,-0.075065,-0.015530,-0.048000
19.9127,-0.075065,-0.015530,-0.048000
19.9180,-0.075065,-0.015530,-0.048000
19.9239,-0.075065,-0.015530,-0.048000
19.9301,-0.075065,-0.015530,-0.048000
19.9357,-0.075065,-0.015530,-0.048000
19.9414,-0.075065,-0.015530,-0.048000
19.9469,-0.075065,-0.015530,-0.048000
19.9524,-0.075065,-0.015530,-0.048000
19.9578,-0.075065,-0.015530,-0.048000
19.9634,-0.075065,-0.015530,-0.048000
19.9694,-0.075065,-0.015530,-0.048000
19.9753,-0.075065,-0.015530,-0.048000
19.9818,-0.075065,-0.015530,-0.048000
19.9878,-0.075065,-0.015530,-0.048000
19.9938,-0.075065,-0.015530,-0.048000
19.9993,-0.075065,-0.015530,-0.048000
```
</details>
- Evidence: Resolved map-&gt;ridgeback_base_link samples (100 Hz, 20 s) after the fix (local file: <code>/home/griswald/.no-mistakes/evidence/01M0DVX1N2R1XPSRCY17NWDGZR/base_z_after.csv</code>)
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (41m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bb8a034efcc70b9d0d042ad9108cbcfb7ef01f7e","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"skipped"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `.github/workflows/ci.yaml` - merge conflict rebasing onto origin/main

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md:841` - The rewritten TF-ownership doc asserts that beluga_amcl publishes a dynamic map-&gt;odom and that the static fallback is suppressed under `localization:=True` (&#34;the default&#34;). Neither exists in this config: `localization_launch.py` starts only `map_server` (AMCL is commented out at line 148), `nav2_params.yaml:1` states &#34;amcl is not used&#34;, there is no `localization` launch argument, and `static_tf_map_to_odom` is gated solely on `not slam` with `slam` defaulting to False (robot_drivers_to_persist_sim.launch.py:130, 276). So map-&gt;odom is always the static identity in the shipped config. Same claim repeats at lines 807 and 876, and the rationale comment at robot_drivers_to_persist_sim.launch.py:284 justifies the re-parenting with &#34;AMCL&#39;s live map-&gt;odom correction&#34; for a node that is never launched. This is the reference doc for exactly the TF-ownership question this change exists to settle, so a reader debugging a future frame conflict will look for a nonexistent publisher.
- ⚠️ `src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py:290` - Re-parenting MoveIt&#39;s planning root `world` under `odom` also moves the static environment, not just the robot. `ur5e_ridgeback.xacro:38` attaches `xacro:hangar_urdf parent=&#34;world&#34;`, i.e. the whole building (floor `collision_SM_Floor_376`, pillars, walls, the plane) is rigidly under `world`, which is now under `odom`. Concrete trace: launch with `slam:=True` -&gt; `static_tf_map_to_odom` is skipped (line 276 condition `not slam`) -&gt; slam_toolbox publishes a non-identity correction C on map-&gt;odom -&gt; TF `map -&gt; collision_SM_Floor_376` becomes C * (world-&gt;floor), so the hangar itself translates in the map frame every time localization corrects. The doc claim at NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md:841 that the correction &#34;shifts the entire robot subtree ... exactly the REP-105 localization semantics&#34; is therefore only half true: REP-105 puts the robot under `odom`, not the fixed world model. Second consequence of the same edge: in slam mode nothing publishes map-&gt;odom at startup, so the robot AND environment subtree is now a disconnected TF root until slam_toolbox comes up, where previously `world` was rooted at `mj_world` and `world-&gt;map` always resolved. Not reachable in the shipped default (slam=False, no AMCL, map-&gt;odom identity), so this is a follow-up rather than a merge blocker; the durable shape is to keep the fixed environment anchored above `odom` (e.g. under `map`/`mj_world`) and put only the robot chain beneath it.
- ℹ️ `src/hangar_sim/description/ur5e_ridgeback.xacro:85` - The -48 mm virtual-rail origin correctly re-aligns robot_state_publisher with the physics, but it also shifts every world-frame geometric relationship that was tuned against the old (wrong) model. Two concrete spots: (a) the raster/surface objectives hardcode world-frame crop ROIs, e.g. raster_path_along_fuselage.xml:62 `position_xyz=&#34;0;12;1.7&#34;` with `crop_box_size=&#34;5;15;0.2&#34;` — the wrist-camera cloud now lands 48 mm lower in `world`, which is 48% of that slice&#39;s half-thickness, so slice membership shifts even though nothing errors; (b) the SRDF ACM was generated with the base at world z=0, and `wrist_2_link`, `wrist_3_link`, `wrist_3_pinch_link`, `vacuum_base`, `vacuum_base_top`, `vacuum_suction_cups` are the only robot links with no `collision_SM_Floor_376` disable pair, so any reach that previously cleared the floor by under 48 mm now plans as in-collision. The integration suite runs these objectives unskipped, so CI does exercise it — flagging so a failure there is read as this shift rather than a flake.
- ℹ️ `src/hangar_sim/config/fuse/fuse.yaml:95` - With `publish_tf: false`, fuse&#39;s only remaining output in hangar_sim is `odom_filtered`, and nothing in this package subscribes to it (the only `odom_filtered` consumers are in `moveit_pro_kinova_configs/space_satellite_sim`). Combined with `use_fuse` defaulting to &#34;false&#34; (robot_drivers_to_persist_sim.launch.py:185), the entire fuse node, its config, and the RELIABLE-QoS relay path that exists to feed it are now dead weight in this config. Either wire the estimate somewhere (the yaml comment suggests the virtual-rail joint-state bridge) or drop the fuse node and its config from hangar_sim.
- ℹ️ `Dockerfile:28` - `userdel -r ubuntu` returns exit code 12 (&#34;can&#39;t remove home directory or mail spool&#34;) when /home/ubuntu or /var/mail/ubuntu is absent, which fails the RUN and breaks the image build. That is reachable on any 24.04-derived base image where the `ubuntu` account exists but its home has already been pruned — exactly the images where the `id -u ubuntu` guard passes. Falling back (`userdel -r ubuntu || userdel ubuntu`) keeps the UID freed without making a missing home fatal.

🔧 Fix: Correct fabricated AMCL doc claims; guard userdel exit code
2 infos still open:
- ℹ️ `Dockerfile:28` - The fix-round fallback `userdel -r ubuntu || userdel ubuntu` cannot succeed in the scenario it targets. Per `man userdel`, exit 12 is specifically &#34;can&#39;t remove home directory&#34; while exits 1 and 10 cover &#34;can&#39;t update password file&#34; / &#34;can&#39;t update group file&#34; — so a 12 implies the passwd/shadow/group entries were already committed and only the home/mail-spool removal failed. Concrete trace: base image has `ubuntu` with an unremovable /home/ubuntu (bind mount, immutable file) -&gt; `id -u ubuntu` passes -&gt; `userdel -r ubuntu` removes the account, fails on the directory, exits 12 -&gt; fallback `userdel ubuntu` runs against a now-nonexistent user, exits 6 -&gt; the `RUN` fails exactly as before. Every other non-zero exit (1 can&#39;t-update-passwd, 8 user-logged-in, 10 can&#39;t-update-group) reproduces identically on the second invocation, so no exit code reaches the fallback and succeeds. The fallback reads as a guard but is dead. To actually free UID/GID 1000 without making a failed home removal fatal, tolerate the specific code: `userdel -r ubuntu || [ $? -eq 12 ]` (or `|| true`, which still fails loudly later at `useradd --uid $USER_UID` if the UID was never freed).
- ℹ️ `src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md:797` - The `Transform Tree Configuration` block is presented as a verbatim quote of `robot_drivers_to_persist_sim.launch.py:256-272`, but it does not match the file and the line range is stale (the actual node definitions span lines 260-297). Most materially, the quoted `static_tf_map_to_odom` at line 808-812 omits `condition=IfCondition(PythonExpression([&#34;not &#34;, slam]))` — the single line that decides whether the static fallback is published at all, which is the exact subject of the paragraph two sections below (line 841) that the fix round just rewrote. It also omits `name=` and `output=` on all three nodes. Separately, the comment this change introduced at line 807 (&#34;only used when neither SLAM nor AMCL is publishing it&#34;) is the last surviving AMCL reference in the doc after the fix round corrected lines 841 and 878; on v9.4 nothing can put AMCL in that position, so the accurate wording is &#34;only used when SLAM is not publishing it&#34;. A reader who trusts the block as source will conclude the fallback is unconditional. Fix: correct the line range to 260-297, add the `condition=` argument to the quoted `static_tf_map_to_odom`, and drop &#34;nor AMCL&#34; from the comment.

</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro:41` - On the currently published MoveIt Pro v9.4 image (picknikciuser/moveit-studio:v9.4-jazzy-amd64-cuda13.2-cudnn9), the branch&#39;s new test `test_base_link_has_single_tf_parent` FAILS: `saw parents: [&#39;base_platform&#39;, &#39;virtual_rail_link_2&#39;]`. The `base_link_name` hardware parameter this change relies on does not exist in that core (verified: the symbol is present in `libmujoco_hw_interface.so` on `main-jazzy-amd64` and on `backport_20258-mujoco-base-link-name-v9.4-...`, absent on `v9.4-jazzy-amd64-cuda13.2-cudnn9`), so it is silently ignored and MuJoCo&#39;s lidar fill-in chain keeps publishing `base_platform -&gt; ridgeback_base_link`. The same test PASSES on the paired backport image. This matches the PR&#39;s own Dependency section, but it means the `hangar_sim` integration-test job will stay red until moveit_pro#20258 is backported to v9.4 and the v9.4 images are republished (or until CI is dispatched with that image_ref). Merge ordering is your call.
- ℹ️ `src/hangar_sim/config/fuse/fuse.yaml:93` - fuse&#39;s `publish_tf: false` could not be exercised live: `ros-jazzy-fuse-optimizers` in the test container aborts at startup with an undefined `diagnostic_updater::Updater` symbol (apt/image ABI mismatch), unrelated to this change. `use_fuse` defaults to false so CI never launches fuse either; the launch-file half of that change (removal of the OpaqueFunction guard that aborted bring-up on `use_fuse:=true` + `publish_odom: true`) was verified live instead.
- <code>`python3 -m pytest src/hangar_sim/test/objectives_integration_test.py -k base_link_has_single_tf_parent -v` on image `backport_20258-mujoco-base-link-name-v9.4-jazzy-amd64-cuda13.2-cudnn9` with this branch&#39;s hangar_sim — PASSED</code>
- <code>Same test, same image, with base-commit (6c51424) `ur5e_ridgeback.xacro` / `picknik_ur_mujoco_ros2_control.xacro` / `config.yaml` / `fuse.yaml` / sim persist launch staged ahead of the built package — FAILED with `saw parents: [&#39;base_platform&#39;, &#39;odom&#39;, &#39;virtual_rail_link_2&#39;]` (fail-before/pass-after)</code>
- <code>Same test on the published `v9.4-jazzy-amd64-cuda13.2-cudnn9` image with this branch — FAILED with `saw parents: [&#39;base_platform&#39;, &#39;virtual_rail_link_2&#39;]` (documented moveit_pro#20258 dependency)</code>
- <code>`python3 -m pytest src/hangar_sim/test/objectives_integration_test.py -k move_forward -v` (objective `Solution - Move Forward 2m`, full backend, base motion through the re-anchored frame chain) — PASSED</code>
- <code>Live TF parent census: `ros2_control_node` with `picknik_mujoco_ros/MujocoSystem` + `joint_state_broadcaster` + `robot_state_publisher` + the launch file&#39;s `static_transform_publisher` nodes, counting every `/tf` message with `child_frame_id == ridgeback_base_link` over 30 s — before: 3 parents, after: 1 parent (run on v9.4+backport, published v9.4, and main images)</code>
- <code>URDF-vs-physics FK cross-check: robot_state_publisher fed the `hangar_scene.xml` keyframe rail joint values, `lookup_transform(world, ridgeback_base_link)` compared against `mujoco.mj_forward` body xpos — before 48 mm z error, after exact match at z = -0.048</code>
- <code>`/odom` `pose.position.z` sampled over the same runs to exercise `odom_planar` (replacing the silently-ignored `odom_zero_z`) — before max |z| = 0.048, after 0.000</code>
- <code>`LaunchService` running `hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py` with `use_fuse:=true` and the shipped `publish_odom: true` — base commit exits rc=1 via the OpaqueFunction guard, this branch stays up with the nav2 stack and `static_tf_odom_to_world` running</code>
- <code>100 Hz sampling of the transform a consumer resolves (`lookup_transform(map, ridgeback_base_link)`) for 20 s — before: both 0.000 and -0.048 observed; after: constant -0.048</code>
- <code>`strings libmujoco_hw_interface.so | grep -x base_link_name` across the three MoveIt Pro images to confirm which cores define the parameter</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `src/hangar_sim/docs/NAV2_AND_WHOLE_BODY_PLANNING_ARCHITECTURE.md:848` - The v9.4 architecture doc carries an inline note (&#34;this section diverges from the same doc on `main` (PR #756), which describes a beluga_amcl-driven map → odom&#34;) added by the prior review commit. It is accurate today but is branch/PR narrative embedded in reference prose and will rot once the branches converge. Judgment call left to the author: keep it as a deliberate backport-divergence marker, or drop it and let the doc simply describe what runs here.
- ℹ️ `src/hangar_sim/script/odometry_joint_state_publisher.py:1` - Out-of-scope follow-up: `src/hangar_sim/script/odometry_joint_state_publisher.py` is installed by CMakeLists.txt but instantiated by no launch file (true at the base commit too). This pass corrected the doc to describe it as the hardware pattern rather than something that runs, but the underlying question — delete the script, or wire it into a hardware driver launch — is a code decision outside a documentation pass.

🔧 Fix: Reword AMCL divergence note as self-contained behavior
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
