### PR TITLE
fix(hangar_sim): replace deprecated behavior and ports in move boxes subtree

### DIFF
--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -285,9 +285,10 @@
                         output_pose="{leveled_grasp_pose}"
                       />
                       <Action
-                        ID="AddPoseStampedToVector"
-                        input="{leveled_grasp_pose}"
-                        vector="{leveled_grasp_poses}"
+                        ID="PushBackVector"
+                        input_vector="{leveled_grasp_poses}"
+                        element="{leveled_grasp_pose}"
+                        output_vector="{leveled_grasp_poses}"
                       />
                     </Control>
                   </Decorator>
@@ -428,7 +429,6 @@
                   />
                   <Action
                     ID="PlanCartesianPath"
-                    acceleration_scale_factor="1.000000"
                     blending_radius="0.020000"
                     ik_cartesian_space_density="0.010000"
                     ik_joint_space_density="0.100000"
@@ -437,8 +437,7 @@
                     planning_group_name="manipulator"
                     cartesian_constraint="[{constraint_type: position_and_orientation}]"
                     tip_links="grasp_link"
-                    trajectory_sampling_rate="100"
-                    velocity_scale_factor="1.000000"
+                    trajectory_timing="[{mode: time_optimal, velocity_scale_factor: 1.0, acceleration_scale_factor: 1.0, trajectory_sampling_rate: 100}]"
                   />
                   <!--Execute the lift on the JTC pipeline. ExecuteTrajectory defaults to the JTAC
                       (admittance) controller, which hangar_sim does not run; this objective uses


### PR DESCRIPTION
## Problem

Running `hangar_sim` → **ML Move Boxes to Loading Zone** emits two deprecation warnings on every cycle, both from the subtree it calls, `move_boxes_to_loading_zone_from_waypoint.xml`:

- **`AddPoseStampedToVector`** — deprecated, will be removed in a future release; use `PushBackVector`.
- **`PlanCartesianPath`** — the `velocity_scale_factor`, `acceleration_scale_factor`, and `trajectory_sampling_rate` ports are deprecated in favor of the `trajectory_timing` port.

## Changes

**`AddPoseStampedToVector` → `PushBackVector`** (line 288). Ports remap as `input` → `element`, and `vector` splits into `input_vector`/`output_vector` on the same blackboard key so the enclosing `ForEach` still accumulates. `ResetPoseStampedVector` already clears `{leveled_grasp_poses}` ahead of the loop, so the first read sees a valid empty vector. The same read-then-write pattern is already used elsewhere in this file for `{lift_path}`.

**`PlanCartesianPath` scale-factor ports → `trajectory_timing`** (line 430). All three deprecated values carry over unchanged into the new typed port:

```
trajectory_timing="[{mode: time_optimal, velocity_scale_factor: 1.0, acceleration_scale_factor: 1.0, trajectory_sampling_rate: 100}]"
```

Verified against `moveit_studio_msgs/TrajectoryTiming.msg`, which carries `trajectory_sampling_rate` alongside the two scale factors, so nothing is dropped and the planned lift is timed exactly as before.

## Notes

- The `velocity_scale_factor`/`acceleration_scale_factor` ports on `SetupMTCConnectWithProRRT` and the `Move to Waypoint (JTC)` subtree in this same file are **not** deprecated and are left untouched — only `PlanCartesianPath`'s versions were.
- Scoped deliberately to the one subtree named in the issue. The deprecated `PlanCartesianPath` ports appear across other `hangar_sim` objectives too; that workspace-wide sweep is being handled separately.

Fixes PickNikRobotics/BCR_platform_mirror#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)