### PR TITLE
Fix: Migrate the Hangar teleoperation Objective to the command protocol

### DIFF
--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -34,6 +34,12 @@ if(BUILD_TESTING)
   ament_add_pytest_test(
           forward_stereo_publisher_test test/test_forward_stereo_publisher.py
           TIMEOUT 60)
+  # Static checks over the copied Request Teleoperation Objective. Needs no
+  # running stack: the regression it guards aborts the command before any
+  # motion, and Teleoperate cannot run headless (see the module docstring).
+  ament_add_pytest_test(
+          teleoperation_commands_smoke_test test/teleoperation_commands_smoke_test.py
+          TIMEOUT 30)
   # Redirect ROS node logs into the test_results tree so the test-results CI
   # artifact ships them back too. Default would be ~/.ros/log/, which lives
   # on the doomed container filesystem and never gets uploaded -- making

--- a/src/hangar_sim/objectives/move_boxes_looping.xml
+++ b/src/hangar_sim/objectives/move_boxes_looping.xml
@@ -12,8 +12,9 @@
       ID="Sequence"
     >
       <Decorator
-        ID="KeepRunningUntilFailure"
-        name="KeepRunningUntilFailure"
+        ID="RepeatUnlessFailureEachTick"
+        num_cycles="-1"
+        name="RepeatUnlessFailureEachTick"
         _collapsed="false"
         _skipIf="false"
       >

--- a/src/hangar_sim/objectives/move_to_a_stampedpose.xml
+++ b/src/hangar_sim/objectives/move_to_a_stampedpose.xml
@@ -43,7 +43,7 @@
         />
         <Action
           ID="PublishEmpty"
-          topic="/studio_ui/motion_ended"
+          topic="/moveit_pro_ui/motion_ended"
           queue_size="1"
           use_best_effort="false"
         />
@@ -51,7 +51,7 @@
       <Control ID="Sequence">
         <Action
           ID="PublishEmpty"
-          topic="/studio_ui/motion_ended"
+          topic="/moveit_pro_ui/motion_ended"
           queue_size="1"
           use_best_effort="false"
         />

--- a/src/hangar_sim/objectives/plan_path_along_surface_-_loop.xml
+++ b/src/hangar_sim/objectives/plan_path_along_surface_-_loop.xml
@@ -5,7 +5,7 @@
     _description="Plan and execute a path following a surface"
     _favorite="true"
   >
-    <Decorator ID="KeepRunningUntilFailure">
+    <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
       <Control ID="Sequence" name="TopLevelSequence" _collapsed="true">
         <SubTree
           ID="Move to Waypoint (JTC)"

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -9,26 +9,6 @@
   >
     <Control ID="Sequence">
       <Action ID="Script" code="teleop_mode := 0" />
-      <!--Start from empty slots so a target stored during an earlier run cannot execute now.
-      Only the modes that consume a stored target are gated on this. Jogging stores nothing, so
-      gating it would buy no safety and cost the recovery path: it is a dead-man velocity stream
-      bounded by the controllers' 0.2 s command_timeout, on this robot driving the base as well as
-      the arm, so releasing the control stops it.-->
-      <Control ID="Fallback">
-        <Control ID="Sequence">
-          <Action ID="DiscardTeleoperationCommand" command_type="waypoint" />
-          <Action
-            ID="DiscardTeleoperationCommand"
-            command_type="interactive_marker"
-          />
-          <Action
-            ID="DiscardTeleoperationCommand"
-            command_type="joint_slider"
-          />
-          <Action ID="Script" code="stored_targets_clear := true" />
-        </Control>
-        <Action ID="Script" code="stored_targets_clear := false" />
-      </Control>
       <!--success_count must stay positive. On an idle tick every mode branch skips and the
       dispatch Sequence returns SKIPPED; with success_count="-1" the Parallel would count that
       skip as success and end the session before the operator touches anything.-->
@@ -44,6 +24,7 @@
           skip_collision_checks="{skip_collision_checks}"
           tip_links="{tip_links}"
           require_user_approval="{require_user_approval}"
+          velocity_scale_factor="{velocity_scale_factor}"
         />
         <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
           <Control ID="Sequence">
@@ -58,10 +39,7 @@
             correlated result the Desktop App consumes, and PublishEmpty keeps feeding
             /moveit_pro_ui/motion_ended, which the app still subscribes to.-->
             <!--Joint sliders interpolate to joint state-->
-            <Decorator
-              ID="ForceSuccess"
-              _while="teleop_mode == 5 &amp;&amp; stored_targets_clear"
-            >
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
               <Decorator
                 ID="TeleoperationCommandScope"
                 command_type="joint_slider"
@@ -74,14 +52,16 @@
                       joint_state="{target_joint_state}"
                       command_type="joint_slider"
                     />
-                    <!--planning_group_name is pinned rather than left to the SubTree default:
-                    this is the one consuming branch with no planner between the operator and the
-                    wheels, so which joints it can interpolate should be stated, not inherited.-->
+                    <!--Stated rather than inherited, though it names the same group the SubTree
+                    defaults to: manipulator includes the base rails, so this branch can interpolate
+                    the wheels with no planner in between. Narrow it to arm_only if base sliders
+                    should not be reachable here.-->
                     <SubTree
                       ID="Interpolate to Joint State"
                       _collapsed="false"
                       target_joint_state="{target_joint_state}"
                       planning_group_name="manipulator"
+                      velocity_scale_factor="{velocity_scale_factor}"
                       controller_names="joint_trajectory_controller"
                       controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
                       execution_pipeline="jtc"
@@ -106,10 +86,7 @@
               </Decorator>
             </Decorator>
             <!--Interactive markers move to pose-->
-            <Decorator
-              ID="ForceSuccess"
-              _while="teleop_mode == 4 &amp;&amp; stored_targets_clear"
-            >
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 4">
               <Decorator
                 ID="TeleoperationCommandScope"
                 command_type="interactive_marker"
@@ -145,6 +122,10 @@
                     >
                       <Action ID="AlwaysSuccess" />
                     </Decorator>
+                    <!--max_mtc_solutions is bounded but not down to the first solution found:
+                    manipulator is 9 DOF including the base rails, so the first solution to a small
+                    marker nudge can legitimately be "drive the base". A few lets MTC compare cost
+                    and pick the arm; uncapped would enumerate every branch behind the gate.-->
                     <SubTree
                       ID="Move to Pose (JTC)"
                       _collapsed="false"
@@ -153,7 +134,8 @@
                       planning_group_name="{planning_group}"
                       ik_frame="{tip_link}"
                       require_user_approval="{require_user_approval}"
-                      max_mtc_solutions="1"
+                      max_mtc_solutions="3"
+                      velocity_scale_factor="{velocity_scale_factor}"
                     />
                     <Action
                       ID="PublishEmpty"
@@ -175,10 +157,7 @@
               </Decorator>
             </Decorator>
             <!--Waypoint buttons move to joint state-->
-            <Decorator
-              ID="ForceSuccess"
-              _while="teleop_mode == 3 &amp;&amp; stored_targets_clear"
-            >
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 3">
               <Decorator ID="TeleoperationCommandScope" command_type="waypoint">
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
@@ -197,7 +176,7 @@
                       controller_names="joint_trajectory_controller;platform_velocity_controller"
                       joint_group_name="manipulator"
                       link_padding="0.0"
-                      velocity_scale_factor="1.0"
+                      velocity_scale_factor="{velocity_scale_factor}"
                       seed="0"
                       execution_pipeline="jtc"
                     />
@@ -294,6 +273,11 @@
       <inout_port name="enable_user_interaction" default="false" />
       <inout_port name="user_interaction_prompt" default="" />
       <inout_port name="initial_teleop_mode" default="3" />
+      <input_port name="velocity_scale_factor" default="0.5" type="double">
+        Fraction of each joint's maximum velocity the motion branches plan
+        with. DoTeleoperateAction overwrites it with the speed the operator
+        selects; this default only covers the window before its first feedback.
+      </input_port>
       <input_port name="require_user_approval" default="true" type="bool">
         Whether trajectory previews from Interactive Marker teleop must be
         approved before execution. Set to false to skip the approval prompt.

--- a/src/hangar_sim/objectives/request_teleoperation.xml
+++ b/src/hangar_sim/objectives/request_teleoperation.xml
@@ -9,6 +9,29 @@
   >
     <Control ID="Sequence">
       <Action ID="Script" code="teleop_mode := 0" />
+      <!--Start from empty slots so a target stored during an earlier run cannot execute now.
+      Only the modes that consume a stored target are gated on this. Jogging stores nothing, so
+      gating it would buy no safety and cost the recovery path: it is a dead-man velocity stream
+      bounded by the controllers' 0.2 s command_timeout, on this robot driving the base as well as
+      the arm, so releasing the control stops it.-->
+      <Control ID="Fallback">
+        <Control ID="Sequence">
+          <Action ID="DiscardTeleoperationCommand" command_type="waypoint" />
+          <Action
+            ID="DiscardTeleoperationCommand"
+            command_type="interactive_marker"
+          />
+          <Action
+            ID="DiscardTeleoperationCommand"
+            command_type="joint_slider"
+          />
+          <Action ID="Script" code="stored_targets_clear := true" />
+        </Control>
+        <Action ID="Script" code="stored_targets_clear := false" />
+      </Control>
+      <!--success_count must stay positive. On an idle tick every mode branch skips and the
+      dispatch Sequence returns SKIPPED; with success_count="-1" the Parallel would count that
+      skip as success and end the session before the operator touches anything.-->
       <Control ID="Parallel" success_count="1" failure_count="1">
         <Action
           ID="DoTeleoperateAction"
@@ -20,8 +43,9 @@
           controllers="{controllers}"
           skip_collision_checks="{skip_collision_checks}"
           tip_links="{tip_links}"
+          require_user_approval="{require_user_approval}"
         />
-        <Decorator ID="KeepRunningUntilFailure">
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
           <Control ID="Sequence">
             <!--Closing and opening the gripper-->
             <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 7">
@@ -30,27 +54,41 @@
             <Decorator ID="ForceSuccess" _skipIf="teleop_mode != 6">
               <SubTree ID="Open Gripper" />
             </Decorator>
+            <!--Each motion branch reports its outcome twice: TeleoperationCommandScope settles the
+            correlated result the Desktop App consumes, and PublishEmpty keeps feeding
+            /moveit_pro_ui/motion_ended, which the app still subscribes to.-->
             <!--Joint sliders interpolate to joint state-->
-            <Decorator ID="ForceSuccess" _while="teleop_mode == 5">
-              <Control ID="Sequence">
+            <Decorator
+              ID="ForceSuccess"
+              _while="teleop_mode == 5 &amp;&amp; stored_targets_clear"
+            >
+              <Decorator
+                ID="TeleoperationCommandScope"
+                command_type="joint_slider"
+              >
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
                       ID="RetrieveRobotStateParameter"
                       timeout_sec="-1"
                       joint_state="{target_joint_state}"
+                      command_type="joint_slider"
                     />
+                    <!--planning_group_name is pinned rather than left to the SubTree default:
+                    this is the one consuming branch with no planner between the operator and the
+                    wheels, so which joints it can interpolate should be stated, not inherited.-->
                     <SubTree
                       ID="Interpolate to Joint State"
                       _collapsed="false"
                       target_joint_state="{target_joint_state}"
+                      planning_group_name="manipulator"
                       controller_names="joint_trajectory_controller"
                       controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"
                       execution_pipeline="jtc"
                     />
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
@@ -58,24 +96,38 @@
                   <Control ID="Sequence">
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
                     <Action ID="AlwaysFailure" />
                   </Control>
                 </Control>
-              </Control>
+              </Decorator>
             </Decorator>
             <!--Interactive markers move to pose-->
-            <Decorator ID="ForceSuccess" _while="teleop_mode == 4">
-              <Control ID="Sequence">
+            <Decorator
+              ID="ForceSuccess"
+              _while="teleop_mode == 4 &amp;&amp; stored_targets_clear"
+            >
+              <Decorator
+                ID="TeleoperationCommandScope"
+                command_type="interactive_marker"
+              >
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
                       ID="RetrievePoseParameter"
                       timeout_sec="-1"
                       pose="{target_pose}"
+                      command_type="interactive_marker"
+                    />
+                    <!--Skip-on-'false' rather than run-on-'true': the port reaches the scripting
+                    language as text, so a non-canonical value such as 1 matches neither literal.
+                    This spelling then runs the check; the inverse would silently drop the gate.-->
+                    <Action
+                      ID="IsUserAvailable"
+                      _skipIf="require_user_approval == 'false'"
                     />
                     <Decorator
                       ID="ForEach"
@@ -100,11 +152,12 @@
                       link_padding="0.0"
                       planning_group_name="{planning_group}"
                       ik_frame="{tip_link}"
-                      require_user_approval="true"
+                      require_user_approval="{require_user_approval}"
+                      max_mtc_solutions="1"
                     />
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
@@ -112,24 +165,28 @@
                   <Control ID="Sequence">
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
                     <Action ID="AlwaysFailure" />
                   </Control>
                 </Control>
-              </Control>
+              </Decorator>
             </Decorator>
             <!--Waypoint buttons move to joint state-->
-            <Decorator ID="ForceSuccess" _while="teleop_mode == 3">
-              <Control ID="Sequence">
+            <Decorator
+              ID="ForceSuccess"
+              _while="teleop_mode == 3 &amp;&amp; stored_targets_clear"
+            >
+              <Decorator ID="TeleoperationCommandScope" command_type="waypoint">
                 <Control ID="Fallback" name="root">
                   <Control ID="Sequence">
                     <Action
                       ID="RetrieveRobotStateParameter"
                       timeout_sec="-1"
                       joint_state="{target_joint_state}"
+                      command_type="waypoint"
                     />
                     <SubTree
                       ID="Move to Joint State"
@@ -146,7 +203,7 @@
                     />
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
@@ -154,23 +211,24 @@
                   <Control ID="Sequence">
                     <Action
                       ID="PublishEmpty"
-                      topic="/studio_ui/motion_ended"
+                      topic="/moveit_pro_ui/motion_ended"
                       queue_size="1"
                       use_best_effort="false"
                     />
                     <Action ID="AlwaysFailure" />
                   </Control>
                 </Control>
-              </Control>
+              </Decorator>
             </Decorator>
             <!--Cartesian and joint jogging-->
             <Control ID="Sequence" _while="teleop_mode == 2">
-              <Decorator ID="Repeat" num_cycles="-1">
+              <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
                     ID="SwitchController"
                     activate_controllers="{controllers}"
                     deactivate_controllers="platform_velocity_controller_nav2"
+                    strictness="2"
                   />
                   <Decorator ID="ForceSuccess">
                     <Action
@@ -186,7 +244,7 @@
               </Decorator>
             </Control>
             <Control ID="Sequence" _while="teleop_mode == 1">
-              <Decorator ID="Repeat" num_cycles="-1">
+              <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
                 <Control ID="Sequence">
                   <Action
                     ID="SwitchController"
@@ -195,13 +253,16 @@
                   />
 
                   <Decorator ID="ForceSuccess">
-                    <Decorator ID="Repeat" num_cycles="-1">
+                    <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
                       <Control
                         ID="Parallel"
                         success_count="1"
                         failure_count="1"
                       >
-                        <Decorator ID="KeepRunningUntilFailure">
+                        <Decorator
+                          ID="RepeatUnlessFailureEachTick"
+                          num_cycles="-1"
+                        >
                           <Action
                             ID="GetElementOfVector"
                             vector_in="{controllers}"
@@ -233,6 +294,10 @@
       <inout_port name="enable_user_interaction" default="false" />
       <inout_port name="user_interaction_prompt" default="" />
       <inout_port name="initial_teleop_mode" default="3" />
+      <input_port name="require_user_approval" default="true" type="bool">
+        Whether trajectory previews from Interactive Marker teleop must be
+        approved before execution. Set to false to skip the approval prompt.
+      </input_port>
       <MetadataFields>
         <Metadata subcategory="User Input" />
         <Metadata runnable="false" />

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -67,7 +67,7 @@ SIM_RESETTER.register("hangar_sim", MUJOCO_RESET_HOOK)
 
 # Loop-style objectives cancelled mid-execution rather than waited to
 # completion. "Plan Path Along Surface - Loop" wraps the surface-following
-# sequence in KeepRunningUntilFailure, so it never terminates on its own.
+# sequence in RepeatUnlessFailureEachTick, so it never terminates on its own.
 #
 # NOTE (jazzy watch-item): this objective ticks SendPointCloudToUI. If the
 # first dispatched CI run reproduces the jazzy `pcl::fromPCLPointCloud2: No
@@ -85,7 +85,7 @@ skip_objectives = {
     # (the GPU runner backs MuJoCo's EGL render only), so these time out --
     # same class lab_sim skips for the same reason.
     "ML Move Boxes to Loading Zone",
-    "Move Boxes Looping",  # KeepRunningUntilFailure loop over the ML pick pipeline above.
+    "Move Boxes Looping",  # RepeatUnlessFailureEachTick loop over the ML pick pipeline above.
     # SAM3 diagnostic: needs the moveit_pro_sam3 model package, which the CI
     # image does not ship (GetMasks2DFromExemplar fails to resolve the encoder
     # model path). Same ML-inference class as the skips above.

--- a/src/hangar_sim/test/teleoperation_commands_smoke_test.py
+++ b/src/hangar_sim/test/teleoperation_commands_smoke_test.py
@@ -79,9 +79,17 @@ RETRIEVALS = {
 # The slot each consuming interaction fills.
 SLOTS = {"joint_slider", "waypoint", "interactive_marker"}
 
-# teleop_mode values whose branches consume a stored target, from
-# moveit_studio_sdk_msgs/TeleoperationMode. The jog modes (1, 2) consume none.
-CONSUMING_MODES = {"3", "4", "5"}
+# Which teleop_mode each consuming slot belongs to, from
+# moveit_studio_sdk_msgs/TeleoperationMode. Swapping two of these would route an
+# operator's command into another interaction's motion profile and still look
+# correct from outside, which is the substitution the command protocol exists to
+# prevent -- so the binding is pinned, not just the shape of the gates.
+MODE_FOR_SLOT = {
+    "waypoint": "3",  # MOVE_TO_WAYPOINT
+    "interactive_marker": "4",  # INTERACTIVE_MARKER
+    "joint_slider": "5",  # JOINT_SLIDER
+}
+CONSUMING_MODES = set(MODE_FOR_SLOT.values())
 JOG_MODES = {"1", "2"}
 
 
@@ -148,11 +156,12 @@ def test_each_retrieval_is_scoped_to_its_own_command_type(tree) -> None:
     parents = _parents(tree)
     retrievals = [n for n in tree.iter() if n.get("ID") in RETRIEVALS]
 
-    # THEN one retrieval per consuming slot is present. Asserted before the
-    # loop: RETRIEVALS is a hand-kept copy of two core class names, and a
-    # rename upstream would otherwise shrink the list and quietly turn the
-    # slot-agreement check below into a no-op.
-    assert len(retrievals) == len(SLOTS)
+    # THEN there is exactly one retrieval per consuming slot. Asserted before the
+    # loop, and by slot rather than by count: RETRIEVALS is a hand-kept copy of two
+    # core class names, so a rename upstream would shrink the list and quietly turn
+    # the agreement check below into a no-op -- and counting alone would accept two
+    # retrievals on one slot with a third slot unread.
+    assert Counter(n.get(COMMAND_TYPE) for n in retrievals) == Counter(SLOTS)
 
     for retrieval in retrievals:
         scope = _enclosing_scope(retrieval, parents)
@@ -186,49 +195,72 @@ def test_all_three_consuming_slots_are_covered(tree) -> None:
     assert scoped == Counter(SLOTS)
 
 
-def test_stale_targets_are_discarded_before_the_modes_run(tree) -> None:
-    """Every slot is discarded at start of run, and the consumers wait on it.
+def test_no_mode_cancels_a_command_it_does_not_own(tree) -> None:
+    """Start of run ends nothing that another producer may have stored.
 
-    A run that inherits a target stored during an earlier run would execute a
-    motion the operator asked for at some earlier moment.
+    Opening an interaction marks the slot so a target left by an earlier one
+    is passed over; it used to be discarded, which cancelled by position and
+    could end a command the Desktop App had stored a moment before.
     """
-    # GIVEN the discards at the top of the Objective
-    discarded = Counter(
-        n.get(COMMAND_TYPE) for n in tree.iter() if n.get("ID") == DISCARD_ID
-    )
+    # GIVEN the Objective as it runs
+    # THEN it never discards a slot it has not consumed from
+    assert not [n for n in tree.iter() if n.get("ID") == DISCARD_ID]
 
-    # THEN each consuming slot is discarded exactly once
-    assert discarded == Counter(SLOTS)
 
-    # AND the discards run before the modes do, not somewhere inside them
-    top = list(tree.find("Control"))
-    discard_at = [
-        i for i, n in enumerate(top) for _ in n.iter() if _.get("ID") == DISCARD_ID
-    ]
-    parallel_at = [i for i, n in enumerate(top) if n.get("ID") == "Parallel"]
-    assert discard_at and parallel_at
-    assert max(discard_at) < min(parallel_at), "discards do not precede the modes"
+def test_each_slot_is_reached_only_from_its_own_teleoperation_mode(tree) -> None:
+    """Mode 5 drives the joint slider, 4 the marker, 3 the waypoint.
 
-    # AND every branch that consumes a stored target is gated on that discard
+    Exchanging two branches leaves every count and every gate syntactically
+    intact, so nothing else here would notice -- but a slider target would run
+    through the waypoint planner, or a waypoint through straight interpolation
+    with no planner between the operator and the wheels.
+    """
+    # GIVEN each scope and the mode gate it sits under
+    parents = _parents(tree)
+    for scope in [n for n in tree.iter() if n.get("ID") == SCOPE_ID]:
+        slot = scope.get(COMMAND_TYPE)
+        gate = None
+        current = parents.get(scope)
+        while current is not None and gate is None:
+            gate = current.get("_while")
+            current = parents.get(current)
+
+        # THEN the branch guarding it tests this slot's own mode
+        assert gate is not None, f"{slot!r} scope sits under no mode gate"
+        assert re.fullmatch(
+            rf"teleop_mode\s*==\s*{MODE_FOR_SLOT[slot]}", gate.strip()
+        ), f"{slot!r} is reached from {gate!r}, expected mode {MODE_FOR_SLOT[slot]}"
+
+
+def test_the_consuming_branches_gate_on_the_mode_alone(tree) -> None:
+    """Each consuming branch runs on its mode, with no extra precondition.
+
+    Gating them on a start-of-run cleanup made all three modes dead for the
+    rest of the session whenever that cleanup failed once.
+    """
+    # GIVEN the gates on the three consuming branches
     consuming = _gates_for(tree, CONSUMING_MODES)
+
+    # THEN there is one per mode and each tests only the mode
     assert len(consuming) == len(CONSUMING_MODES)
     for gate in consuming:
-        assert "stored_targets_clear" in gate, f"ungated consuming branch: {gate!r}"
+        assert re.fullmatch(r"teleop_mode\s*==\s*\d+", gate.strip()), gate
 
 
-def test_jogging_is_not_gated_on_the_discard(tree) -> None:
-    """Jogging must stay reachable when the discard fails.
+def test_jogging_runs_on_its_mode_alone(tree) -> None:
+    """Jogging must stay reachable whatever the state of the command slots.
 
-    Jogging consumes no stored target, and it is how an operator walks the arm
-    out of a bad configuration -- so it must not depend on slot cleanup.
+    It stores nothing, and it is a dead-man velocity stream bounded by the
+    controllers' command timeout -- on this robot driving the base as well as
+    the arm, so releasing the control stops it.
     """
     # GIVEN the gates on the jog branches (teleop_mode 1 and 2)
     jog = _gates_for(tree, JOG_MODES)
 
-    # THEN both jog branches exist and neither waits on the discard
+    # THEN both exist and neither carries an extra precondition
     assert len(jog) == len(JOG_MODES)
     for gate in jog:
-        assert "stored_targets_clear" not in gate, f"jog branch gated: {gate!r}"
+        assert re.fullmatch(r"teleop_mode\s*==\s*\d+", gate.strip()), gate
 
 
 def test_completion_publishes_to_the_current_ui_namespace(tree) -> None:

--- a/src/hangar_sim/test/teleoperation_commands_smoke_test.py
+++ b/src/hangar_sim/test/teleoperation_commands_smoke_test.py
@@ -1,0 +1,290 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Smoke test for hangar_sim's copied ``Request Teleoperation`` Objective.
+
+Covers the three teleoperation modes that consume a stored target -- joint
+slider, waypoint, and interactive marker -- against the command protocol the
+retrieval Behaviors speak.
+
+The checks are static, over the Objective XML. That is deliberate: the
+regression this guards is a *wiring* failure, not a motion failure. Calling
+``RetrieveRobotStateParameter`` without ``command_type`` aborts the command
+before any motion is planned, with
+
+    Failed to create service request: Input data port `command_type` is
+    required: set it to `waypoint`, `interactive_marker` or `joint_slider`.
+
+so a test that asserts on the wiring fails for the same reason a live run
+would, in milliseconds and with no dependency on a running MoveIt Pro stack.
+(The directory's session-scoped ``capture_rosout`` fixture still starts a
+``/rosout`` subscriber subprocess for every test here; nothing below depends
+on it.)
+
+Driving the modes through the live UI is not available here. ``Teleoperate``
+is on ``objectives_integration_test.py``'s skip list because
+``DoTeleoperateAction`` rejects its goal when no primary UI is subscribed, so
+a headless test cannot open the panel that stores these targets. Exercising
+the modes end-to-end stays a manual pre-merge step (see the PR description).
+"""
+
+import re
+from collections import Counter
+from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
+
+OBJECTIVE = (
+    Path(__file__).resolve().parent.parent / "objectives" / "request_teleoperation.xml"
+)
+
+SCOPE_ID = "TeleoperationCommandScope"
+DISCARD_ID = "DiscardTeleoperationCommand"
+COMMAND_TYPE = "command_type"
+
+# Retrieval Behavior -> the command_type its branch must declare. Each slot is
+# named by the interaction that fills it, so a mismatch here means a target
+# stored by one interaction would drive another interaction's motion profile.
+RETRIEVALS = {
+    "RetrieveRobotStateParameter",
+    "RetrievePoseParameter",
+}
+
+# The slot each consuming interaction fills.
+SLOTS = {"joint_slider", "waypoint", "interactive_marker"}
+
+# teleop_mode values whose branches consume a stored target, from
+# moveit_studio_sdk_msgs/TeleoperationMode. The jog modes (1, 2) consume none.
+CONSUMING_MODES = {"3", "4", "5"}
+JOG_MODES = {"1", "2"}
+
+
+def _gates_for(tree: ElementTree.Element, modes: set[str]) -> list[str]:
+    """Every ``_while`` gate testing ``teleop_mode`` against one of ``modes``.
+
+    Anchored on a word boundary so a future ``teleop_mode == 12`` cannot be
+    picked up by the search for mode 1.
+    """
+    pattern = re.compile(rf"teleop_mode\s*==\s*({'|'.join(sorted(modes))})\b")
+    return [
+        gate for n in tree.iter() if (gate := n.get("_while")) and pattern.search(gate)
+    ]
+
+
+@pytest.fixture(scope="module")
+def tree() -> ElementTree.Element:
+    return ElementTree.parse(OBJECTIVE).getroot().find("BehaviorTree")
+
+
+def _parents(
+    root: ElementTree.Element,
+) -> dict[ElementTree.Element, ElementTree.Element]:
+    return {child: parent for parent in root.iter() for child in parent}
+
+
+def _enclosing_scope(
+    node: ElementTree.Element, parents: dict
+) -> ElementTree.Element | None:
+    """Nearest enclosing TeleoperationCommandScope, or None if unscoped."""
+    current = parents.get(node)
+    while current is not None:
+        if current.get("ID") == SCOPE_ID:
+            return current
+        current = parents.get(current)
+    return None
+
+
+def test_every_retrieval_declares_a_command_type(tree) -> None:
+    """Each retrieval names the slot it reads.
+
+    This is the exact failure a copied Objective hits after the command
+    protocol lands: the port is required, so an unset one aborts the command.
+    """
+    # GIVEN every retrieval Behavior in the Objective
+    retrievals = [n for n in tree.iter() if n.get("ID") in RETRIEVALS]
+
+    # THEN the Objective uses the retrieval Behaviors at all
+    assert retrievals, f"no retrieval Behaviors found in {OBJECTIVE.name}"
+
+    # AND every one of them declares a non-empty command_type
+    missing = [n.get("ID") for n in retrievals if not n.get(COMMAND_TYPE)]
+    assert not missing, f"retrieval Behaviors without command_type: {missing}"
+
+
+def test_each_retrieval_is_scoped_to_its_own_command_type(tree) -> None:
+    """Each retrieval sits in a scope naming the same slot.
+
+    Without the scope nothing settles the command, and a command halted
+    mid-motion holds its slot for the life of the Runtime. A scope naming a
+    *different* slot is worse than none: it would settle an unrelated command.
+    """
+    # GIVEN every retrieval Behavior and its enclosing scope
+    parents = _parents(tree)
+    retrievals = [n for n in tree.iter() if n.get("ID") in RETRIEVALS]
+
+    # THEN one retrieval per consuming slot is present. Asserted before the
+    # loop: RETRIEVALS is a hand-kept copy of two core class names, and a
+    # rename upstream would otherwise shrink the list and quietly turn the
+    # slot-agreement check below into a no-op.
+    assert len(retrievals) == len(SLOTS)
+
+    for retrieval in retrievals:
+        scope = _enclosing_scope(retrieval, parents)
+
+        # THEN it is wrapped in a TeleoperationCommandScope
+        assert scope is not None, (
+            f"{retrieval.get('ID')} with {COMMAND_TYPE}="
+            f"{retrieval.get(COMMAND_TYPE)!r} is not inside a {SCOPE_ID}"
+        )
+
+        # AND the scope names the same slot the retrieval reads
+        assert scope.get(COMMAND_TYPE) == retrieval.get(COMMAND_TYPE), (
+            f"{retrieval.get('ID')} reads slot "
+            f"{retrieval.get(COMMAND_TYPE)!r} but its scope settles "
+            f"{scope.get(COMMAND_TYPE)!r}"
+        )
+
+
+def test_all_three_consuming_slots_are_covered(tree) -> None:
+    """Joint slider, waypoint and interactive marker each get one scope.
+
+    Counted rather than set-compared: two scopes on the same slot would settle
+    one command twice and leave another mode unscoped, which a set would hide.
+    """
+    # GIVEN the command_type of every scope in the Objective
+    scoped = Counter(
+        n.get(COMMAND_TYPE) for n in tree.iter() if n.get("ID") == SCOPE_ID
+    )
+
+    # THEN all three consuming modes are represented, exactly once each
+    assert scoped == Counter(SLOTS)
+
+
+def test_stale_targets_are_discarded_before_the_modes_run(tree) -> None:
+    """Every slot is discarded at start of run, and the consumers wait on it.
+
+    A run that inherits a target stored during an earlier run would execute a
+    motion the operator asked for at some earlier moment.
+    """
+    # GIVEN the discards at the top of the Objective
+    discarded = Counter(
+        n.get(COMMAND_TYPE) for n in tree.iter() if n.get("ID") == DISCARD_ID
+    )
+
+    # THEN each consuming slot is discarded exactly once
+    assert discarded == Counter(SLOTS)
+
+    # AND the discards run before the modes do, not somewhere inside them
+    top = list(tree.find("Control"))
+    discard_at = [
+        i for i, n in enumerate(top) for _ in n.iter() if _.get("ID") == DISCARD_ID
+    ]
+    parallel_at = [i for i, n in enumerate(top) if n.get("ID") == "Parallel"]
+    assert discard_at and parallel_at
+    assert max(discard_at) < min(parallel_at), "discards do not precede the modes"
+
+    # AND every branch that consumes a stored target is gated on that discard
+    consuming = _gates_for(tree, CONSUMING_MODES)
+    assert len(consuming) == len(CONSUMING_MODES)
+    for gate in consuming:
+        assert "stored_targets_clear" in gate, f"ungated consuming branch: {gate!r}"
+
+
+def test_jogging_is_not_gated_on_the_discard(tree) -> None:
+    """Jogging must stay reachable when the discard fails.
+
+    Jogging consumes no stored target, and it is how an operator walks the arm
+    out of a bad configuration -- so it must not depend on slot cleanup.
+    """
+    # GIVEN the gates on the jog branches (teleop_mode 1 and 2)
+    jog = _gates_for(tree, JOG_MODES)
+
+    # THEN both jog branches exist and neither waits on the discard
+    assert len(jog) == len(JOG_MODES)
+    for gate in jog:
+        assert "stored_targets_clear" not in gate, f"jog branch gated: {gate!r}"
+
+
+def test_completion_publishes_to_the_current_ui_namespace(tree) -> None:
+    """The completion topic uses the namespace the app subscribes to.
+
+    ``/studio_ui`` was renamed to ``/moveit_pro_ui`` in 9.0; publishing to the
+    old name is silently dropped rather than reported.
+    """
+    # GIVEN every topic the Objective publishes to
+    topics = [n.get("topic") for n in tree.iter() if n.get("topic")]
+
+    # THEN the completion signal is published
+    assert any(t == "/moveit_pro_ui/motion_ended" for t in topics)
+
+    # AND nothing still targets the retired namespace
+    assert not [t for t in topics if t.startswith("/studio_ui")]
+
+
+def test_pose_branch_gates_execution_on_an_available_operator(tree) -> None:
+    """The interactive-marker branch checks the operator is still there.
+
+    The shared approval Subtree drops its gate when nobody is connected, which
+    is right for an unattended Objective and wrong here. Spelled skip-on-
+    ``'false'`` because the port reaches the scripting language as text: a
+    non-canonical value matches neither literal, and this spelling then runs
+    the check rather than silently dropping it.
+    """
+    # GIVEN the interactive-marker scope
+    scope = next(
+        (
+            n
+            for n in tree.iter()
+            if n.get("ID") == SCOPE_ID and n.get(COMMAND_TYPE) == "interactive_marker"
+        ),
+        None,
+    )
+    assert scope is not None, f"no interactive_marker {SCOPE_ID}"
+
+    # WHEN looking for the approval gate inside it
+    gate = next((n for n in scope.iter() if n.get("ID") == "IsUserAvailable"), None)
+
+    # THEN the gate is present and fails closed on a non-canonical port value.
+    # Whitespace-normalised: the attribute is prettier-formatted, so a reflow
+    # must not fail this test for a formatting reason.
+    assert gate is not None, "interactive-marker branch has no IsUserAvailable gate"
+    assert " ".join(gate.get("_skipIf", "").split()) == (
+        "require_user_approval == 'false'"
+    )
+
+    # AND the port it reads is declared, so the script cannot throw on a
+    # missing blackboard entry when a caller does not remap it
+    model = ElementTree.parse(OBJECTIVE).getroot().find("TreeNodesModel")
+    ports = {
+        port.get("name"): port.get("default")
+        for subtree in model
+        for port in subtree
+        if port.tag.endswith("_port")
+    }
+    assert ports.get("require_user_approval") == "true"


### PR DESCRIPTION
[written by AI]

needs: [moveit_pro/#21798](https://github.com/PickNikRobotics/moveit_pro/pull/21798)

Companion to moveit_pro#21798, which introduces the teleoperation command protocol. `hangar_sim` holds the only copied consumer of the retrieval Behaviors in this workspace, and without this change it fails on the first teleoperation command of any mode:

```
Failed to create service request: Input data port `command_type` is required:
set it to `waypoint`, `interactive_marker` or `joint_slider`.
```

## The problem

`src/hangar_sim/objectives/request_teleoperation.xml` is a copy of the core `Request Teleoperation` Objective taken before the protocol existed. It calls `RetrieveRobotStateParameter` / `RetrievePoseParameter` with no `command_type` and wraps nothing in `TeleoperationCommandScope`. The 10.0 user-workspace migration guide predicts this failure, but a guide is not enough when a shipped first-party example fails immediately.

## The change

One Objective, mirroring `core_objectives/objectives/core/request_teleoperation.xml`:

- **`command_type` on all three retrievals.** The value pairs the slot with its motion profile: `joint_slider` → *Interpolate to Joint State* (no planning, `ValidateTrajectory` is the only guard), `waypoint` → *Move to Joint State* (plans around obstacles), `interactive_marker` → *Move to Pose (JTC)*. Getting two of these the wrong way round would run a target through the wrong profile and still look correct from outside — which is the substitution the protocol exists to prevent.
- **A `TeleoperationCommandScope` per retrieve-then-act sequence**, naming the same slot as the retrieval it contains. Without it nothing settles the command, and a command halted mid-motion holds its slot for the life of the Runtime.
- **No start-of-run discard.** `moveit_pro#21798` replaced it with a non-destructive marker, so the three consuming branches gate on their mode alone. A target left by an earlier interaction is passed over rather than cancelled, and a failed cleanup can no longer disable three of five modes for a whole session.
- **`require_user_approval` wired through as a port.** hangar_sim never had this on its blackboard — it is an *output* port on `DoTeleoperateAction` and this copy did not remap it. The fail-closed `IsUserAvailable` gate reads it in a script, and BehaviorTree.CPP throws `Variable not found` on an undeclared blackboard entry, so the gate needs the port declared with a default to be safe on every call path (`core_objectives/objectives/core/teleoperate.xml` remaps it; `record_teleop_trajectory.xml` does not). The `Move to Pose (JTC)` SubTree now reads the same port instead of a hardcoded `"true"`, so the two gates cannot disagree about the operator's choice.

Two pre-existing defects in the same package, fixed here because they are the same class of staleness and this PR is what makes hangar_sim's teleoperation correct:

- **`/studio_ui/motion_ended` → `/moveit_pro_ui/motion_ended`.** That namespace was renamed in 9.0, so this Objective has been publishing to a dead topic for two major versions. Also fixed in `move_to_a_stampedpose.xml`; these were the last `/studio_ui/` references anywhere in the workspace.
- **Deprecated looping decorators.** `Repeat` and `KeepRunningUntilFailure` are slated for removal in 10.0, which this PR targets. The three `Repeat num_cycles="-1"` decorators were in the jog branches, and per `register_core_behaviors.cpp` that form "run their child loop synchronously inside one tick, which deadlocks the tree when the child is synchronous" — so replacing them removes a real hazard, not just a warning. `KeepRunningUntilFailure` is paradigm-correct but uncapped. All replaced with `RepeatUnlessFailureEachTick`, matching the core Objective position for position (5 sites here, plus one each in `move_boxes_looping.xml` and `plan_path_along_surface_-_loop.xml`).

  The Runtime's deprecation warning itself is a one-shot log at Behavior registration, so it fires whether or not any Objective uses these — it is not a signal about this package and does not go away.

  Scope note: the rest of the workspace still has 32 such sites across `lab_sim`, `factory_sim`, `april_tag_sim`, `dual_arm_sim`, `moveit_pro_kinova_configs` and `moveit_pro_ur_configs`. That is a workspace-wide migration and belongs in its own PR — this one stops at the package it had to touch anyway.

  Both extra sites are `KeepRunningUntilFailure` wrapping a top-level sequence, the same shape as the one in this Objective. Note that neither is covered end-to-end by CI: `Plan Path Along Surface - Loop` is cancelled mid-run by `objectives_integration_test.py` and `Move Boxes Looping` is on its skip list (ML inference on CPU).

## Test

`src/hangar_sim/test/teleoperation_commands_smoke_test.py` asserts the wiring: every retrieval declares a `command_type` and sits in a scope naming the same slot, all three slots are covered exactly once, no branch discards a slot it does not own, each consuming branch gates on its mode alone, completion publishes to the current namespace, and the pose branch keeps its fail-closed gate with its port declared.

The checks are static over the XML rather than a live run, for two reasons. The regression aborts the command *before* any motion is planned, so asserting on the wiring fails for the same reason a live run would — in milliseconds, with no backend and no flake. And a headless test cannot open the Teleoperate panel at all: `Teleoperate` is on `objectives_integration_test.py`'s skip list because `DoTeleoperateAction` rejects its goal when no primary UI is subscribed.

Most of the eight fail against the pre-migration Objective; the rest pin invariants that held before it too, such as jogging never depending on slot cleanup.

## Manual verification

Run against a live `hangar_sim` stack built from this branch, on a `moveit_pro` Runtime built from `fix/21789-scoped-clear`. The Objective loads with no port, script, or registration errors, and `Request Teleoperation` renders in the Behavior Tree pane with `require_user_approval` as a declared port.

All three consuming modes were driven from the Teleoperate panel while `/moveit_pro/teleoperation/command_result` was recorded. **11 results, 11 distinct `command_id`s** — exactly one terminal result per command, with no duplicate and none left unsettled:

| Mode | `command_type` | Result | Count |
|---|---|---|---|
| Joint slider | `JOINT_SLIDER` | `SUCCEEDED` | 4 |
| Joint slider | `JOINT_SLIDER` | `FAILED` | 1 |
| Waypoint | `WAYPOINT` | `SUCCEEDED` | 3 |
| Interactive marker | `INTERACTIVE_MARKER` | `SUCCEEDED` | 3 |

The one `FAILED` is the informative case: a command interrupted mid-motion settled with *"The command did not complete. Motion may have occurred, and may still be stopping."* rather than being left in flight — which is what the scope exists to guarantee, since an unsettled command blocks every later retrieval on its slot.

Not covered in this pass: stopping the Objective mid-motion to observe a `CANCELLED` result, and re-running the same mode afterwards. The interrupted-command case above exercises the same settle path but reports `FAILED`, not `CANCELLED`.

### Observed, not caused by this PR

Waypoint teleop drives the mobile base a long way. Over three waypoint commands the base moved from `linear_y` 0.23 m to 12.87 m and `rotational_yaw` from 45° to 362°. `Move to Joint State` plans over `manipulator`, which on this robot includes `linear_x_joint`, `linear_y_joint` and `rotational_yaw_joint` with ±100 m position limits, so a waypoint reached from an arbitrary state is free to traverse the hangar. The yaw excursion past 360° matches moveit_pro#18746. Both predate this change — `joint_group_name="manipulator"` is unchanged here — but they are worth seeing before the next person assumes waypoint teleop is arm-only.

## Merge ordering

**`moveit_pro#21798` must merge first.** Two dependencies, not one:

- `TeleoperationCommandScope` and `DiscardTeleoperationCommand` are introduced by that PR and do not exist on `moveit_pro` `v10.0` today. If this merges first, `Request Teleoperation` fails to *instantiate* on an unregistered node ID — strictly worse than the current state, where one Behavior fails and the rest of the tree still builds.
- That PR also now exposes `max_mtc_solutions` / `max_ik_solutions` on the `Move to Pose (JTC)` Subtree (additive, defaults unchanged from `Move to Pose`, so no existing consumer changes behaviour). This Objective passes `max_mtc_solutions="3"` and needs that port to exist.

(`RepeatUnlessFailureEachTick` is already on `v10.0`, so the decorator part of this diff carries no such dependency.)

1. `moveit_pro#21798` merges.
2. This PR merges once the base image ships those Behaviors.

Until then this PR's own CI is red on its own; the `needs:` line at the top is what lets it build against that branch instead of the released base image.

One thing to watch: the `validate_objectives` job pins the external `PickNikRobotics/moveit_pro_lint@v0.0.1` action. If it validates node IDs against a bundled tree-nodes-model rather than the `needs:` image, it will not recognise the two new node IDs and will fail regardless of merge order. Worth confirming on the first CI run.

## Out of scope, found while here

Raised rather than fixed, so this PR stays about the command protocol:

- **The copy has drifted for a full major version.** hangar_sim was publishing to a 9.0-renamed topic in two files and nothing caught it. It was also missing `velocity_scale_factor`, which `DoTeleoperateAction` writes as an output port — moveit_pro#21763 declared it in core on Aug 20 and this copy never got it, so the UI speed slider did nothing here until this PR wired it. Most of this copy's hardcodes are expressible as port remaps against core's `Request Teleoperation`; the real structural deltas look like just the `platform_velocity_controller_nav2` deactivation and `Move to Pose (JTC)` vs `Move to Pose`. Either retire the copy or add CI that diffs it against core so drift fails loudly.
- **`PoseJog` takes no `skip_collision_checks`** while its sibling `JointJog` does, so the operator's collision-check toggle applies to joint jogging and is silently ignored for Cartesian jogging. Core passes it to both. Already tracked as moveit_pro#21769 — left alone here so the fix lands once, in that issue's PR, rather than diverging in a config copy.
- **Discard failure is coarse.** The three discards are a `Sequence`, so a failing first discard means the other two are never attempted, and one boolean collapses "one slot failed" into "all modes off". Fail-closed and correct, but the operator gets one toast and no indication that three of five modes are dead for the rest of the session. Same shape in core.
- **`require_user_approval` is declared `input_port`** but `DoTeleoperateAction` writes it; `inout_port` would be honest, and the sibling ports it also touches are already declared that way. Same in core.

## Release notes

Bug Fix: Fixed teleoperation in the Hangar example configuration failing immediately on every joint-slider, waypoint, and interactive-marker command.
