### PR TITLE
Remove the moveit_pro_clipseg submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,9 +17,6 @@
 	path = src/external_dependencies/franka_config/franka_description
 	url = https://github.com/frankarobotics/franka_description.git
 	branch = main
-[submodule "src/moveit_pro_clipseg"]
-	path = src/moveit_pro_clipseg
-	url = https://github.com/PickNikRobotics/moveit_pro_clipseg.git
 [submodule "src/external_dependencies/phoebe_ws"]
 	path = src/external_dependencies/phoebe_ws
 	url = https://github.com/PickNikRobotics/phoebe_ws.git

--- a/src/dual_arm_sim/objectives/sort_blocks.xml
+++ b/src/dual_arm_sim/objectives/sort_blocks.xml
@@ -2,7 +2,7 @@
 <root BTCPP_format="4" main_tree_to_execute="Sort Blocks">
   <BehaviorTree
     ID="Sort Blocks"
-    _description="Clears colored blocks off the table by color, right arm for red and left for green. A CLIPSeg no-masks error is expected when a color runs out of blocks."
+    _description="Clears colored blocks off the table by color, right arm for red and left for green. An error is expected when a color runs out of blocks: segmentation returns no masks, and the downstream point cloud lookup then fails on the empty result."
     _favorite="true"
   >
     <Control ID="Sequence">

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -95,12 +95,11 @@
       />
       <Control ID="Sequence">
         <!--
-          SAM3 text-prompt segmentation. Unlike the previous CLIPSeg + SAM2-refine
-          chain, SAM3 produces high-quality per-detection masks directly from a text
-          prompt, so no point-prompt refinement step is needed. The Behavior returns
-          SUCCESS with `mask_count == 0` when nothing is detected, which the
-          `_skipIf` below uses to bypass the pick loop and let the Subtree exit
-          cleanly with `picked_box=false`.
+          SAM3 text-prompt segmentation. SAM3 produces high-quality per-detection
+          masks directly from a text prompt, so no point-prompt refinement step is
+          needed. The Behavior returns SUCCESS with `mask_count == 0` when nothing
+          is detected, which the `_skipIf` below uses to bypass the pick loop and
+          let the Subtree exit cleanly with `picked_box=false`.
         -->
         <Action
           ID="GetMasks2DFromExemplar"


### PR DESCRIPTION
[written by AI]

Removes the `src/moveit_pro_clipseg` submodule from the workspace. Half of PickNikRobotics/moveit_pro#21895; the SAM2 half is not touched here.

## Problem

Cloning this workspace with `--recurse-submodules` pulls ~1.04 GB of CLIPSeg ONNX weights that nothing uses: 520 MB in the working tree (`models/clip.onnx` 254 MB, `models/clipseg.onnx` 291 MB) plus 521 MB under `.git/modules`.

Nothing in the workspace consumes the package. There is no `<exec_depend>moveit_pro_clipseg</exec_depend>` in any `package.xml` and no `model_package="moveit_pro_clipseg"` port in any Objective. Text-prompt segmentation already moved to SAM3: `dual_arm_sim`, `picknik_ur_base_config`, and `franka_base_config` all run `GetMasks2DFromExemplar` with `model_package="moveit_pro_sam3"`.

## Approach

Drop the submodule (`.gitmodules` entry and gitlink) and fix the two stale CLIPSeg strings the SAM3 move left behind:

- `src/dual_arm_sim/objectives/sort_blocks.xml` - the `_description` shown in the Objective list promised "A CLIPSeg no-masks error", which cannot happen any more. That tree reaches SAM3 through `Find Red Block` / `Find Green Block` -> `Find with prompt` -> `Segment Point Cloud from Text Prompt Subtree`.
- `src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml` - a comment contrasted SAM3 against "the previous CLIPSeg + SAM2-refine chain". Per `.claude/rules/writing-style.md`, comments explain the current code rather than its history, so the historical clause is gone and the SAM3 facts stay.

## Attribution side effect

The removed submodule shipped ~545 MB of third-party ONNX weights (CLIP, from OpenAI; CLIPSeg, from CIDAS) under a `LICENSE` that was PickNik's own BSD-3-Clause reading "Copyright (c) 2025 PickNik Inc. All rights reserved", with no model card, upstream provenance, or `NOTICE`. Dropping it closes that gap rather than opening one: nothing in this workspace or in `moveit_pro` attributed CLIP or CLIPSeg, so no `NOTICE` or `LICENSE` is left describing something the product no longer ships. The two remaining model submodules are unaffected and self-contained: `moveit_pro_sam2` carries Apache-2.0 plus a Meta `NOTICE`, and `moveit_pro_sam3` carries Meta's SAM License with per-file SHA-256 provenance.

## Remaining CLIPSeg reference

One reference survives, inside the `phoebe_ws` submodule: `src/phoebe_sim/objectives/segment_image_from_no_negative_text_prompt_subtree.xml`. It is already dead. It calls `GetMasks2DFromTextQuery`, a Behavior that no longer exists in `moveit_pro`, and nothing in `phoebe_ws` or in this workspace invokes the Subtree, so this PR does not change its behavior.

PickNikRobotics/phoebe_ws#39 deletes it. Once that merges, the `phoebe_ws` submodule pointer here can be bumped, which is a follow-up rather than a blocker for this one.

## Existing checkouts need one cleanup command

`git rm` on a gitlink cannot touch per-checkout state, so anyone who had already
initialized the submodule keeps a stale `src/moveit_pro_clipseg` directory and a
`submodule.src/moveit_pro_clipseg.url` entry in `.git/config` after pulling this.
Clear it once:

```bash
git submodule deinit -f src/moveit_pro_clipseg && rm -rf .git/modules/src/moveit_pro_clipseg
```

Fresh clones are unaffected.

## Manual verification

- `git ls-tree HEAD src/moveit_pro_clipseg` is empty and `git submodule status` no longer lists it; nine submodules remain.
- `grep -ri clipseg` over the worktree returns nothing outside the `phoebe_ws` submodule.
- `pre-commit run` passes on the changed files.

