### PR TITLE
Fix factory_sim Plan Path Along Surface Objective

### DIFF
--- a/src/factory_sim/objectives/plan_path_along_surface.xml
+++ b/src/factory_sim/objectives/plan_path_along_surface.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <root BTCPP_format="4" main_tree_to_execute="Plan Path Along Surface">
-  <!--//////////-->
   <BehaviorTree
     ID="Plan Path Along Surface"
     _description="Plan and execute a path following a surface"
@@ -18,6 +17,8 @@
         seed="0"
         velocity_scale_factor="1.0"
         waypoint_name="View bowls"
+        execution_pipeline="jtac"
+        orientation_constraint="[]"
       />
       <!--Get a point cloud and crop it to the area of interest-->
       <Action
@@ -80,7 +81,7 @@
         slice_distance_from_plane="0.100000"
         slice_plane="{centroid}"
         contour_crop_angle_span="3.18"
-        contour_crop_angle_start="1.57"
+        contour_crop_angle_start="1.65"
       />
       <Action
         ID="VisualizePath"
@@ -135,7 +136,7 @@
           end_effector_link="grasp_link"
           ik_group="manipulator"
           ik_timeout_s="1"
-          max_ik_solutions="1000"
+          max_ik_solutions="4"
           monitored_stage="current state"
           target_poses="{ik_targets}"
           task="{mtc_task}"
@@ -158,8 +159,16 @@
         <Action ID="PlanMTCTask" solution="{mtc_solution}" task="{mtc_task}" />
         <SubTree
           ID="Execute MTC Solution"
+          _collapsed="true"
           solution="{mtc_solution}"
           goal_duration_tolerance="-1.0"
+          controller_names="joint_trajectory_admittance_controller"
+          execution_pipeline="jtac"
+          admittance_parameters_msg="{admittance_parameters_msg}"
+          controller_action_name="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+          goal_position_tolerance="{goal_position_tolerance}"
+          path_position_tolerance="{path_position_tolerance}"
+          absolute_force_torque_threshold="{absolute_force_torque_threshold}"
         />
       </Control>
     </Control>


### PR DESCRIPTION
Closes https://github.com/PickNikRobotics/BCR_platform_mirror/issues/30

Likely the robot or bowl positions changed slightly, moving the beginning of the path to the infeasible space.
Just makes the contour path a little shorter to make it feasible.