### PR TITLE
Fix: Derive the hangar_sim base height from the wheel geometry

### DIFF
--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -28,6 +28,11 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # Pure-data comparison of the URDF chain against the MJCF bodies; no simulator,
+  # so it stays outside the long objectives suite below.
+  ament_add_pytest_test(
+          base_geometry_test test/test_base_geometry.py
+          TIMEOUT 30)
   ament_add_pytest_test(
           forward_stereo_calibration_test test/test_forward_stereo_calibration.py
           TIMEOUT 30)

--- a/src/hangar_sim/description/hangar_scene.xml
+++ b/src/hangar_sim/description/hangar_scene.xml
@@ -17,7 +17,10 @@
          a + r            = 75.9002 mm  peak, reached only at each sphere
          a*cos(pi/N) + r  = 75.0889 mm  between spheres; the static ride height,
                                         which ur5e_ridgeback.xacro anchors to
-         hull perimeter/2pi = 75.630 mm rolling radius, for kinematics.wheels_radius
+         hull perimeter/2pi = 75.630 mm rolling radius, for the controllers'
+                                        kinematics.wheels_radius — which still reads
+                                        0.0666 in picknik_ur.ros2_control.yaml and is
+                                        corrected on feat/19667-fuse-odometry
        The 0.811 mm ripple between the first two is inherent to approximating a
        circle with N spheres — a*(1-cos(pi/N)) — and sizing them tangent would not
        remove it. They are not tangent as built: tangency wants r = 10.309 mm, so

--- a/src/hangar_sim/description/hangar_scene.xml
+++ b/src/hangar_sim/description/hangar_scene.xml
@@ -12,11 +12,19 @@
        objectives. 0.008 keeps the runner at-or-under realtime while staying
        finer than the original 0.025. Wheel velocity actuators still hold:
        armature/kv = 1.0/500 = 0.002 s < 0.008 s (see CLAUDE.md). -->
-  <!-- 20 roller spheres per mecanum wheel, sized tangent: r = a*sin(pi/N),
-       a + r = 75.9 mm. Bigger spheres overlap and self-collide, doubling the
-       contact count; smaller ones leave gaps that make the rolling radius
-       vary and shake the base. Changing N means re-expanding the keyframe
-       qpos below: N zeros per wheel, after each wheel angle. -->
+  <!-- 20 roller spheres per mecanum wheel: r = 10 mm on a ring of a = 65.9002081 mm.
+       Three radii come out of that and they are not interchangeable:
+         a + r            = 75.9002 mm  peak, reached only at each sphere
+         a*cos(pi/N) + r  = 75.0889 mm  between spheres; the static ride height,
+                                        which ur5e_ridgeback.xacro anchors to
+         hull perimeter/2pi = 75.630 mm rolling radius, for kinematics.wheels_radius
+       The 0.811 mm ripple between the first two is inherent to approximating a
+       circle with N spheres — a*(1-cos(pi/N)) — and sizing them tangent would not
+       remove it. They are not tangent as built: tangency wants r = 10.309 mm, so
+       adjacent spheres sit 0.618 mm apart. Larger r overlaps and self-collides,
+       doubling the contact count. Changing N moves all three radii and means
+       re-expanding the keyframe qpos below: N zeros per wheel, after each wheel
+       angle. -->
   <option
     integrator="implicitfast"
     timestep="0.008"

--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -78,11 +78,14 @@
     <axis xyz="1 0 0"/>
     <parent link="world" />
     <child link="virtual_rail_link_1" />
-    <!-- Height of the base above the floor, from the wheel geometry: the axle sits
-         axle_offset (0.05) above chassis_link and the wheel radius is 0.0759, so the
-         chassis must ride 0.0259 up for the wheels to touch z = 0. Keep in step with
-         the MJCF base_platform_rotation anchor. -->
-    <origin xyz="0 0 0.0259" rpy="0 0 0" />
+    <!-- Height of the base above the floor, from the wheel geometry. The roller ring is a
+         ring of N=20 spheres of r=0.010 centred at a=0.0659002081, so its envelope
+         ripples between a+r at each sphere and a*cos(pi/N)+r between them. Ride on
+         the lower figure: the base carries no z DOF, so an anchor set to the peak
+         radius leaves a wheel clear of the floor at every angle but bottom dead
+         centre. anchor = a*cos(pi/N) + r - axle_offset = 0.0750889 - 0.05.
+         Keep in step with the MJCF base_platform_rotation anchor. -->
+    <origin xyz="0 0 0.0250889" rpy="0 0 0" />
     <limit effort="1000.0" lower="-25.0" upper="25.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>

--- a/src/hangar_sim/description/ur5e_ridgeback.xacro
+++ b/src/hangar_sim/description/ur5e_ridgeback.xacro
@@ -78,11 +78,11 @@
     <axis xyz="1 0 0"/>
     <parent link="world" />
     <child link="virtual_rail_link_1" />
-    <!-- z matches the MJCF base_platform_rotation anchor (pos 0 0 -0.048), which is tuned
-         so the wheels contact the floor (the sim base has no z DOF). Without this offset
-         the robot_state_publisher chain renders the robot 48 mm above where the physics
-         (and every sensor frame) actually put it. -->
-    <origin xyz="0 0 -0.048" rpy="0 0 0" />
+    <!-- Height of the base above the floor, from the wheel geometry: the axle sits
+         axle_offset (0.05) above chassis_link and the wheel radius is 0.0759, so the
+         chassis must ride 0.0259 up for the wheels to touch z = 0. Keep in step with
+         the MJCF base_platform_rotation anchor. -->
+    <origin xyz="0 0 0.0259" rpy="0 0 0" />
     <limit effort="1000.0" lower="-25.0" upper="25.0" velocity="0.175" acceleration="10.0"/>
     <dynamics damping="20.0" friction="500.0" />
   </joint>

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -198,7 +198,7 @@
   </asset>
 
   <worldbody>
-    <body name="base_platform_rotation" pos="0 0 -0.048" euler="0 0 0">
+    <body name="base_platform_rotation" pos="0 0 0.0259" euler="0 0 0">
       <inertial mass="0.01" pos="0 0 0" diaginertia="0.001 0.001 0.001" />
       <!--      <joint-->
       <!--        type="free"-->
@@ -1494,17 +1494,17 @@
               axis="1 0 0"
               range="-0.08726 0.08726"
             />
-            <body name="front_left_wheel_link" pos="0 0.2755 0.07">
+            <body name="front_left_wheel_link" pos="0 0.2755 0">
               <include file="front_left_wheel_link.xml" />
             </body>
-            <body name="front_right_wheel_link" pos="0 -0.2755 0.07">
+            <body name="front_right_wheel_link" pos="0 -0.2755 0">
               <include file="front_right_wheel_link.xml" />
             </body>
           </body>
-          <body name="rear_left_wheel_link" pos="-0.319 0.2755 0.12">
+          <body name="rear_left_wheel_link" pos="-0.319 0.2755 0.05">
             <include file="rear_left_wheel_link.xml" />
           </body>
-          <body name="rear_right_wheel_link" pos="-0.319 -0.2755 0.12">
+          <body name="rear_right_wheel_link" pos="-0.319 -0.2755 0.05">
             <include file="rear_right_wheel_link.xml" />
           </body>
           <!-- IMU: position from ridgeback.urdf.xacro imu_joint, relative to chassis_link -->

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -198,7 +198,7 @@
   </asset>
 
   <worldbody>
-    <body name="base_platform_rotation" pos="0 0 0.0259" euler="0 0 0">
+    <body name="base_platform_rotation" pos="0 0 0.0250889" euler="0 0 0">
       <inertial mass="0.01" pos="0 0 0" diaginertia="0.001 0.001 0.001" />
       <!--      <joint-->
       <!--        type="free"-->
@@ -1516,7 +1516,7 @@
             />
             <site name="imu_site" pos="0 0 0" size="0.01" rgba="0 1 0 1" />
           </body>
-          <body name="ham_assem" pos="0 0 0.278813" euler="1.5708 -1.57079 0">
+          <body name="ham_assem" pos="0 0 0.27365" euler="1.5708 -1.57079 0">
             <geom
               name="ham_assem"
               mesh="ham_assem"

--- a/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
+++ b/src/hangar_sim/objectives/move_boxes_to_loading_zone_from_waypoint.xml
@@ -331,12 +331,15 @@
                     task="{task}"
                     velocity_scale="1.000000"
                   />
+                  <!--`manipulator` is the whole-body group, so a solve relocates the base metres
+                      from the seed with the arm low in its envelope; 0.01 s leaves pose_ik too few
+                      restarts and it returns nothing for any generated grasp about half the time.-->
                   <Action
                     ID="SetupMTCBatchPoseIK"
                     end_effector_group="moveit_ee"
                     end_effector_link="grasp_link"
                     ik_group="manipulator"
-                    ik_timeout_s="0.01"
+                    ik_timeout_s="0.05"
                     max_ik_solutions="8"
                     monitored_stage="allow collision (gripper, &lt;octomap&gt;)"
                     target_poses="{leveled_grasp_poses}"

--- a/src/hangar_sim/package.xml
+++ b/src/hangar_sim/package.xml
@@ -41,6 +41,9 @@
   <exec_depend>moveit_pro_sam2</exec_depend>
   <exec_depend>moveit_pro_sam3</exec_depend>
 
+  <!-- test_base_geometry.py resolves ridgeback_description's share directory. -->
+  <test_depend>ridgeback_description</test_depend>
+  <test_depend>ament_index_python</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
 

--- a/src/hangar_sim/test/test_base_geometry.py
+++ b/src/hangar_sim/test/test_base_geometry.py
@@ -1,10 +1,32 @@
 #!/usr/bin/env python3
 
 # Copyright 2026 PickNik Inc.
-# All rights reserved.
 #
-# Unauthorized copying of this code base via any medium is strictly prohibited.
-# Proprietary and confidential.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 """The kinematic model and the physics model must place the wheels identically.
 
@@ -31,7 +53,6 @@ from ament_index_python.packages import get_package_share_directory
 
 DESCRIPTION = Path(__file__).resolve().parent.parent / "description"
 MJCF = DESCRIPTION / "ur5e_ridgeback.xml"
-WHEEL_INCLUDE = DESCRIPTION / "front_left_wheel_link.xml"
 XACRO = DESCRIPTION / "ur5e_ridgeback.xacro"
 RIDGEBACK_XACRO = (
     Path(get_package_share_directory("ridgeback_description"))
@@ -44,12 +65,20 @@ RIDGEBACK_XACRO = (
 # correct anchor from one set to the peak radius.
 TOLERANCE_M = 1e-5
 
+# Where HAM_Assem.stl begins along its mounting axis, measured off the mesh. The mount
+# rotation maps the mesh's local +y to world +z, so the plate lands this far above the
+# joint origin.
+MESH_BASE_OFFSET_M = 0.00635
+
 WHEELS = (
     "front_left_wheel_link",
     "front_right_wheel_link",
     "rear_left_wheel_link",
     "rear_right_wheel_link",
 )
+
+# One MJCF include per wheel, each holding that wheel's ring of roller spheres.
+WHEEL_INCLUDES = tuple(DESCRIPTION / f"{wheel}.xml" for wheel in WHEELS)
 
 
 def _xacro_property(source: Path, name: str) -> float:
@@ -63,8 +92,8 @@ def _xacro_property(source: Path, name: str) -> float:
 def _base_anchor_z() -> float:
     """z of the joint that hangs the whole robot off the world frame."""
     match = re.search(
-        r'<joint name="linear_x_joint".*?<origin xyz="[-0-9.eE]+ [-0-9.eE]+ '
-        r'([-0-9.eE]+)"',
+        r'<joint name="linear_x_joint"[^>]*>(?:(?!</joint>).)*?'
+        r'<origin xyz="[-0-9.eE]+ [-0-9.eE]+ ([-0-9.eE]+)"',
         XACRO.read_text(),
         re.DOTALL,
     )
@@ -75,9 +104,10 @@ def _base_anchor_z() -> float:
 def _urdf_wheel_height() -> float:
     """World z of a wheel axle, walked down the URDF chain.
 
-    world -> ... -> chassis_link is the base anchor; chassis_link -> axle_link is
-    `axle_offset`; the rocker and wheel joints below it are planar in the vendored
-    description, so any z they gain is a change this test should catch.
+    `linear_x_joint` carries the whole robot's height; the joints between it and
+    `chassis_link` are planar, which `test_base_chain_is_otherwise_planar` holds to.
+    Below that, chassis -> axle is `axle_offset` and the rocker and wheel joints add
+    whatever z the vendored description gives them.
     """
     rocker_z, wheel_z = _rocker_and_wheel_z()
     return (
@@ -91,7 +121,8 @@ def _urdf_wheel_height() -> float:
 def _rocker_and_wheel_z() -> tuple[float, float]:
     text = RIDGEBACK_XACRO.read_text()
     rocker = re.search(
-        r'<joint name="\$\{prefix\}_rocker".*?<origin xyz="[^"]*?\s([-0-9.eE]+)"',
+        r'<joint name="\$\{prefix\}_rocker"[^>]*>(?:(?!</joint>).)*?'
+        r'<origin xyz="[^"]*?\s([-0-9.eE]+)"',
         text,
         re.DOTALL,
     )
@@ -111,19 +142,23 @@ def _roller_ring() -> tuple[float, float, int]:
     The ring is spheres, not a cylinder, so it has no single radius. Callers pick
     the one their question needs — see the comment in `hangar_scene.xml`.
     """
-    text = WHEEL_INCLUDE.read_text()
-    radii = {float(m) for m in re.findall(r'<geom\s+size="([-0-9.eE]+)"', text)}
-    assert len(radii) == 1, f"expected one sphere radius, found {sorted(radii)}"
-    centres = {
-        round(math.hypot(float(x), float(z)), 9)
-        for x, _, z in re.findall(
-            r'pos="([-0-9.eE]+)\s+([-0-9.eE]+)\s+([-0-9.eE]+)"', text
-        )
-    }
-    ring = max(centres)
-    count = len(re.findall(r"<geom\s+size=", text))
-    assert ring > 0 and count > 2, "could not read the roller ring from the wheel"
-    return ring, radii.pop(), count
+    rings = set()
+    for source in WHEEL_INCLUDES:
+        text = source.read_text()
+        radii = {float(m) for m in re.findall(r'<geom\s+size="([-0-9.eE]+)"', text)}
+        assert len(radii) == 1, f"{source.name}: sphere radii differ, {sorted(radii)}"
+        centres = {
+            round(math.hypot(float(x), float(z)), 9)
+            for x, _, z in re.findall(
+                r'pos="([-0-9.eE]+)\s+([-0-9.eE]+)\s+([-0-9.eE]+)"', text
+            )
+        }
+        count = len(re.findall(r"<geom\s+size=", text))
+        assert max(centres) > 0 and count > 2, f"{source.name}: no roller ring found"
+        rings.add((round(max(centres), 9), radii.pop(), count))
+    # One wheel standing in for four is only sound while they are the same wheel.
+    assert len(rings) == 1, f"the four wheels carry different rollers: {sorted(rings)}"
+    return rings.pop()
 
 
 def _static_ride_height() -> float:
@@ -154,6 +189,67 @@ def _mjcf_wheel_heights() -> dict[str, float]:
     return heights
 
 
+def test_base_chain_is_otherwise_planar() -> None:
+    """`_urdf_wheel_height` reads one joint's z; the rest of the chain must add none."""
+    text = XACRO.read_text() + RIDGEBACK_XACRO.read_text()
+    for joint in ("linear_y_joint", "rotational_yaw_joint", "base_link_joint"):
+        match = re.search(
+            rf'<joint name="{joint}"[^>]*>(?:(?!</joint>).)*?'
+            rf'<origin xyz="[-0-9.eE]+ [-0-9.eE]+ ([-0-9.eE]+)"',
+            text,
+            re.DOTALL,
+        )
+        if match is None:
+            continue  # no origin means the identity, which is what we want
+        assert float(match.group(1)) == pytest.approx(0.0, abs=TOLERANCE_M), (
+            f"{joint} now adds {float(match.group(1)):+.6f} m of height, which the "
+            f"wheel-height walk does not account for."
+        )
+
+
+def _rotation_of(body: ET.Element) -> str | None:
+    """The body's orientation, or None when it is the identity however it is written."""
+    identities = {
+        "euler": (0.0, 0.0, 0.0),
+        "quat": (1.0, 0.0, 0.0, 0.0),
+        "zaxis": (0.0, 0.0, 1.0),
+        "xyaxes": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+    }
+    for attr, identity in identities.items():
+        raw = body.get(attr)
+        if raw is None:
+            continue
+        values = tuple(float(v) for v in raw.split())
+        if len(values) != len(identity) or any(
+            abs(v - i) > 1e-9 for v, i in zip(values, identity)
+        ):
+            return f'{attr}="{raw}"'
+    return None
+
+
+def test_no_rotation_above_the_wheels() -> None:
+    """The MJCF height walk sums `pos` only, so a rotated parent would invalidate it."""
+
+    def walk(element: ET.Element) -> None:
+        for body in element.findall("body"):
+            name = body.get("name", "")
+            if name in WHEELS:
+                continue
+            rotation = _rotation_of(body)
+            if rotation is not None and any(
+                child.get("name", "") in WHEELS for child in body.iter("body")
+            ):
+                raise AssertionError(
+                    f"{name} sits above a wheel and carries {rotation}; summing pos z "
+                    f"down this chain no longer gives a world height."
+                )
+            walk(body)
+
+    worldbody = ET.parse(MJCF).getroot().find("worldbody")
+    assert worldbody is not None
+    walk(worldbody)
+
+
 def test_mjcf_describes_every_wheel() -> None:
     """A wheel missing from the MJCF would make the comparisons below vacuous."""
     assert sorted(_mjcf_wheel_heights()) == sorted(WHEELS)
@@ -175,7 +271,7 @@ def test_urdf_wheel_radius_matches_the_rollers() -> None:
     """The URDF cylinder stands in for the MJCF spheres; it must match their peak."""
     ring, radius, _ = _roller_ring()
     declared = _xacro_property(RIDGEBACK_XACRO, "wheel_radius")
-    assert ring + radius == pytest.approx(declared, abs=1e-5), (
+    assert ring + radius == pytest.approx(declared, abs=TOLERANCE_M), (
         f"the roller ring reaches {ring + radius:.7f} m but the URDF collision cylinder is "
         f"{declared:.7f} m. Re-sizing the rollers without updating the URDF leaves "
         f"the two models describing different wheels."
@@ -195,8 +291,8 @@ def test_wheels_rest_on_the_floor() -> None:
 def test_arm_mount_agrees_between_the_models() -> None:
     """The 5 mm that matters: an offset here lands at the gripper."""
     urdf = re.search(
-        r'<joint name="ham_assem_joint".*?<origin xyz="[-0-9.eE]+ [-0-9.eE]+ '
-        r'([-0-9.eE]+)"',
+        r'<joint name="ham_assem_joint"[^>]*>(?:(?!</joint>).)*?'
+        r'<origin xyz="[-0-9.eE]+ [-0-9.eE]+ ([-0-9.eE]+)"',
         XACRO.read_text(),
         re.DOTALL,
     )
@@ -205,10 +301,17 @@ def test_arm_mount_agrees_between_the_models() -> None:
         MJCF.read_text(),
     )
     assert urdf and mjcf, "could not read the ham_assem mount from both models"
-    assert float(urdf.group(1)) == pytest.approx(
-        float(mjcf.group(1)), abs=TOLERANCE_M
-    ), (
-        f"the arm mounts at {float(urdf.group(1)):.6f} m in the URDF and "
+    urdf_z = float(urdf.group(1))
+    assert urdf_z == pytest.approx(float(mjcf.group(1)), abs=TOLERANCE_M), (
+        f"the arm mounts at {urdf_z:.6f} m in the URDF and "
         f"{float(mjcf.group(1)):.6f} m in the MJCF, so every arm frame is offset "
         f"between TF and the physics."
+    )
+
+    # Agreeing on a wrong height would still pass the check above, so pin the mount to
+    # the thing it exists to sit on.
+    deck = _xacro_property(RIDGEBACK_XACRO, "deck_height")
+    assert urdf_z + MESH_BASE_OFFSET_M == pytest.approx(deck, abs=TOLERANCE_M), (
+        f"the arm plate lands at {urdf_z + MESH_BASE_OFFSET_M:.6f} m rather than on "
+        f"the {deck:.6f} m deck."
     )

--- a/src/hangar_sim/test/test_base_geometry.py
+++ b/src/hangar_sim/test/test_base_geometry.py
@@ -21,6 +21,7 @@ friends) and would tie these assertions to launch configuration they do not care
 about. No simulator, no ROS.
 """
 
+import math
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -30,6 +31,7 @@ from ament_index_python.packages import get_package_share_directory
 
 DESCRIPTION = Path(__file__).resolve().parent.parent / "description"
 MJCF = DESCRIPTION / "ur5e_ridgeback.xml"
+WHEEL_INCLUDE = DESCRIPTION / "front_left_wheel_link.xml"
 XACRO = DESCRIPTION / "ur5e_ridgeback.xacro"
 RIDGEBACK_XACRO = (
     Path(get_package_share_directory("ridgeback_description"))
@@ -37,8 +39,10 @@ RIDGEBACK_XACRO = (
     / "ridgeback.urdf.xacro"
 )
 
-# Slack for float formatting across the two file formats, not a physical tolerance.
-TOLERANCE_M = 0.001
+# Slack for decimal rounding between the two file formats, not a physical tolerance.
+# It has to stay well under the roller ring's 0.811 mm ripple, or the check cannot tell a
+# correct anchor from one set to the peak radius.
+TOLERANCE_M = 1e-5
 
 WHEELS = (
     "front_left_wheel_link",
@@ -101,6 +105,38 @@ def _rocker_and_wheel_z() -> tuple[float, float]:
     return float(rocker.group(1)), float(wheel.group(1))
 
 
+def _roller_ring() -> tuple[float, float, int]:
+    """Ring radius, sphere radius and sphere count of one mecanum roller ring.
+
+    The ring is spheres, not a cylinder, so it has no single radius. Callers pick
+    the one their question needs — see the comment in `hangar_scene.xml`.
+    """
+    text = WHEEL_INCLUDE.read_text()
+    radii = {float(m) for m in re.findall(r'<geom\s+size="([-0-9.eE]+)"', text)}
+    assert len(radii) == 1, f"expected one sphere radius, found {sorted(radii)}"
+    centres = {
+        round(math.hypot(float(x), float(z)), 9)
+        for x, _, z in re.findall(
+            r'pos="([-0-9.eE]+)\s+([-0-9.eE]+)\s+([-0-9.eE]+)"', text
+        )
+    }
+    ring = max(centres)
+    count = len(re.findall(r"<geom\s+size=", text))
+    assert ring > 0 and count > 2, "could not read the roller ring from the wheel"
+    return ring, radii.pop(), count
+
+
+def _static_ride_height() -> float:
+    """Distance from the axle to the floor once the roller ring has settled.
+
+    Between spheres the envelope drops to `a*cos(pi/N) + r`; the peak `a + r` is
+    reached only N times per revolution. The base has no z DOF, so anchoring to the
+    peak leaves the wheel clear of the floor at every other angle.
+    """
+    ring, radius, count = _roller_ring()
+    return ring * math.cos(math.pi / count) + radius
+
+
 def _mjcf_wheel_heights() -> dict[str, float]:
     """World z of each wheel body, accumulated down the MJCF body nesting."""
     heights: dict[str, float] = {}
@@ -135,12 +171,44 @@ def test_urdf_and_mjcf_agree_on_wheel_height(wheel: str) -> None:
     )
 
 
+def test_urdf_wheel_radius_matches_the_rollers() -> None:
+    """The URDF cylinder stands in for the MJCF spheres; it must match their peak."""
+    ring, radius, _ = _roller_ring()
+    declared = _xacro_property(RIDGEBACK_XACRO, "wheel_radius")
+    assert ring + radius == pytest.approx(declared, abs=1e-5), (
+        f"the roller ring reaches {ring + radius:.7f} m but the URDF collision cylinder is "
+        f"{declared:.7f} m. Re-sizing the rollers without updating the URDF leaves "
+        f"the two models describing different wheels."
+    )
+
+
 def test_wheels_rest_on_the_floor() -> None:
-    """Agreeing on a wrong height is still wrong: the axle sits one radius up."""
-    radius = _xacro_property(RIDGEBACK_XACRO, "wheel_radius")
-    contact = _urdf_wheel_height() - radius
+    """Taken from the MJCF rollers, so a change to them alone still fails."""
+    contact = _urdf_wheel_height() - _static_ride_height()
     assert contact == pytest.approx(0.0, abs=TOLERANCE_M), (
         f"the wheels contact z = {contact:+.4f} m rather than the floor. Negative "
-        f"means the robot is modelled sunk into the ground plane; positive means "
-        f"it floats."
+        f"means the robot is modelled sunk into the ground plane; positive means it "
+        f"floats — and with no z DOF on the base, nothing settles it."
+    )
+
+
+def test_arm_mount_agrees_between_the_models() -> None:
+    """The 5 mm that matters: an offset here lands at the gripper."""
+    urdf = re.search(
+        r'<joint name="ham_assem_joint".*?<origin xyz="[-0-9.eE]+ [-0-9.eE]+ '
+        r'([-0-9.eE]+)"',
+        XACRO.read_text(),
+        re.DOTALL,
+    )
+    mjcf = re.search(
+        r'<body name="ham_assem" pos="[-0-9.eE]+ [-0-9.eE]+ ([-0-9.eE]+)"',
+        MJCF.read_text(),
+    )
+    assert urdf and mjcf, "could not read the ham_assem mount from both models"
+    assert float(urdf.group(1)) == pytest.approx(
+        float(mjcf.group(1)), abs=TOLERANCE_M
+    ), (
+        f"the arm mounts at {float(urdf.group(1)):.6f} m in the URDF and "
+        f"{float(mjcf.group(1)):.6f} m in the MJCF, so every arm frame is offset "
+        f"between TF and the physics."
     )

--- a/src/hangar_sim/test/test_base_geometry.py
+++ b/src/hangar_sim/test/test_base_geometry.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+# All rights reserved.
+#
+# Unauthorized copying of this code base via any medium is strictly prohibited.
+# Proprietary and confidential.
+
+"""The kinematic model and the physics model must place the wheels identically.
+
+They are authored in separate files — the URDF chain in `ur5e_ridgeback.xacro`
+plus the vendored `ridgeback_description`, and the MJCF bodies in
+`ur5e_ridgeback.xml` — with nothing tying the two together. When they drift, TF,
+the nav footprint and collision checking describe a robot the simulator is not
+running, and nothing fails loudly: only the wheels carry collision geometry
+against the ground plane, so MuJoCo stays happy while the rendered robot sinks.
+
+The checks read the description sources directly rather than expanding the
+xacro, which would need the launch's argument set (`visual_parameters_file` and
+friends) and would tie these assertions to launch configuration they do not care
+about. No simulator, no ROS.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from ament_index_python.packages import get_package_share_directory
+
+DESCRIPTION = Path(__file__).resolve().parent.parent / "description"
+MJCF = DESCRIPTION / "ur5e_ridgeback.xml"
+XACRO = DESCRIPTION / "ur5e_ridgeback.xacro"
+RIDGEBACK_XACRO = (
+    Path(get_package_share_directory("ridgeback_description"))
+    / "urdf"
+    / "ridgeback.urdf.xacro"
+)
+
+# Slack for float formatting across the two file formats, not a physical tolerance.
+TOLERANCE_M = 0.001
+
+WHEELS = (
+    "front_left_wheel_link",
+    "front_right_wheel_link",
+    "rear_left_wheel_link",
+    "rear_right_wheel_link",
+)
+
+
+def _xacro_property(source: Path, name: str) -> float:
+    match = re.search(
+        rf'<xacro:property\s+name="{name}"\s+value="([-0-9.eE]+)"', source.read_text()
+    )
+    assert match, f"{source.name} has no numeric xacro:property named {name!r}"
+    return float(match.group(1))
+
+
+def _base_anchor_z() -> float:
+    """z of the joint that hangs the whole robot off the world frame."""
+    match = re.search(
+        r'<joint name="linear_x_joint".*?<origin xyz="[-0-9.eE]+ [-0-9.eE]+ '
+        r'([-0-9.eE]+)"',
+        XACRO.read_text(),
+        re.DOTALL,
+    )
+    assert match, "linear_x_joint has no parsable origin in ur5e_ridgeback.xacro"
+    return float(match.group(1))
+
+
+def _urdf_wheel_height() -> float:
+    """World z of a wheel axle, walked down the URDF chain.
+
+    world -> ... -> chassis_link is the base anchor; chassis_link -> axle_link is
+    `axle_offset`; the rocker and wheel joints below it are planar in the vendored
+    description, so any z they gain is a change this test should catch.
+    """
+    rocker_z, wheel_z = _rocker_and_wheel_z()
+    return (
+        _base_anchor_z()
+        + _xacro_property(RIDGEBACK_XACRO, "axle_offset")
+        + rocker_z
+        + wheel_z
+    )
+
+
+def _rocker_and_wheel_z() -> tuple[float, float]:
+    text = RIDGEBACK_XACRO.read_text()
+    rocker = re.search(
+        r'<joint name="\$\{prefix\}_rocker".*?<origin xyz="[^"]*?\s([-0-9.eE]+)"',
+        text,
+        re.DOTALL,
+    )
+    wheel = re.search(
+        r'<xacro:wheel prefix="\$\{prefix\}" side="left">\s*'
+        r'<origin xyz="[^"]*?\s([-0-9.eE]+)"',
+        text,
+        re.DOTALL,
+    )
+    assert rocker and wheel, "could not read the rocker/wheel origins from ridgeback"
+    return float(rocker.group(1)), float(wheel.group(1))
+
+
+def _mjcf_wheel_heights() -> dict[str, float]:
+    """World z of each wheel body, accumulated down the MJCF body nesting."""
+    heights: dict[str, float] = {}
+
+    def walk(element: ET.Element, z: float) -> None:
+        for body in element.findall("body"):
+            body_z = z + float(body.get("pos", "0 0 0").split()[2])
+            if body.get("name", "") in WHEELS:
+                heights[body.get("name", "")] = body_z
+            walk(body, body_z)
+
+    worldbody = ET.parse(MJCF).getroot().find("worldbody")
+    assert worldbody is not None, f"{MJCF.name} has no <worldbody>"
+    walk(worldbody, 0.0)
+    return heights
+
+
+def test_mjcf_describes_every_wheel() -> None:
+    """A wheel missing from the MJCF would make the comparisons below vacuous."""
+    assert sorted(_mjcf_wheel_heights()) == sorted(WHEELS)
+
+
+@pytest.mark.parametrize("wheel", WHEELS)
+def test_urdf_and_mjcf_agree_on_wheel_height(wheel: str) -> None:
+    """The two models must not drift apart, whatever height they agree on."""
+    urdf_z = _urdf_wheel_height()
+    mjcf_z = _mjcf_wheel_heights()[wheel]
+    assert urdf_z == pytest.approx(mjcf_z, abs=TOLERANCE_M), (
+        f"{wheel}: the URDF chain puts the axle at {urdf_z:.4f} m and the MJCF at "
+        f"{mjcf_z:.4f} m. TF and collision checking follow the URDF while the "
+        f"physics follows the MJCF."
+    )
+
+
+def test_wheels_rest_on_the_floor() -> None:
+    """Agreeing on a wrong height is still wrong: the axle sits one radius up."""
+    radius = _xacro_property(RIDGEBACK_XACRO, "wheel_radius")
+    contact = _urdf_wheel_height() - radius
+    assert contact == pytest.approx(0.0, abs=TOLERANCE_M), (
+        f"the wheels contact z = {contact:+.4f} m rather than the floor. Negative "
+        f"means the robot is modelled sunk into the ground plane; positive means "
+        f"it floats."
+    )


### PR DESCRIPTION

[Screencast from 2026-08-25 23-20-59.webm](https://github.com/user-attachments/assets/6c903743-a384-456e-8631-0fb1db15a755)


## Motivation

`hangar_sim` hung the robot off the world frame at z = −0.048, which put the wheels 74 mm below the floor and the chassis 44 mm into it. Viewed from under the ground plane the whole base is visibly through it. Addresses PickNikRobotics/moveit_pro#21933.

The anchor was a compensation, and says so:

> z matches the MJCF base_platform_rotation anchor (pos 0 0 -0.048), which is tuned so the wheels contact the floor (the sim base has no z DOF).

It was compensating for the MJCF placing the wheel bodies 70 mm higher than the URDF chain does.

## Brief description

The meshes decide which model is wrong, so this does not need a judgement call:

| mesh | z extent | what it fixes |
|---|---|---|
| `wheel.stl` | ±0.0395, radius 0.0761 in x/y | disc centred on its origin — the joint origin *is* the axle |
| `rocker.stl` | ±0.0600, symmetric | no downward crank; the axle sits mid-rocker |
| `body.stl` | +0.0037 … +0.2755 | the chassis lies entirely above its link origin |

With the URDF as authored (`axle_offset` 0.05, no wheel z) the wheel contacts 0.0259 below the chassis origin and the body bottom is 0.0037 above it — a 29.6 mm ground clearance, internally consistent. Add the MJCF's extra 0.07 and the contact point lands *above* the chassis bottom, which cannot happen. **The URDF chain is sound; the MJCF wheel placement is not.**

So the wheel geometry needed no change in either the vendored `ridgeback_description` (untouched here) or the URDF. What was wrong is the anchor, and it follows from the geometry rather than from tuning:

```
anchor = a·cos(π/N) + r − axle_offset = 0.0750889 − 0.05 = +0.0250889
```

`a·cos(π/N) + r` rather than the `a + r` outer radius, because the wheel is a ring of N=20 spheres and not a cylinder: the peak is reached only 20× per revolution, and the base carries no z DOF to take up the 0.811 mm ripple between spheres. Anchoring to the peak leaves wheels hanging clear at every other angle. Caught in review — the first version of this PR made exactly that mistake.

Three files change: the anchor in `ur5e_ridgeback.xacro`; the MJCF brought into agreement (front wheels 0.07 → 0, rear 0.12 → 0.05, anchor likewise, and `ham_assem` 0.278813 → 0.27365); and the roller comment in `hangar_scene.xml`, which claimed a tangency the spheres do not have.

The `ham_assem` correction is pre-existing rather than introduced here, and it is the same bug one link up — 5.163 mm between the models, which lands at the gripper rather than at a wheel. `HAM_Assem.stl` runs from y=+0.006350 and the mount rotation maps local y to world z, so the URDF's 0.27365 + 0.00635 = 0.280000 = `deck_height`: the arm sits on the deck, and the URDF is the correct side again.

## How it was tested

Measured against live TF on a running `hangar_sim`, before and after:

| | before | after | expected |
|---|---|---|---|
| `chassis_link` z | −0.048 | 0.025 | +0.0250889 |
| wheel link z | +0.002 | 0.075 | +0.0750889 |
| wheel contact | −0.0739 | **0.000 … 0.811 mm penetration** | in contact at every angle |
| ground clearance | −44 mm | **28.8 mm** | 28.8 mm |
| `ham_assem_link` z | — | 0.299 | 0.0250889 + 0.27365 |

`Navigate to Clicked Point` succeeds and the wheels hold 0.076 for the whole drive. Launch log carries only the four pre-existing `rotational_yaw_joint` startup errors.

`colcon test --packages-select hangar_sim`: the new `base_geometry_test` is 6/6. One unrelated pre-existing failure in `forward_stereo_publisher_test` is untouched by this change.

Every `hangar_sim` Objective that `skip_objectives` keeps out of CI was then run from the Desktop App against the fixed tree, and all pass: `ML Move Boxes to Loading Zone` (full drain), `Find and Spray Plane`, `Solution - Spray Plane`, `Solution - Find and Spray Plane`, `Cartesian Path with Collision Checking`, `Cartesian Plan Simple Square`, `Solution - Draw Square`, `Solution - Draw Picknik`, `Reset MuJoCo Sim`. `Move Boxes Looping` is `KeepRunningUntilFailure` and cannot terminate, so it ran one clean pick cycle and was cancelled. `ML Move Boxes` was the only regression.

## The pick regression this surfaced

Raising the base moves the arm 68 mm higher relative to the boxes (73.1 mm of chassis rise, less the 5.163 mm `ham_assem` correction). That broke `ML Move Boxes to Loading Zone`: `pose IK` returned no solution for any of the 32 generated grasps, and the Objective failed without executing a single pick motion.

It is not a reach limit. `manipulator` is the whole-body group, so IK can always drive the base closer, and perception is camera-relative, so the perceived box moves only 5 mm — what changes is that the arm must reach 67.9 mm deeper in the planning model. What fails is a marginal collision-aware solve: `pose_ik_distance.yaml` runs `optimize_distance` with `optimization_timeout: 0.005`, and the Objective allowed `ik_timeout_s="0.01"`.

Ten solves per condition, single-pose MTC probe against the live scene:

| condition | solved |
|---|---|
| box top (0.250 m), `ik_timeout_s` 0.01 | 5-7 / 10 |
| box top + 68 mm, `ik_timeout_s` 0.01 | 10 / 10 |
| box top, `ik_timeout_s` 0.05 | 10 / 10 |
| either height, no octomap | 12 / 12 |

The last row identifies the mechanism: with no octomap in the scene both heights solve every time, so the pressure is collision checking rather than kinematics.

The fix is `ik_timeout_s` 0.01 to 0.05 in `move_boxes_to_loading_zone_from_waypoint.xml`, the value `compute_ik_plan_and_move.xml` already uses. Geometry is unchanged.

A/B on the same scene, swapping only the anchor:

| geometry | IK failures | trajectories executed | outcome |
|---|---|---|---|
| this branch, before the fix | 10 | 1 (the drive to the waypoint) | failed in under 3 minutes |
| `main` | 4 | 39 | repeated pick cycles |
| this branch, with the fix | 0 | 22 | repeated pick cycles, full drain succeeds |

## The new test, and why it is trustworthy

`test/test_base_geometry.py` walks the URDF chain and the MJCF body nesting and asserts they agree, then that the wheels rest on z = 0. It reads the description sources directly rather than expanding the xacro, which would drag in the launch's argument set (`visual_parameters_file` and friends) for assertions that do not care about it. No simulator, no ROS, 0.03 s.

Every assertion was mutation-checked rather than merely observed to pass:

- restoring the −0.048 anchor fails 5 of 8, reporting `contact z = -0.0739 m`
- raising one MJCF wheel by 0.07 fails **only** the agreement test — both models still "touch the floor", so nothing but the cross-model comparison catches that drift
- re-sizing the rollers alone, exactly the edit #875 made (r 0.010 → 0.0165), fails 2 of 8. The first version of this test read `wheel_radius` from the URDF on both sides and would have passed that silently
- restoring `ham_assem` to 0.278813 fails 1 of 8
- setting the anchor back to the peak radius fails 1 of 8 — which the first version also missed, because `TOLERANCE_M` was 1e-3, larger than the 0.811 mm error it was meant to catch. It is 1e-5 now

## Effect on base jitter

#21933 raised the possibility that this mismatch was contributing to the `hangar_sim` base jitter. It was, and correcting it makes the base **quieter and far more repeatable**. Three nav runs per geometry, same goal, fresh sim each run, one variable changed:

| geometry | rocker peak-to-peak | median | spread | sd |
|---|---|---|---|---|
| original (`main`) | 0.292 / 0.348 / 0.314 | 0.314° | 0.056 | 0.0223–0.0397 |
| peak-radius anchor | 0.871 / 0.463 / 1.362 | 0.871° | 0.899 | 0.0186–0.0251 |
| **this PR** | 0.204 / 0.216 / 0.191 | **0.204°** | **0.025** | **0.0113–0.0177** |

No overlap with either other condition — the worst run here (0.216°) sits below the best original one (0.292°) — and the spread collapses from 0.899 to 0.025.

The middle row is the instructive one. It is this PR's earlier revision, which anchored to the wheels' peak radius `a + r`; with no z DOF on the base that left three of four wheels hanging clear of the floor at the keyframe, so the robot started on one corner and the excursions went erratic. Anchoring to the envelope between spheres puts all four in contact and the jitter drops below where it started.

An earlier version of this description read that the correction *increases* rocker excursion, on the strength of that middle row. That was wrong: the increase belonged to the bad anchor, not to the corrected geometry. Thanks to @bkanator for catching the anchor error, which is what made the difference visible.

This still does not establish how much the real Ridgeback rocks — that needs hardware, or someone who knows the platform.

## Release notes

- `Bug Fix:` Fixed the `hangar_sim` Ridgeback base being modelled below the floor, which placed the wheels 74 mm underground and left TF, the navigation footprint and collision checking describing a robot the simulator was not running.
- `Bug Fix:` Fixed the `hangar_sim` UR5e mount sitting 5.2 mm higher in the simulation than in TF, which offset every arm frame between the two. Grasp poses tuned against the old simulation may need re-checking.




