### PR TITLE
Fix: Enable MPPI open_loop to restore hangar_sim nav speed on 9.4

### DIFF
--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -151,6 +151,10 @@ controller_server:
       vy_max: 0.5
       wz_max: 1.9
       iteration_count: 1
+      # Seed each rollout from the last commanded velocity instead of the
+      # reported odometry, which lags and otherwise pins the commanded speed
+      # near a third of vx_max on Jazzy (moveit_pro issue #21730).
+      open_loop: true
       prune_distance: 1.7
       transform_tolerance: 0.1
       temperature: 0.3


### PR DESCRIPTION
[written by AI]

> [!WARNING]
> **Draft — inert until the moveit_pro side lands.** The stock Jazzy `nav2_mppi_controller` shipped on the 9.4 line (`1.3.12`) does not declare `open_loop`, so this line is silently ignored today. It only takes effect once the 9.4 image ships `nav2_mppi_controller` 1.3.13 or newer. Do not merge before then.

## Problem

Nav2's MPPI controller drives the `hangar_sim` base at roughly a third of its configured speed on the 9.4 Jazzy line — the same Humble→Jazzy regression tracked on 10.0 as PickNikRobotics/moveit_pro#21202, measured within noise on v9.4 in PickNikRobotics/moveit_pro#21730:

| Metric | 10.0/main | v9.4 |
|---|---|---|
| `/cmd_vel_nav` mean | 0.165 m/s | 0.161 m/s |
| `/cmd_vel_nav` max | 0.173 m/s | 0.177 m/s |
| ground-truth mean | 0.138 m/s | 0.131 m/s |

`vx_max` is 0.5. MPPI seeds each control cycle's rollout from the robot's last *reported* velocity (`/odom`) rather than its own last *commanded* velocity, so lagging odometry re-anchors the optimizer near the current speed every cycle and the command never climbs. Raising `vx_max` does not help — the cap is absolute, not proportional.

## Approach

`open_loop: true` makes MPPI integrate from its own last command instead. It is the option added by ros-navigation/navigation2#5617, backported to the `jazzy` branch by ros-navigation/navigation2#6336 (merged 2026-08-11) and released as nav2 **1.3.13** (tagged 2026-08-21; `open_loop` confirmed present in `nav2_mppi_controller/include/nav2_mppi_controller/models/optimizer_settings.hpp` at that tag).

This is the v9.4 counterpart of #840, which carries the identical hunk against v10.0. The `FollowPath` MPPI block is byte-identical between the two branches, so the change ports without adaptation.

## Blocking dependency

The 9.4 image must first pick up nav2 1.3.13. As of this writing it has not been built:

- `packages.ros.org` jazzy serves `ros-jazzy-nav2-mppi-controller 1.3.12-1noble.20260615.165555`
- the newest `snapshots.ros.org/jazzy` snapshot, `2026-06-18`, carries the same 1.3.12
- `v9.4`'s `Dockerfile` pins `ROS_JAZZY_SNAPSHOT_DATESTAMP="2026-04-13"`, older still

The moveit_pro-side change is a bump of that datestamp to the first snapshot carrying 1.3.13, and it cannot be written until such a snapshot exists. needs: moveit_pro/#21972

## Manual verification

Once the image ships 1.3.13, confirm the parameter is actually live rather than silently dropped:

- `ros2 param get /controller_server FollowPath.open_loop` returns `True` (stock 1.3.12 returns "Parameter not set")
- `/cmd_vel_nav` reaches `vx_max` (0.5 m/s) on a straight `NavigateToPose` goal, against the ~0.17 m/s baseline

Closes part of PickNikRobotics/moveit_pro#21730.

