### PR TITLE
Fix: Octomap Example Objective description typo and stale RViz mention

### DIFF
--- a/src/lab_sim/objectives/octomap_example.xml
+++ b/src/lab_sim/objectives/octomap_example.xml
@@ -3,7 +3,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Octomap Example"
-    _description="Takes a snapshot of the scene camera and then updates the planning scene in RViz with an ocotomap based on the `sensors_3d.yaml` file settings."
+    _description="Takes a snapshot of the scene camera and then updates the planning scene with an octomap based on the `sensors_3d.yaml` file settings."
     _favorite="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">


### PR DESCRIPTION
[written by AI]

## Motivation

The `Octomap Example` Objective's description is shown in the Objective header in the MoveIt Pro Desktop App, and it is wrong in two ways. It also appears in a 10.0 release-note screenshot whose blurb reads "See what the robot thinks is occupied without opening RViz", so the screenshot currently contradicts the sentence above it.

## Brief description

One line, `src/lab_sim/objectives/octomap_example.xml:6`:

- "ocotomap" was a typo for "octomap".
- "updates the planning scene **in RViz**" pointed users at the wrong tool. The planning scene (URDF, point clouds, octomaps, meshes, primitives) renders in the Desktop App's 3D Visualizer, per [About the User Interface](https://docs.picknik.ai/how_to/custom_view_panes/about_the_user_interface/#3d-visualization-pane). RViz is not deprecated wholesale, so the fix is to stop naming the wrong tool rather than to name a replacement.

New description:

> Takes a snapshot of the scene camera and then updates the planning scene with an octomap based on the `sensors_3d.yaml` file settings.

The visualization surface is left unnamed rather than swapped for the Desktop App, because the sentence is about what the Objective does to the planning scene, not about where you look at it.

Related but independent: [moveit_pro#22003](https://github.com/PickNikRobotics/moveit_pro/pull/22003) does the same cleanup in `src/docs/`. No file overlap with this PR, and neither depends on the other.

## How it was tested

No build or runtime test: the change is a static `_description` attribute with no parsing or behavior effect.

- `xmllint --noout src/lab_sim/objectives/octomap_example.xml` passes.
- `grep -rni rviz src/*/objectives/` confirms this was the only RViz mention in any Objective description in the workspace. Remaining RViz references under `moveit_pro_kinova_configs/space_satellite_sim` are launch files and `.rviz` configs, not user-facing prose, and are untouched.
- `grep -rln "Octomap Example"` shows the only other reference is `src/lab_sim/test/objectives_integration_test.py:287`, which matches on the Objective `ID` (unchanged), not the description.

## Release notes

- `Bug Fix:` Fixed the `Octomap Example` Objective description, which contained a typo and referred to RViz rather than the planning scene.

---

## Claude agent checks

- [x] `code-reviewer`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; No required changes, no suggested improvements. Verified XML validity and that no other file references the old text.
- [x] SKIPPED `documentation-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; not a moveit_pro docs or design-doc change
- [x] SKIPPED `licensing-privacy-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no third-party code, models, or data flows
- [x] SKIPPED `platform-architect-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no backend, C++, ROS, REST, or build/CI code
- [x] SKIPPED `roboticist-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; description text only, no planning, control, kinematics, or sim behavior
- [x] SKIPPED `frontend-noah-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no frontend files
- [x] SKIPPED `security-auditor`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no security-sensitive surface
- [x] SKIPPED `compatibility-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; Objective `ID` and ports unchanged, so no public surface is affected
- [x] SKIPPED `sonar-bot`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no C, C++, Python, JavaScript, or TypeScript in the diff
- [x] SKIPPED `test-runner`
  - SHA: ac6b4f4e12a4dc1662f5f6b28115893dc7cd2834; no buildable or testable code in the diff



