### PR TITLE
Fix: Raise vla_sim stacking objective path tolerance above sim servo lag

### DIFF
--- a/src/vla_sim/objectives/stack_cubes_with_the_vla_policy.xml
+++ b/src/vla_sim/objectives/stack_cubes_with_the_vla_policy.xml
@@ -31,7 +31,7 @@
         dt="0.1"
         committed_action_steps="20"
         num_interpolation_points="200"
-        goal_path_tolerance="0.3"
+        goal_path_tolerance="0.5"
         policy_tracking_weight="300.0"
         policy_uses_real_time_chunking="true"
         guidance_horizon="18"


### PR DESCRIPTION
[written by AI]

Running `Stack Cubes with the VLA Policy` repeatedly without resetting the scene aborts about 8 s into motion with `Path tolerance violated on joint_6 (deviation 0.3001 > tolerance 0.3000)`. In a 5-run series at defaults, 4 of 5 runs failed this way.

The abort is pure servo tracking lag, not contact: the FT wrench stays flat through the abort. The arm's MuJoCo `<position>` actuators in `gen3_7dof.xml` (kp=130, kv=45 on the wrist) track a moving reference with a steady-state lag of (kv/kp)*v = 0.346*v and a 0.35 s time constant, both confirmed by recording `controller_state` during an aborting run (0.42 rad lag while joint_6 rides its 1.2218 rad/s limit). Every arm joint has the same ~0.33 ratio, so the velocity limits in `joint_limits.yaml` permit lag of up to ~0.45 rad, above the objective's 0.3 tolerance. Any joint sustaining more than ~0.87 rad/s for ~0.7 s aborts by construction, which the policy routinely commands on a scene where the cubes are already stacked. Even clean successful runs peak within 0.04 rad of the gate, and the objective's own Move to Waypoint leg rides the same limit to 0.43 rad of deviation, surviving only because it falls back to the controller's `default_path_tolerance: 0.5`.

Raising `goal_path_tolerance` to 0.5 matches that controller default. Servo lag alone can then never trip the gate (that would take a sustained velocity above the joint velocity limits), so the tolerance goes back to catching contact and stalls, which still abort within ~0.1 s of a hard stall at speed. Verified on a live sim stack: at 0.3, 4 of 5 consecutive no-reset runs aborted at ~8 s; at 0.5, 5 of 5 completed.
