### PR TITLE
Port the image-based lidar to hangar_sim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ src/vla_sim/hf_cache/*
 # Machine-local launcher/workspace settings and secrets (HF_TOKEN etc.).
 .env
 .env.*
+
+# rosout.ndjson is written into the working directory by any rclpy node that runs
+# outside a launch session -- the lidar_flattener tests instantiate LidarFlattener
+# directly, so pytest drops one inside src/hangar_sim/.
+rosout.ndjson

--- a/src/hangar_sim/CMakeLists.txt
+++ b/src/hangar_sim/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
 
 install(PROGRAMS
   script/forward_stereo_publisher.py
+  script/lidar_flattener.py
   script/odometry_joint_state_publisher.py
   script/odom_qos_relay.py
   DESTINATION lib/${PROJECT_NAME}
@@ -38,6 +39,9 @@ if(BUILD_TESTING)
           TIMEOUT 30)
   ament_add_pytest_test(
           forward_stereo_publisher_test test/test_forward_stereo_publisher.py
+          TIMEOUT 60)
+  ament_add_pytest_test(
+          lidar_flattener_test test/test_lidar_flattener.py
           TIMEOUT 60)
   # Redirect ROS node logs into the test_results tree so the test-results CI
   # artifact ships them back too. Default would be ~/.ros/log/, which lives

--- a/src/hangar_sim/description/hangar.xml
+++ b/src/hangar_sim/description/hangar.xml
@@ -1,5 +1,32 @@
 <mujoco>
   <compiler angle="radian" meshdir="assets" autolimits="true" />
+
+  <default>
+    <!-- Structural collision meshes the lidars have to see.
+
+         The TIM571s are THREE_D_LIDAR cameras now, so they measure by rendering,
+         and the render pass skips group 3, which is what class="collision" is.
+         These 32 are the perimeter walls and box obstacles: unlike the other 45
+         collision_* meshes, they have no visual counterpart at the 0.175 m scan
+         plane, so leaving them in group 3 cost each unit roughly half its beams.
+         Promoting them makes the camera see what mj_ray saw (811/811 beams agree,
+         ranges to 0.009 mm), which is what keeps maps/ and the AMCL tuning valid.
+
+         Side effect: they are now visible to every camera too, but only in the
+         far field: the nearest surface that moves is 7.19 m out, so
+         manipulation perception is unaffected. contype/conaffinity are stated,
+         not inherited, to make clear this changes appearance only, not
+         collision. -->
+    <default class="collision_scannable">
+      <geom
+        type="mesh"
+        group="2"
+        contype="1"
+        conaffinity="1"
+        material="walls"
+      />
+    </default>
+  </default>
   <visual>
     <headlight diffuse="0.5 0.5 0.5" ambient="0.6 0.6 0.6" specular="0 0 0" />
     <rgba haze="0.15 0.25 0.35 1" />
@@ -384,7 +411,7 @@
       quat="0.9604685306549072 0.0 0.0 -0.27838853001594543"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube_004 geom"
         mesh="collision_Cube_004"
@@ -1641,7 +1668,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane geom"
         mesh="collision_Plane"
@@ -1653,7 +1680,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.001 geom"
         mesh="collision_Plane.001"
@@ -1665,7 +1692,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.002 geom"
         mesh="collision_Plane.002"
@@ -1677,7 +1704,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.003 geom"
         mesh="collision_Plane.003"
@@ -1689,7 +1716,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.004 geom"
         mesh="collision_Plane.004"
@@ -1701,7 +1728,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.005 geom"
         mesh="collision_Plane.005"
@@ -1713,7 +1740,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.006 geom"
         mesh="collision_Plane.006"
@@ -1725,7 +1752,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.007 geom"
         mesh="collision_Plane.007"
@@ -1737,7 +1764,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.008 geom"
         mesh="collision_Plane.008"
@@ -1749,7 +1776,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.009 geom"
         mesh="collision_Plane.009"
@@ -1761,7 +1788,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube geom"
         mesh="collision_Cube"
@@ -1786,7 +1813,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.001 geom"
         mesh="collision_Cube.001"
@@ -1798,7 +1825,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.002 geom"
         mesh="collision_Cube.002"
@@ -1810,7 +1837,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.004 geom"
         mesh="collision_Cube.004"
@@ -1822,7 +1849,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.005 geom"
         mesh="collision_Cube.005"
@@ -1834,7 +1861,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.006 geom"
         mesh="collision_Cube.006"
@@ -1846,7 +1873,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.007 geom"
         mesh="collision_Cube.007"
@@ -1858,7 +1885,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.008 geom"
         mesh="collision_Cube.008"
@@ -1870,7 +1897,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.009 geom"
         mesh="collision_Cube.009"
@@ -1882,7 +1909,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.010 geom"
         mesh="collision_Cube.010"
@@ -1894,7 +1921,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.011 geom"
         mesh="collision_Cube.011"
@@ -1906,7 +1933,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.012 geom"
         mesh="collision_Cube.012"
@@ -1918,7 +1945,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.013 geom"
         mesh="collision_Cube.013"
@@ -1930,7 +1957,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.014 geom"
         mesh="collision_Cube.014"
@@ -1942,7 +1969,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube.015 geom"
         mesh="collision_Cube.015"
@@ -1980,7 +2007,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.010 geom"
         mesh="collision_Plane.010"
@@ -1992,7 +2019,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.011 geom"
         mesh="collision_Plane.011"
@@ -2004,7 +2031,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Plane.012 geom"
         mesh="collision_Plane.012"
@@ -2276,7 +2303,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_SM_Room_426.003 geom"
         mesh="collision_SM_Room_426.003"
@@ -2289,7 +2316,7 @@
       quat="1.0 0.0 0.0 0.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_SM_Room_426.004 geom"
         mesh="collision_SM_Room_426.004"
@@ -2522,7 +2549,7 @@
       quat="4.371138828673793e-08 0.0 0.0 -1.0"
     >
       <geom
-        class="collision"
+        class="collision_scannable"
         type="mesh"
         name="collision_Cube_002_001 geom"
         mesh="collision_Cube_002_001"

--- a/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
+++ b/src/hangar_sim/description/picknik_ur_mujoco_ros2_control.xacro
@@ -3,15 +3,16 @@
   <xacro:macro name="picknik_ur_mujoco_ros2_control" params="mujoco_model mujoco_viewer:=false publish_odom:=true">
 
     <ros2_control name="ur_mujoco_control" type="system">
-      <!-- Per-LiDAR topic routing. Sensor names match the MJCF site-name prefix
-           (the portion before the '-' in replicated rangefinder site names).
-           Each LiDAR publishes to its own topic so Nav2's obstacle layer can
-           treat them as independent observation sources. -->
+      <!-- Sensor names match the MJCF <camera> names. These publish an organized
+           PointCloud2, never a LaserScan, so the override is points_topic rather
+           than the <rangefinder> path's topic. lidar_flattener converts each
+           cloud back into /scan_{front,rear}, leaving every consumer unchanged.
+           Names are absolute so they stay out of this node's namespace. -->
       <sensor name="lidar_front">
-        <param name="topic">/scan_front</param>
+        <param name="points_topic">/lidar_front/points</param>
       </sensor>
       <sensor name="lidar_rear">
-        <param name="topic">/scan_rear</param>
+        <param name="points_topic">/lidar_rear/points</param>
       </sensor>
       <!-- Move the plugin's per-camera monocular camera_info off the ROS sibling
            name of the stereo source images. That info carries the same K and
@@ -32,7 +33,12 @@
           <param name="mujoco_model_package">hangar_sim</param>
           <param name="render_publish_rate">20</param>
           <param name="tf_publish_rate">60</param>
-          <param name="lidar_publish_rate">10</param>
+          <!-- 10 Hz is the cadence the <rangefinder> path published scans at, kept
+               so /scan_{front,rear} stay on their old timing. Note this does not
+               bound render cost: the 3 tiles per scanner render on the render
+               timer regardless, taking the scene from 3 offscreen renders per tick
+               to 9. Not yet profiled. -->
+          <param name="point_cloud_publish_rate">10</param>
           <param name="publish_odom">${publish_odom}</param>
           <param name="odom_child_frame">ridgeback_base_link</param>
           <param name="odom_rate">150</param>
@@ -47,7 +53,7 @@
           <param name="odom_publish_tf">false</param>
           <param name="odom_frame">odom</param>
           <param name="publish_mj_world_tf">false</param>
-          <!-- Stop the lidar TF fill-in chain at the robot's base instead of walking to
+          <!-- Stop the site TF fill-in chain at the robot's base instead of walking to
                the MJCF worldbody. Without this, MuJoCo broadcasts
                base_platform -> ridgeback_base_link, a second parent for a frame that
                robot_state_publisher already publishes. -->

--- a/src/hangar_sim/description/ur5e_ridgeback.xml
+++ b/src/hangar_sim/description/ur5e_ridgeback.xml
@@ -4,8 +4,17 @@
   <option integrator="implicitfast" />
 
   <!-- Camera user parameter 0 selects the picknik_mujoco_ros depth type:
-       0=RGB_DEPTH, 1=RGB_ONLY, 2=THREE_D_LIDAR. -->
-  <size nuser_sensor="6" nuser_cam="1" />
+       0=RGB_DEPTH, 1=RGB_ONLY, 2=THREE_D_LIDAR. nuser_cam must be 4, not 1: a
+       THREE_D_LIDAR camera reads user[1..3] as (FOV_X deg, RANGE_MIN m, RANGE_MAX m).
+       Two distinct failures sit below 4, and only the second is quiet. At 0 or 1 the
+       plugin THROWS ("does not define the horizontal field of view"), because FOV_X is
+       user[1] and it requires nuser_cam >= 2 to read it. At 2 or 3 it constructs
+       silently but takes the else branch that leaves range_min=0 and
+       range_max=DBL_MAX, so the lidars stop honoring the TIM571's 0.05 to 25 m spec
+       with no diagnostic. Only nuser_cam == 4 applies the declared ranges. MuJoCo
+       zero-pads the shorter user="1" on the stereo cameras, which leaves them
+       RGB_ONLY as before. -->
+  <size nuser_sensor="6" nuser_cam="4" />
 
   <default>
     <default class="ur5e">
@@ -263,9 +272,14 @@
                center would occlude the stereo images. A regression test pins
                that margin (test_forward_stereo_calibration.py).
                contype/conaffinity remove these from contact dynamics but not
-               from mj_ray, which the rangefinder lidars use; what keeps them
-               out of the front scan is height: the mast's lower cap sits at
-               z=0.30, clear of the z=0.15 scan plane.
+               from the offscreen render pass, which is what the depth-camera
+               lidars below now measure through; two independent things keep
+               this bar out of both scans. Height: the mast's lower cap sits at
+               z=0.30, clear of the z=0.15 scan plane, and only the elevation-0
+               row of each lidar cloud is flattened into a LaserScan. Bearing:
+               at x=0.41 the bar sits behind the front unit (x=+0.45) and ahead
+               of the rear one (x=-0.45), so it falls inside the 90 deg blind
+               notch of each 270 deg fan either way.
                mass="0" keeps this decorative: ridgeback_base_link declares no
                <inertial>, so MuJoCo would otherwise infer added mass and shift
                the base COM from these geoms' default density. -->
@@ -313,571 +327,107 @@
             conaffinity="0"
             group="2"
           />
-          <!-- Front SICK TIM571: mounted at x=+0.45m (front bumper), z=0.15m.
-               91 beams x 3 deg = 270 deg FOV, sweeping CCW from beam-0 at -135 deg in robot frame.
-               Quat rule: site Z axis = beam-0 firing direction. Site X axis must point in world -Z
-               so the plugin's Rot(-90,Y) produces a Z-up _ROS frame.
-               Formula: R_base = Rot_Z(phi) * Rot_Y(+90 deg), where phi = beam-0 robot-frame angle.
-               Front: phi=-135 deg -> R_base = Rot_Z(-135)*Rot_Y(90) -> quat=(0.2706,0.6533,0.2706,-0.6533).
-               angle_min=0 in rangefinder user params so the plugin sets _ROS frame X = beam-0 direction. -->
+          <!-- Both TIM571s are rendered from a depth camera rather than from one
+               <rangefinder> per beam. picknik_mujoco_ros reads
+               user="2 270 0.05 25.0" as (DEPTH_TYPE=THREE_D_LIDAR, FOV_X deg,
+               RANGE_MIN m, RANGE_MAX m), sweeps the camera through
+               ceil(270 / render_fov_x) yaw steps per render tick, and stitches the
+               depth images into one organized PointCloud2 of
+               resolution="811 3" beams on /lidar_{front,rear}/points.
+               script/lidar_flattener.py turns each cloud back into the
+               /scan_{front,rear} LaserScan every consumer here already reads.
+
+               811 beams over 270 deg is the TIM571's datasheet geometry: a 270 deg
+               aperture at 0.33 deg angular resolution, i.e. an increment of exactly
+               1/3 deg. Range 0.05 to 25.0 m and the 270 deg aperture are carried over
+               from the per-beam description this replaces, unchanged. The 91 beams
+               that description declared were a render-budget number, not a property of
+               the sensor: it undersampled the real scanner by 9x.
+
+               Row 1 of the 3 elevation rows is the elevation-0 row and is the only one
+               lidar_flattener reads; rows 0 and 2 sit at +/-fovy/2 and would put floor
+               and ceiling returns into the scan plane. Column h spans azimuth
+               h*(270/810) - 135 deg about the optical Z, which runs CLOCKWISE in the
+               scan frame, so the flattener reverses the row before publishing.
+
+               fovy=70 is not a physical property of the scanner, it is the render tile
+               height. With hangar_scene.xml's offscreen buffer (offwidth=1280,
+               offheight=720) it sets render_f = 360 / tan(35 deg) = 514 px and
+               render_fov_x = 2*atan(640/514) = 102.4 deg, which lands the tile count on
+               3, the fewest this buffer can cover 270 deg with, and the step on
+               90 deg. Each beam then falls at most 45 deg off its tile center, i.e.
+               514 px of the 640 px half-width, leaving 126 px of margin so no beam
+               falls off the edge of its tile; and the coarsest angular sampling, at a
+               tile center, is atan(1/514) = 0.111 deg, 3.0x finer than the 1/3 deg beam
+               pitch. Raise fovy and the margin grows but the tile center coarsens
+               toward the beam pitch, at which point the sensor interpolates its own
+               beams; lower it below 58.7 deg and the tile count, and the render cost,
+               go to 4. Unlike meta_ws's nanoScan3 pair, this tile count has NOT been
+               measured against an exact mj_ray per beam, nor profiled for render cost
+               on this scene. 3 tiles per scanner is the arithmetic minimum, chosen
+               because hangar's render thread is the tight resource here.
+
+               The camera quat points the camera's -Z (its view axis) along the mount's
+               sweep-center axis and its +Y (up) along +Z. The optical-frame site is the
+               same frame turned 180 deg about X, the convention every other camera in
+               this file uses, and is the frame the published cloud is expressed in. It
+               is group="3" so it is not itself rendered into any camera image.
+               See: https://docs.picknik.ai/how_to/configuration_tutorials/create_robot_sim_config/migrate_to_mujoco_config/#simulated-lidar-sensor -->
+          <!-- Front: the fan is centered on the mount's +X, which is the robot's +X, so
+               the sweep runs from -135 deg to +135 deg in the robot frame and the
+               blind notch sits behind the unit. That is the same window the 91-beam
+               version swept. -->
           <body name="lidar_front_mount" pos="0.45 0 0.15">
             <inertial
               mass="0.25"
               pos="0 0 0"
               diaginertia="0.0001 0.0001 0.0001"
             />
-            <site
-              name="lidar_front-0"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2706 0.6533 0.2706 -0.6533"
-            />
-            <site
-              name="lidar_front-1"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2876087 0.6459926 0.2876087 -0.6459926"
-            />
-            <site
-              name="lidar_front-2"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3044203 0.6382425 0.3044203 -0.6382425"
-            />
-            <site
-              name="lidar_front-3"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3210233 0.630055 0.3210233 -0.630055"
-            />
-            <site
-              name="lidar_front-4"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3374062 0.6214357 0.3374062 -0.6214357"
-            />
-            <site
-              name="lidar_front-5"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3535579 0.6123904 0.3535579 -0.6123904"
-            />
-            <site
-              name="lidar_front-6"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3694673 0.6029255 0.3694673 -0.6029255"
-            />
-            <site
-              name="lidar_front-7"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3851235 0.5930473 0.3851235 -0.5930473"
-            />
-            <site
-              name="lidar_front-8"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4005157 0.5827627 0.4005157 -0.5827627"
-            />
-            <site
-              name="lidar_front-9"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4156335 0.5720787 0.4156335 -0.5720787"
-            />
-            <site
-              name="lidar_front-10"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4304664 0.5610026 0.4304664 -0.5610026"
-            />
-            <site
-              name="lidar_front-11"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4450042 0.5495421 0.4450042 -0.5495421"
-            />
-            <site
-              name="lidar_front-12"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4592371 0.5377049 0.4592371 -0.5377049"
-            />
-            <site
-              name="lidar_front-13"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4731552 0.5254992 0.4731552 -0.5254992"
-            />
-            <site
-              name="lidar_front-14"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4867491 0.5129333 0.4867491 -0.5129333"
-            />
-            <site
-              name="lidar_front-15"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5000093 0.5000159 0.5000093 -0.5000159"
-            />
-            <site
-              name="lidar_front-16"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5129269 0.4867558 0.5129269 -0.4867558"
-            />
-            <site
-              name="lidar_front-17"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.525493 0.4731621 0.525493 -0.4731621"
-            />
-            <site
-              name="lidar_front-18"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5376989 0.4592441 0.5376989 -0.4592441"
-            />
-            <site
-              name="lidar_front-19"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5495362 0.4450114 0.5495362 -0.4450114"
-            />
-            <site
-              name="lidar_front-20"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.560997 0.4304737 0.560997 -0.4304737"
-            />
-            <site
-              name="lidar_front-21"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5720733 0.415641 0.5720733 -0.415641"
-            />
-            <site
-              name="lidar_front-22"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5827575 0.4005234 0.5827575 -0.4005234"
-            />
-            <site
-              name="lidar_front-23"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5930423 0.3851313 0.5930423 -0.3851313"
-            />
-            <site
-              name="lidar_front-24"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6029206 0.3694752 0.6029206 -0.3694752"
-            />
-            <site
-              name="lidar_front-25"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6123858 0.353566 0.6123858 -0.353566"
-            />
-            <site
-              name="lidar_front-26"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6214312 0.3374144 0.6214312 -0.3374144"
-            />
-            <site
-              name="lidar_front-27"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6300508 0.3210315 0.6300508 -0.3210315"
-            />
-            <site
-              name="lidar_front-28"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6382385 0.3044287 0.6382385 -0.3044287"
-            />
-            <site
-              name="lidar_front-29"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6459889 0.2876172 0.6459889 -0.2876172"
-            />
-            <site
-              name="lidar_front-30"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6532965 0.2706086 0.6532965 -0.2706086"
-            />
-            <site
-              name="lidar_front-31"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6601563 0.2534145 0.6601563 -0.2534145"
-            />
-            <site
-              name="lidar_front-32"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6665637 0.2360467 0.6665637 -0.2360467"
-            />
-            <site
-              name="lidar_front-33"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6725143 0.2185172 0.6725143 -0.2185172"
-            />
-            <site
-              name="lidar_front-34"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.678004 0.2008379 0.678004 -0.2008379"
-            />
-            <site
-              name="lidar_front-35"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.683029 0.183021 0.683029 -0.183021"
-            />
-            <site
-              name="lidar_front-36"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6875859 0.1650786 0.6875859 -0.1650786"
-            />
-            <site
-              name="lidar_front-37"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6916715 0.1470231 0.6916715 -0.1470231"
-            />
-            <site
-              name="lidar_front-38"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6952831 0.1288668 0.6952831 -0.1288668"
-            />
-            <site
-              name="lidar_front-39"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6984182 0.1106222 0.6984182 -0.1106222"
-            />
-            <site
-              name="lidar_front-40"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7010746 0.0923018 0.7010746 -0.0923018"
-            />
-            <site
-              name="lidar_front-41"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7032506 0.0739181 0.7032506 -0.0739181"
-            />
-            <site
-              name="lidar_front-42"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7049445 0.0554838 0.7049445 -0.0554838"
-            />
-            <site
-              name="lidar_front-43"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7061554 0.0370115 0.7061554 -0.0370115"
-            />
-            <site
-              name="lidar_front-44"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7068822 0.0185137 0.7068822 -0.0185137"
-            />
-            <site
-              name="lidar_front-45"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7071246 0.0000033 0.7071246 -0.0000033"
-            />
-            <site
-              name="lidar_front-46"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7068824 -0.0185071 0.7068824 0.0185071"
-            />
-            <site
-              name="lidar_front-47"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7061557 -0.0370048 0.7061557 0.0370048"
-            />
-            <site
-              name="lidar_front-48"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7049451 -0.0554772 0.7049451 0.0554772"
-            />
-            <site
-              name="lidar_front-49"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7032513 -0.0739115 0.7032513 0.0739115"
-            />
-            <site
-              name="lidar_front-50"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.7010755 -0.0922952 0.7010755 0.0922952"
-            />
-            <site
-              name="lidar_front-51"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6984192 -0.1106156 0.6984192 0.1106156"
-            />
-            <site
-              name="lidar_front-52"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6952843 -0.1288602 0.6952843 0.1288602"
-            />
-            <site
-              name="lidar_front-53"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6916729 -0.1470166 0.6916729 0.1470166"
-            />
-            <site
-              name="lidar_front-54"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6875874 -0.1650721 0.6875874 0.1650721"
-            />
-            <site
-              name="lidar_front-55"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6830307 -0.1830145 0.6830307 0.1830145"
-            />
-            <site
-              name="lidar_front-56"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6780059 -0.2008315 0.6780059 0.2008315"
-            />
-            <site
-              name="lidar_front-57"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6725164 -0.2185109 0.6725164 0.2185109"
-            />
-            <site
-              name="lidar_front-58"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6665659 -0.2360404 0.6665659 0.2360404"
-            />
-            <site
-              name="lidar_front-59"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6601587 -0.2534083 0.6601587 0.2534083"
-            />
-            <site
-              name="lidar_front-60"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.653299 -0.2706024 0.653299 0.2706024"
-            />
-            <site
-              name="lidar_front-61"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6459916 -0.2876111 0.6459916 0.2876111"
-            />
-            <site
-              name="lidar_front-62"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6382414 -0.3044227 0.6382414 0.3044227"
-            />
-            <site
-              name="lidar_front-63"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6300538 -0.3210256 0.6300538 0.3210256"
-            />
-            <site
-              name="lidar_front-64"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6214344 -0.3374085 0.6214344 0.3374085"
-            />
-            <site
-              name="lidar_front-65"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6123891 -0.3535602 0.6123891 0.3535602"
-            />
-            <site
-              name="lidar_front-66"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6029241 -0.3694695 0.6029241 0.3694695"
-            />
-            <site
-              name="lidar_front-67"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5930459 -0.3851257 0.5930459 0.3851257"
-            />
-            <site
-              name="lidar_front-68"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5827613 -0.4005179 0.5827613 0.4005179"
-            />
-            <site
-              name="lidar_front-69"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5720772 -0.4156356 0.5720772 0.4156356"
-            />
-            <site
-              name="lidar_front-70"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5610011 -0.4304684 0.5610011 0.4304684"
-            />
-            <site
-              name="lidar_front-71"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5495404 -0.4450062 0.5495404 0.4450062"
-            />
-            <site
-              name="lidar_front-72"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5377032 -0.4592391 0.5377032 0.4592391"
-            />
-            <site
-              name="lidar_front-73"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5254974 -0.4731572 0.5254974 0.4731572"
-            />
-            <site
-              name="lidar_front-74"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5129315 -0.486751 0.5129315 0.486751"
-            />
-            <site
-              name="lidar_front-75"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5000141 -0.5000112 0.5000141 0.5000112"
-            />
-            <site
-              name="lidar_front-76"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4867539 -0.5129287 0.4867539 0.5129287"
-            />
-            <site
-              name="lidar_front-77"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4731602 -0.5254947 0.4731602 0.5254947"
-            />
-            <site
-              name="lidar_front-78"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4592422 -0.5377006 0.4592422 0.5377006"
-            />
-            <site
-              name="lidar_front-79"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4450094 -0.5495379 0.4450094 0.5495379"
-            />
-            <site
-              name="lidar_front-80"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4304716 -0.5609986 0.4304716 0.5609986"
-            />
-            <site
-              name="lidar_front-81"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4156389 -0.5720748 0.4156389 0.5720748"
-            />
-            <site
-              name="lidar_front-82"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4005212 -0.5827589 0.4005212 0.5827589"
-            />
-            <site
-              name="lidar_front-83"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3851291 -0.5930437 0.3851291 0.5930437"
-            />
-            <site
-              name="lidar_front-84"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.369473 -0.602922 0.369473 0.602922"
-            />
-            <site
-              name="lidar_front-85"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3535637 -0.6123871 0.3535637 0.6123871"
-            />
-            <site
-              name="lidar_front-86"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3374121 -0.6214325 0.3374121 0.6214325"
-            />
-            <site
-              name="lidar_front-87"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3210292 -0.630052 0.3210292 0.630052"
-            />
-            <site
-              name="lidar_front-88"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3044263 -0.6382397 0.3044263 0.6382397"
-            />
-            <site
-              name="lidar_front-89"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2876148 -0.6459899 0.2876148 0.6459899"
-            />
-            <site
-              name="lidar_front-90"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2706062 -0.6532974 0.2706062 0.6532974"
-            />
-            <!-- TIM571 body: dark cylinder, visual-only -->
+            <camera
+              name="lidar_front"
+              mode="fixed"
+              pos="0 0 0"
+              quat="0.5 0.5 -0.5 -0.5"
+              fovy="70"
+              resolution="811 3"
+              user="2 270 0.05 25.0"
+            />
+            <site
+              name="lidar_front_optical_frame"
+              pos="0 0 0"
+              quat="0.5 -0.5 0.5 -0.5"
+              size="0.01"
+              group="3"
+            />
+            <!-- TIM571 housing, visual-only, split into a cap above and a cap
+                 below the scan plane so the depth camera can see out of it.
+                 This was one geom spanning z=-0.042 to +0.042 with the sensor
+                 origin inside it. That was harmless while the sensor was
+                 <rangefinder> sites, because mj_ray skips geoms in the site's own
+                 body. The render pass does not: group 2 is rendered, the scene's
+                 near plane sits at 0.0115 m (vis.map.znear * stat.extent) and the
+                 housing wall is at 0.030 m, so every beam would have returned
+                 0.030 m and both scanners would have been blind. Leaving a 12 mm
+                 window band centered on z=0 models the real TIM571's optical
+                 window and keeps the outer silhouette identical: same radius, same
+                 0.084 m total height. 6 mm of clearance is +/-11.3 deg of elevation
+                 at this radius, against a rendered tile row of 0.097 deg, so the
+                 elevation-0 row cannot clip a cap edge. -->
             <geom
-              name="lidar_front_body"
+              name="lidar_front_body_upper"
               type="cylinder"
-              size="0.030 0.042"
-              pos="0 0 0"
+              size="0.030 0.018"
+              pos="0 0 0.024"
+              rgba="0.2 0.2 0.2 1"
+              contype="0"
+              conaffinity="0"
+              group="2"
+            />
+            <geom
+              name="lidar_front_body_lower"
+              type="cylinder"
+              size="0.030 0.018"
+              pos="0 0 -0.024"
               rgba="0.2 0.2 0.2 1"
               contype="0"
               conaffinity="0"
@@ -885,568 +435,61 @@
             />
           </body>
 
-          <!-- Rear SICK TIM571: mounted at x=-0.45m (rear bumper), z=0.15m.
-               91 beams x 3 deg = 270 deg FOV, sweeping CCW from beam-0 at +45 deg in robot frame.
-               Rear: phi=+45 deg -> R_base = Rot_Z(45)*Rot_Y(90) -> quat=(0.6533,-0.2706,0.6533,0.2706).
-               angle_min=0 in rangefinder user params so the plugin sets _ROS frame X = beam-0 direction. -->
+          <!-- Rear: the fan is centered on the mount's -X, so the camera and optical
+               site carry the front quats composed with Rot_Z(180 deg). The sweep runs
+               from +45 deg to +315 deg in the robot frame, the same window the 91-beam
+               version swept. -->
           <body name="lidar_rear_mount" pos="-0.45 0 0.15">
             <inertial
               mass="0.25"
               pos="0 0 0"
               diaginertia="0.0001 0.0001 0.0001"
             />
-            <site
-              name="lidar_rear-0"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6533 -0.2706 0.6533 0.2706"
-            />
-            <site
-              name="lidar_rear-1"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6459926 -0.2876087 0.6459926 0.2876087"
-            />
-            <site
-              name="lidar_rear-2"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6382425 -0.3044203 0.6382425 0.3044203"
-            />
-            <site
-              name="lidar_rear-3"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.630055 -0.3210233 0.630055 0.3210233"
-            />
-            <site
-              name="lidar_rear-4"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6214357 -0.3374062 0.6214357 0.3374062"
-            />
-            <site
-              name="lidar_rear-5"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6123904 -0.3535579 0.6123904 0.3535579"
-            />
-            <site
-              name="lidar_rear-6"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.6029255 -0.3694673 0.6029255 0.3694673"
-            />
-            <site
-              name="lidar_rear-7"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5930473 -0.3851235 0.5930473 0.3851235"
-            />
-            <site
-              name="lidar_rear-8"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5827627 -0.4005157 0.5827627 0.4005157"
-            />
-            <site
-              name="lidar_rear-9"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5720787 -0.4156335 0.5720787 0.4156335"
-            />
-            <site
-              name="lidar_rear-10"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5610026 -0.4304664 0.5610026 0.4304664"
-            />
-            <site
-              name="lidar_rear-11"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5495421 -0.4450042 0.5495421 0.4450042"
-            />
-            <site
-              name="lidar_rear-12"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5377049 -0.4592371 0.5377049 0.4592371"
-            />
-            <site
-              name="lidar_rear-13"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5254992 -0.4731552 0.5254992 0.4731552"
-            />
-            <site
-              name="lidar_rear-14"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5129333 -0.4867491 0.5129333 0.4867491"
-            />
-            <site
-              name="lidar_rear-15"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.5000159 -0.5000093 0.5000159 0.5000093"
-            />
-            <site
-              name="lidar_rear-16"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4867558 -0.5129269 0.4867558 0.5129269"
-            />
-            <site
-              name="lidar_rear-17"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4731621 -0.525493 0.4731621 0.525493"
-            />
-            <site
-              name="lidar_rear-18"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4592441 -0.5376989 0.4592441 0.5376989"
-            />
-            <site
-              name="lidar_rear-19"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4450114 -0.5495362 0.4450114 0.5495362"
-            />
-            <site
-              name="lidar_rear-20"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4304737 -0.560997 0.4304737 0.560997"
-            />
-            <site
-              name="lidar_rear-21"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.415641 -0.5720733 0.415641 0.5720733"
-            />
-            <site
-              name="lidar_rear-22"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.4005234 -0.5827575 0.4005234 0.5827575"
-            />
-            <site
-              name="lidar_rear-23"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3851313 -0.5930423 0.3851313 0.5930423"
-            />
-            <site
-              name="lidar_rear-24"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3694752 -0.6029206 0.3694752 0.6029206"
-            />
-            <site
-              name="lidar_rear-25"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.353566 -0.6123858 0.353566 0.6123858"
-            />
-            <site
-              name="lidar_rear-26"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3374144 -0.6214312 0.3374144 0.6214312"
-            />
-            <site
-              name="lidar_rear-27"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3210315 -0.6300508 0.3210315 0.6300508"
-            />
-            <site
-              name="lidar_rear-28"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.3044287 -0.6382385 0.3044287 0.6382385"
-            />
-            <site
-              name="lidar_rear-29"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2876172 -0.6459889 0.2876172 0.6459889"
-            />
-            <site
-              name="lidar_rear-30"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2706086 -0.6532965 0.2706086 0.6532965"
-            />
-            <site
-              name="lidar_rear-31"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2534145 -0.6601563 0.2534145 0.6601563"
-            />
-            <site
-              name="lidar_rear-32"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2360467 -0.6665637 0.2360467 0.6665637"
-            />
-            <site
-              name="lidar_rear-33"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2185172 -0.6725143 0.2185172 0.6725143"
-            />
-            <site
-              name="lidar_rear-34"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.2008379 -0.678004 0.2008379 0.678004"
-            />
-            <site
-              name="lidar_rear-35"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.183021 -0.683029 0.183021 0.683029"
-            />
-            <site
-              name="lidar_rear-36"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.1650786 -0.6875859 0.1650786 0.6875859"
-            />
-            <site
-              name="lidar_rear-37"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.1470231 -0.6916715 0.1470231 0.6916715"
-            />
-            <site
-              name="lidar_rear-38"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.1288668 -0.6952831 0.1288668 0.6952831"
-            />
-            <site
-              name="lidar_rear-39"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.1106222 -0.6984182 0.1106222 0.6984182"
-            />
-            <site
-              name="lidar_rear-40"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0923018 -0.7010746 0.0923018 0.7010746"
-            />
-            <site
-              name="lidar_rear-41"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0739181 -0.7032506 0.0739181 0.7032506"
-            />
-            <site
-              name="lidar_rear-42"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0554838 -0.7049445 0.0554838 0.7049445"
-            />
-            <site
-              name="lidar_rear-43"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0370115 -0.7061554 0.0370115 0.7061554"
-            />
-            <site
-              name="lidar_rear-44"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0185137 -0.7068822 0.0185137 0.7068822"
-            />
-            <site
-              name="lidar_rear-45"
-              size="0.01"
-              pos="0 0 0"
-              quat="0.0000033 -0.7071246 0.0000033 0.7071246"
-            />
-            <site
-              name="lidar_rear-46"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.0185071 -0.7068824 -0.0185071 0.7068824"
-            />
-            <site
-              name="lidar_rear-47"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.0370048 -0.7061557 -0.0370048 0.7061557"
-            />
-            <site
-              name="lidar_rear-48"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.0554772 -0.7049451 -0.0554772 0.7049451"
-            />
-            <site
-              name="lidar_rear-49"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.0739115 -0.7032513 -0.0739115 0.7032513"
-            />
-            <site
-              name="lidar_rear-50"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.0922952 -0.7010755 -0.0922952 0.7010755"
-            />
-            <site
-              name="lidar_rear-51"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.1106156 -0.6984192 -0.1106156 0.6984192"
-            />
-            <site
-              name="lidar_rear-52"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.1288602 -0.6952843 -0.1288602 0.6952843"
-            />
-            <site
-              name="lidar_rear-53"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.1470166 -0.6916729 -0.1470166 0.6916729"
-            />
-            <site
-              name="lidar_rear-54"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.1650721 -0.6875874 -0.1650721 0.6875874"
-            />
-            <site
-              name="lidar_rear-55"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.1830145 -0.6830307 -0.1830145 0.6830307"
-            />
-            <site
-              name="lidar_rear-56"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2008315 -0.6780059 -0.2008315 0.6780059"
-            />
-            <site
-              name="lidar_rear-57"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2185109 -0.6725164 -0.2185109 0.6725164"
-            />
-            <site
-              name="lidar_rear-58"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2360404 -0.6665659 -0.2360404 0.6665659"
-            />
-            <site
-              name="lidar_rear-59"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2534083 -0.6601587 -0.2534083 0.6601587"
-            />
-            <site
-              name="lidar_rear-60"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2706024 -0.653299 -0.2706024 0.653299"
-            />
-            <site
-              name="lidar_rear-61"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.2876111 -0.6459916 -0.2876111 0.6459916"
-            />
-            <site
-              name="lidar_rear-62"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3044227 -0.6382414 -0.3044227 0.6382414"
-            />
-            <site
-              name="lidar_rear-63"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3210256 -0.6300538 -0.3210256 0.6300538"
-            />
-            <site
-              name="lidar_rear-64"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3374085 -0.6214344 -0.3374085 0.6214344"
-            />
-            <site
-              name="lidar_rear-65"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3535602 -0.6123891 -0.3535602 0.6123891"
-            />
-            <site
-              name="lidar_rear-66"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3694695 -0.6029241 -0.3694695 0.6029241"
-            />
-            <site
-              name="lidar_rear-67"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.3851257 -0.5930459 -0.3851257 0.5930459"
-            />
-            <site
-              name="lidar_rear-68"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4005179 -0.5827613 -0.4005179 0.5827613"
-            />
-            <site
-              name="lidar_rear-69"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4156356 -0.5720772 -0.4156356 0.5720772"
-            />
-            <site
-              name="lidar_rear-70"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4304684 -0.5610011 -0.4304684 0.5610011"
-            />
-            <site
-              name="lidar_rear-71"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4450062 -0.5495404 -0.4450062 0.5495404"
-            />
-            <site
-              name="lidar_rear-72"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4592391 -0.5377032 -0.4592391 0.5377032"
-            />
-            <site
-              name="lidar_rear-73"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.4731572 -0.5254974 -0.4731572 0.5254974"
-            />
-            <site
-              name="lidar_rear-74"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.486751 -0.5129315 -0.486751 0.5129315"
-            />
-            <site
-              name="lidar_rear-75"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5000112 -0.5000141 -0.5000112 0.5000141"
-            />
-            <site
-              name="lidar_rear-76"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5129287 -0.4867539 -0.5129287 0.4867539"
-            />
-            <site
-              name="lidar_rear-77"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5254947 -0.4731602 -0.5254947 0.4731602"
-            />
-            <site
-              name="lidar_rear-78"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5377006 -0.4592422 -0.5377006 0.4592422"
-            />
-            <site
-              name="lidar_rear-79"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5495379 -0.4450094 -0.5495379 0.4450094"
-            />
-            <site
-              name="lidar_rear-80"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5609986 -0.4304716 -0.5609986 0.4304716"
-            />
-            <site
-              name="lidar_rear-81"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5720748 -0.4156389 -0.5720748 0.4156389"
-            />
-            <site
-              name="lidar_rear-82"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5827589 -0.4005212 -0.5827589 0.4005212"
-            />
-            <site
-              name="lidar_rear-83"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.5930437 -0.3851291 -0.5930437 0.3851291"
-            />
-            <site
-              name="lidar_rear-84"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.602922 -0.369473 -0.602922 0.369473"
-            />
-            <site
-              name="lidar_rear-85"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.6123871 -0.3535637 -0.6123871 0.3535637"
-            />
-            <site
-              name="lidar_rear-86"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.6214325 -0.3374121 -0.6214325 0.3374121"
-            />
-            <site
-              name="lidar_rear-87"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.630052 -0.3210292 -0.630052 0.3210292"
-            />
-            <site
-              name="lidar_rear-88"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.6382397 -0.3044263 -0.6382397 0.3044263"
-            />
-            <site
-              name="lidar_rear-89"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.6459899 -0.2876148 -0.6459899 0.2876148"
-            />
-            <site
-              name="lidar_rear-90"
-              size="0.01"
-              pos="0 0 0"
-              quat="-0.6532974 -0.2706062 -0.6532974 0.2706062"
-            />
-            <!-- TIM571 body: dark cylinder, visual-only -->
+            <camera
+              name="lidar_rear"
+              mode="fixed"
+              pos="0 0 0"
+              quat="0.5 0.5 0.5 0.5"
+              fovy="70"
+              resolution="811 3"
+              user="2 270 0.05 25.0"
+            />
+            <site
+              name="lidar_rear_optical_frame"
+              pos="0 0 0"
+              quat="0.5 -0.5 -0.5 0.5"
+              size="0.01"
+              group="3"
+            />
+            <!-- TIM571 housing, visual-only, split into a cap above and a cap
+                 below the scan plane so the depth camera can see out of it.
+                 This was one geom spanning z=-0.042 to +0.042 with the sensor
+                 origin inside it. That was harmless while the sensor was
+                 <rangefinder> sites, because mj_ray skips geoms in the site's own
+                 body. The render pass does not: group 2 is rendered, the scene's
+                 near plane sits at 0.0115 m (vis.map.znear * stat.extent) and the
+                 housing wall is at 0.030 m, so every beam would have returned
+                 0.030 m and both scanners would have been blind. Leaving a 12 mm
+                 window band centered on z=0 models the real TIM571's optical
+                 window and keeps the outer silhouette identical: same radius, same
+                 0.084 m total height. 6 mm of clearance is +/-11.3 deg of elevation
+                 at this radius, against a rendered tile row of 0.097 deg, so the
+                 elevation-0 row cannot clip a cap edge. -->
             <geom
-              name="lidar_rear_body"
+              name="lidar_rear_body_upper"
               type="cylinder"
-              size="0.030 0.042"
-              pos="0 0 0"
+              size="0.030 0.018"
+              pos="0 0 0.024"
+              rgba="0.2 0.2 0.2 1"
+              contype="0"
+              conaffinity="0"
+              group="2"
+            />
+            <geom
+              name="lidar_rear_body_lower"
+              type="cylinder"
+              size="0.030 0.018"
+              pos="0 0 -0.024"
               rgba="0.2 0.2 0.2 1"
               contype="0"
               conaffinity="0"
@@ -1833,708 +876,5 @@
     <framequat objtype="site" objname="imu_site" />
     <gyro site="imu_site" />
     <accelerometer site="imu_site" />
-    <!-- Front TIM571: 270 deg FOV, 3 deg resolution (91 beams), 0.05-25m range.
-         angle_min=0 so the _ROS frame X axis points at beam-0 (per plugin convention).
-         The sweep is 0 to 4.7124 rad (270 deg) in the sensor frame, which maps to
-         beam-0 at -135 deg and beam-90 at +135 deg in the robot frame. -->
-    <rangefinder
-      site="lidar_front-0"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-1"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-2"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-3"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-4"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-5"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-6"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-7"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-8"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-9"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-10"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-11"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-12"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-13"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-14"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-15"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-16"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-17"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-18"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-19"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-20"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-21"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-22"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-23"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-24"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-25"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-26"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-27"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-28"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-29"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-30"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-31"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-32"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-33"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-34"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-35"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-36"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-37"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-38"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-39"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-40"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-41"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-42"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-43"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-44"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-45"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-46"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-47"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-48"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-49"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-50"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-51"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-52"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-53"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-54"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-55"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-56"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-57"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-58"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-59"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-60"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-61"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-62"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-63"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-64"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-65"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-66"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-67"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-68"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-69"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-70"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-71"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-72"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-73"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-74"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-75"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-76"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-77"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-78"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-79"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-80"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-81"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-82"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-83"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-84"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-85"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-86"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-87"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-88"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-89"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_front-90"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <!-- Rear TIM571: same convention — angle_min=0, frame X points at beam-0 (+45 deg robot frame). -->
-    <rangefinder site="lidar_rear-0" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-1" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-2" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-3" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-4" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-5" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-6" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-7" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-8" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder site="lidar_rear-9" user="0.05 0.0 4.7124 0.05236 0.05 25.0" />
-    <rangefinder
-      site="lidar_rear-10"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-11"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-12"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-13"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-14"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-15"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-16"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-17"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-18"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-19"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-20"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-21"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-22"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-23"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-24"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-25"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-26"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-27"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-28"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-29"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-30"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-31"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-32"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-33"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-34"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-35"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-36"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-37"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-38"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-39"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-40"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-41"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-42"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-43"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-44"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-45"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-46"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-47"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-48"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-49"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-50"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-51"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-52"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-53"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-54"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-55"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-56"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-57"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-58"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-59"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-60"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-61"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-62"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-63"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-64"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-65"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-66"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-67"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-68"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-69"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-70"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-71"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-72"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-73"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-74"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-75"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-76"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-77"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-78"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-79"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-80"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-81"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-82"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-83"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-84"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-85"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-86"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-87"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-88"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-89"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
-    <rangefinder
-      site="lidar_rear-90"
-      user="0.05 0.0 4.7124 0.05236 0.05 25.0"
-    />
   </sensor>
 </mujoco>

--- a/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
+++ b/src/hangar_sim/launch/sim/robot_drivers_to_persist_sim.launch.py
@@ -348,6 +348,72 @@ def generate_launch_description():
         output="log",
     )
 
+    # The two TIM571s are DEPTH_TYPE=THREE_D_LIDAR cameras in the MJCF, so
+    # picknik_mujoco_ros publishes them as organized PointCloud2 on
+    # /lidar_{front,rear}/points and never as a LaserScan. This node reads the
+    # elevation-0 row of each cloud and republishes it as the /scan_{front,rear}
+    # LaserScan the filter chains below, dual_laser_merger, AMCL, slam_toolbox and
+    # both costmap obstacle layers already consume. Topic names, message types,
+    # frames and the 0 to 270 deg angular window are all unchanged from the
+    # <rangefinder> path, so nothing downstream needed touching.
+    lidar_flattener = Node(
+        package="hangar_sim",
+        executable="lidar_flattener.py",
+        name="lidar_flattener",
+        parameters=[{"use_sim_time": use_sim_time}],
+        output="log",
+    )
+
+    # The frame each flattened scan is published in: z-up, X at the scan's angle_min
+    # (beam 0), which is what params/laser_filter_params.yaml computes its self-hit
+    # arcs against. MuJoCo used to broadcast these itself, as a by-product of the
+    # <rangefinder> path; a camera gets no such frame, so they are published here.
+    #
+    # Static, and parented straight to ridgeback_base_link rather than to the
+    # lidar_*_mount bodies, for two reasons. The mounts are fixed in the MJCF, so
+    # the offsets below are exact and cannot drift. And the plugin only puts those
+    # mount bodies on /tf at tf_publish_rate, arriving before every link carries its
+    # real pose: a scan frame resolved through that chain can latch a wrong mount for
+    # the rest of the session and publish beams that keep their ranges but land at
+    # wrong bearings, which reads as a map that will not close rather than as a
+    # sensor fault. Values are read out of description/ur5e_ridgeback.xml:
+    # lidar_front_mount at (+0.45, 0, 0.15) with the fan centered on +X, so beam 0
+    # sits at -135 deg; lidar_rear_mount at (-0.45, 0, 0.15) with the fan centered on
+    # -X, so beam 0 sits at +45 deg.
+    static_tf_lidar_front_ros = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_tf_lidar_front_ros",
+        output="log",
+        arguments=[
+            "0.45",
+            "0.0",
+            "0.15",
+            "-2.3561945",
+            "0.0",
+            "0.0",
+            "ridgeback_base_link",
+            "lidar_front_ROS",
+        ],
+    )
+
+    static_tf_lidar_rear_ros = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_tf_lidar_rear_ros",
+        output="log",
+        arguments=[
+            "-0.45",
+            "0.0",
+            "0.15",
+            "0.7853982",
+            "0.0",
+            "0.0",
+            "ridgeback_base_link",
+            "lidar_rear_ROS",
+        ],
+    )
+
     # Angular bounds filter: clips chassis self-hitting beams (±93° to ±135°).
     # One filter instance per lidar; each publishes its filtered scan to
     # /scan_{front,rear}_filtered for Nav2 to consume as an independent
@@ -433,6 +499,9 @@ def generate_launch_description():
     ld.add_action(static_tf_map_to_odom)
     ld.add_action(sensor_qos_relay)
     ld.add_action(forward_stereo_publisher)
+    ld.add_action(lidar_flattener)
+    ld.add_action(static_tf_lidar_front_ros)
+    ld.add_action(static_tf_lidar_rear_ros)
     ld.add_action(laser_filter_front_node)
     ld.add_action(laser_filter_rear_node)
     ld.add_action(fuse_state_estimator)

--- a/src/hangar_sim/params/laser_filter_params.yaml
+++ b/src/hangar_sim/params/laser_filter_params.yaml
@@ -6,13 +6,22 @@
 #   front lidar frame yaw = -135 deg: robot angle = scan_angle - 135 deg
 #   rear  lidar frame yaw =  +45 deg: robot angle = scan_angle + 45 deg
 #
+# The scans come from script/lidar_flattener.py, which flattens the MuJoCo
+# depth-camera lidar clouds. It preserves that window exactly -- angle_min=0,
+# angle_max=4.7124, X of the _ROS frame at beam 0 -- which is why the arcs below
+# survived the move off <rangefinder> sensors unchanged. The beam count did not:
+# the sweep now carries 811 beams at 1/3 deg rather than 91 at 3 deg. Everything
+# here is expressed in angles, not beam indices, so the bounds still bite; only
+# the beam numbers quoted below moved.
+#
 # Chassis self-hits occur in the rear corners of each lidar's sweep. Empirically
 # (measured in simulation from /scan_front raw data) the self-hit beams are:
 #   scan  0-30 deg  (0.000-0.524 rad): rear-corner hits at 0.25-0.28 m
 #   scan 240-270 deg (4.189-4.712 rad): rear-corner hits at 0.25-0.39 m
-# Bounds widened slightly (-0.01 to 0.54 rad, 4.18 to 4.72 rad) to catch beam 0
-# (exactly 0 rad) and beam 80 (exactly 240 deg = 4.189 rad) which sat on the
+# Bounds widened slightly (-0.01 to 0.54 rad, 4.18 to 4.72 rad) to catch the beam
+# at exactly 0 rad and the one at exactly 240 deg (4.189 rad) which sat on the
 # filter boundary and slipped through, creating obstacle trails in the costmap.
+# At 3 deg those were beams 0 and 80; at 1/3 deg they are beams 0 and 720.
 # Valid obstacle returns begin at scan ~33 deg. Filtering only these two narrow
 # arcs removes all chassis self-hits while preserving the maximum useful coverage.
 # Combined, each lidar keeps ~230 deg of valid arc; the two lidars together give

--- a/src/hangar_sim/script/lidar_flattener.py
+++ b/src/hangar_sim/script/lidar_flattener.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Turns each MuJoCo 3D-lidar point cloud into the LaserScan the rest of the stack expects.
+
+Both simulated SICK TIM571s are <camera> sensors with DEPTH_TYPE=THREE_D_LIDAR, so
+picknik_mujoco_ros publishes them as an organized PointCloud2 rather than as a LaserScan.
+Everything downstream of /scan_front and /scan_rear -- the two laser_filters chains, then
+dual_laser_merger, then beluga_amcl on /scan_merged and both Nav2 costmap obstacle layers
+on the filtered scans -- is built on LaserScan, and neither AMCL nor slam_toolbox accepts a
+cloud at all. Flattening here keeps every one of those topics identical in name, type,
+frame and angular window to what the <rangefinder> path published, so nothing else in the
+package has to know which sensor model produced the scan. In particular
+params/laser_filter_params.yaml keys its two self-hit rejection arcs off angle_min=0 and
+angle_max=4.7124 in the lidar_*_ROS frame, and those still hold.
+
+The cloud is `resolution` beams wide and 3 rows tall. Row 1 is the elevation-0 row and is
+the only one that belongs in a 2D scan; rows 0 and 2 sit at +/-fovy/2 and would put floor
+and ceiling returns into the scan plane. Columns run from azimuth -fov_x/2 to +fov_x/2
+about the camera's optical Z, which is clockwise in the scan frame, so they are reversed to
+give the counter-clockwise LaserScan convention.
+
+Column order and the scan frame are fixed by the MJCF and are checked in against it: for
+the front unit, column 810 lands at -135 deg and column 0 at +135 deg in the mount frame,
+so after the reversal beam 0 sits at -135 deg, which is exactly where lidar_front_ROS puts
+its X axis. If the camera or optical-site quaternions in description/ur5e_ridgeback.xml
+change, these change with them.
+"""
+
+import math
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import (
+    QoSDurabilityPolicy,
+    QoSHistoryPolicy,
+    QoSProfile,
+    QoSReliabilityPolicy,
+)
+from sensor_msgs.msg import LaserScan, PointCloud2
+
+
+class LidarFlattener(Node):
+    """Publishes one LaserScan per configured 3D-lidar point cloud."""
+
+    def __init__(self):
+        super().__init__("lidar_flattener")
+
+        self.declare_parameter("lidars", ["lidar_front", "lidar_rear"])
+        # The published window is the one the <rangefinder> path published and the one
+        # params/laser_filter_params.yaml is written against: angle_min 0, angle_max
+        # 4.7124 rad (270 deg), X of the lidar_*_ROS frame at beam 0. The sweep must equal
+        # the camera's user[FOV_X] and the beam count its resolution width in
+        # description/ur5e_ridgeback.xml, or these angles stop describing the columns
+        # published. At resolution="811 3" the increment works out to exactly 1/3 deg,
+        # which is the TIM571's datasheet angular resolution.
+        self.declare_parameter("angle_min", 0.0)
+        self.declare_parameter("angle_max", math.radians(270.0))
+        # Neither fan ends on its own housing here, and the chassis self-hits that do
+        # occur are already rejected downstream by the two angular-bounds stages in
+        # params/laser_filter_params.yaml. Trimming in this node as well would move
+        # angle_min off 0 and silently invalidate those bounds, so it defaults off.
+        self.declare_parameter("trim_low_deg", 0.0)
+        self.declare_parameter("trim_high_deg", 0.0)
+        self.declare_parameter("range_min", 0.05)
+        self.declare_parameter("range_max", 25.0)
+        # Off by default, which reproduces the <rangefinder> path exactly: it declared a
+        # beam_std_dev the plugin never applied, so the old scan carried no noise either.
+        # The rendered sensor is likewise noiseless, landing within a millimetre or two of
+        # an exact ray cast. The TIM571 datasheet gives a 20 mm statistical error at 10%
+        # reflectivity, so set this to 0.02 to model the real scanner -- but that is a
+        # behavior change for AMCL and both costmaps, not a port, so it is left to a
+        # deliberate follow-up rather than folded in here.
+        self.declare_parameter("range_noise_stddev", 0.0)
+        # The sensor reports to the millimetre. Rounding to the same grid keeps a consumer
+        # from reading precision out of the simulation that the hardware cannot give it.
+        self.declare_parameter("range_quantum", 0.001)
+
+        lidars = self.get_parameter("lidars").value
+        self.angle_min = float(self.get_parameter("angle_min").value)
+        self.angle_max = float(self.get_parameter("angle_max").value)
+        self.trim_low_deg = float(self.get_parameter("trim_low_deg").value)
+        self.trim_high_deg = float(self.get_parameter("trim_high_deg").value)
+        self.range_min = float(self.get_parameter("range_min").value)
+        self.range_max = float(self.get_parameter("range_max").value)
+        self.noise = float(self.get_parameter("range_noise_stddev").value)
+        self.quantum = float(self.get_parameter("range_quantum").value)
+        self.rng = np.random.default_rng()
+        self._last_stamp = {}
+        self._logged_window = set()
+
+        # BEST_EFFORT to match the plugin's SensorDataQoS on the cloud, and to match what
+        # the laser_filters chains already subscribe to /scan_{front,rear} with.
+        qos = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            durability=QoSDurabilityPolicy.VOLATILE,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=5,
+        )
+
+        self.publishers_by_name = {}
+        for name in lidars:
+            self.declare_parameter(f"{name}.points_topic", f"/{name}/points")
+            suffix = name.rsplit("_", 1)[-1]
+            self.declare_parameter(f"{name}.scan_topic", f"/scan_{suffix}")
+            # The <rangefinder> path published its scans in <name>_ROS, a z-up frame with
+            # X at beam 0, and MuJoCo broadcast that frame itself. Nothing publishes it
+            # once the sensor is a camera, so the launch file publishes it statically and
+            # this node keeps stamping scans with the same name.
+            self.declare_parameter(f"{name}.frame_id", f"{name}_ROS")
+            points_topic = self.get_parameter(f"{name}.points_topic").value
+            scan_topic = self.get_parameter(f"{name}.scan_topic").value
+            frame_id = self.get_parameter(f"{name}.frame_id").value
+
+            pub = self.create_publisher(LaserScan, scan_topic, qos)
+            self.publishers_by_name[name] = (pub, frame_id)
+            self.create_subscription(
+                PointCloud2,
+                points_topic,
+                lambda msg, n=name: self._cloud_callback(msg, n),
+                qos,
+            )
+            self.get_logger().info(
+                f"{name}: {points_topic} -> {scan_topic} in {frame_id}"
+            )
+
+    def _cloud_callback(self, msg, name):
+        pub, frame_id = self.publishers_by_name[name]
+
+        # The plugin sizes the cloud from the camera's resolution and publishes it on a
+        # timer that can fire before the first render, so an empty message is normal at
+        # startup rather than a fault.
+        if msg.height < 1 or msg.width < 2 or not msg.data:
+            return
+        if msg.point_step != 12 or len(msg.data) != msg.width * msg.height * 12:
+            self.get_logger().warn(
+                f"{name}: unexpected cloud layout "
+                f"({msg.width}x{msg.height}, point_step {msg.point_step}); ignoring",
+                throttle_duration_sec=5.0,
+            )
+            return
+
+        xyz = np.frombuffer(msg.data, dtype=np.float32).reshape(
+            msg.height, msg.width, 3
+        )
+        ranges = np.linalg.norm(xyz[msg.height // 2], axis=1).astype(np.float64)
+
+        # Increment comes from the sensor's full declared sweep and the cloud's own width,
+        # so trimming moves the window without disturbing the beam spacing.
+        increment = (self.angle_max - self.angle_min) / (msg.width - 1)
+        n_low = int(math.ceil(math.radians(self.trim_low_deg) / increment - 1e-9))
+        n_high = int(math.ceil(math.radians(self.trim_high_deg) / increment - 1e-9))
+        if n_low + n_high >= msg.width - 1:
+            self.get_logger().error(
+                f"{name}: trim_low_deg + trim_high_deg leaves nothing to publish; ignoring",
+                throttle_duration_sec=10.0,
+            )
+            return
+
+        # A beam that hit nothing, or hit outside [range_min, range_max], is left as NaN
+        # by the plugin's stitcher. LaserScan wants those out of range, not NaN, because
+        # AMCL and both costmap layers only skip a reading they can compare against
+        # range_max.
+        valid = np.isfinite(ranges)
+        if self.noise > 0.0:
+            ranges[valid] += self.rng.normal(0.0, self.noise, int(valid.sum()))
+        if self.quantum > 0.0:
+            ranges[valid] = np.round(ranges[valid] / self.quantum) * self.quantum
+        valid &= (ranges >= self.range_min) & (ranges <= self.range_max)
+        ranges = np.where(valid, ranges, math.inf)
+
+        # Columns run clockwise in the scan frame, so reverse first, then trim the ends of
+        # the published order.
+        ranges = ranges[::-1]
+        last = msg.width - n_high
+        ranges = ranges[n_low:last]
+
+        scan = LaserScan()
+        scan.header.stamp = msg.header.stamp
+        scan.header.frame_id = frame_id
+        scan.angle_min = self.angle_min + n_low * increment
+        scan.angle_max = scan.angle_min + (len(ranges) - 1) * increment
+        scan.angle_increment = increment
+        # The whole cloud is rendered at one instant, so there is no per-beam offset to
+        # report. The real sensor sweeps at 15 Hz and reports a beam every 82 us.
+        scan.time_increment = 0.0
+        # Measured from the gap to the previous cloud rather than assumed, because the
+        # rate is whatever point_cloud_publish_rate delivers and that is capped by the
+        # render timer this scene shares with the stereo pair and the wrist camera.
+        stamp = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+        prev = self._last_stamp.get(name)
+        self._last_stamp[name] = stamp
+        scan.scan_time = (
+            float(stamp - prev) if prev is not None and stamp > prev else 0.0
+        )
+        scan.range_min = self.range_min
+        scan.range_max = self.range_max
+        scan.ranges = ranges.astype(np.float32).tolist()
+        pub.publish(scan)
+
+        if name not in self._logged_window:
+            self._logged_window.add(name)
+            self.get_logger().info(
+                f"{name}: publishing {len(ranges)} of {msg.width} beams, "
+                f"{math.degrees(scan.angle_min):+.3f} to "
+                f"{math.degrees(scan.angle_max):+.3f} deg, "
+                f"increment {math.degrees(increment):.4f} deg"
+            )
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LidarFlattener()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hangar_sim/test/test_forward_stereo_calibration.py
+++ b/src/hangar_sim/test/test_forward_stereo_calibration.py
@@ -50,7 +50,11 @@ def test_forward_stereo_model_matches_calibration():
     root = ET.parse(MODEL).getroot()
     size = root.find("size")
     assert size is not None
-    assert size.attrib["nuser_cam"] == "1"
+    # 4, not 1: the two TIM571s are DEPTH_TYPE=THREE_D_LIDAR cameras and read
+    # user[1..3] as (FOV_X, RANGE_MIN, RANGE_MAX), which picknik_mujoco_ros only
+    # applies when nuser_cam is exactly 4. MuJoCo zero-pads the shorter user="1"
+    # on these stereo cameras, so they stay RGB_ONLY (asserted below).
+    assert size.attrib["nuser_cam"] == "4"
     cameras = {camera.attrib["name"]: camera for camera in root.iter("camera")}
     sites = {
         site.attrib["name"]: site for site in root.iter("site") if "name" in site.attrib
@@ -94,12 +98,30 @@ def test_forward_stereo_model_matches_calibration():
         int(global_visual.attrib["offwidth"]),
         int(global_visual.attrib["offheight"]),
     )
-    camera_resolutions = {
-        tuple(int(value) for value in camera.attrib["resolution"].split())
-        for document_root in (scene_root, root)
-        for camera in document_root.iter("camera")
-    }
-    assert camera_resolutions == {offscreen_resolution}
+
+    # picknik_mujoco_ros throws unless a camera's resolution equals the offscreen
+    # buffer -- it renders straight into that buffer -- with one exemption: a
+    # THREE_D_LIDAR camera (user[0] == 2) is rendered as several yaw-stepped tiles
+    # and stitched, so it declares its beam grid instead. Partition on that rather
+    # than dropping the check, so a plain camera can still not drift off the buffer.
+    def depth_type(camera):
+        user = camera.attrib.get("user", "0").split()
+        return int(float(user[0]))
+
+    def resolution(camera):
+        return tuple(int(value) for value in camera.attrib["resolution"].split())
+
+    cameras_by_kind = {"lidar": set(), "image": set()}
+    for document_root in (scene_root, root):
+        for camera in document_root.iter("camera"):
+            kind = "lidar" if depth_type(camera) == 2 else "image"
+            cameras_by_kind[kind].add(resolution(camera))
+
+    assert cameras_by_kind["image"] == {offscreen_resolution}
+    # 811 beams over the TIM571's 270 deg aperture is an increment of exactly
+    # 1/3 deg, its datasheet angular resolution; 3 elevation rows so row 1 is the
+    # elevation-0 row script/lidar_flattener.py reads.
+    assert cameras_by_kind["lidar"] == {(811, 3)}
 
 
 def test_right_projection_translation_uses_ros_stereo_convention():

--- a/src/hangar_sim/test/test_lidar_flattener.py
+++ b/src/hangar_sim/test/test_lidar_flattener.py
@@ -1,0 +1,314 @@
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Pins the contract script/lidar_flattener.py has to keep with its consumers.
+
+The flattener is the only thing standing between the MJCF's depth-camera lidars and
+params/laser_filter_params.yaml, dual_laser_merger, AMCL and both costmap obstacle layers,
+all of which were written against the <rangefinder> path. Its published window, beam order
+and beam count therefore are the interface, and each is checked here against the MJCF it
+has to agree with rather than against a copy of the numbers.
+"""
+
+import ast
+import importlib.util
+import math
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+from sensor_msgs.msg import PointCloud2, PointField
+import yaml
+
+
+PACKAGE_ROOT = Path(__file__).parents[1]
+MODEL = PACKAGE_ROOT / "description" / "ur5e_ridgeback.xml"
+FILTERS = PACKAGE_ROOT / "params" / "laser_filter_params.yaml"
+FLATTENER = PACKAGE_ROOT / "script" / "lidar_flattener.py"
+LAUNCH = PACKAGE_ROOT / "launch" / "sim" / "robot_drivers_to_persist_sim.launch.py"
+
+# Both units run the same code path, keyed only by name for the publisher and frame
+# lookup, so every behavioral check below is run against each of them rather than
+# against the front one alone.
+UNITS = ("lidar_front", "lidar_rear")
+
+
+def load_flattener_module():
+    spec = importlib.util.spec_from_file_location("lidar_flattener", FLATTENER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def launch_static_transforms():
+    """The static_transform_publisher argument lists, read out of the launch file.
+
+    Parsed rather than imported: the launch file pulls in the whole ROS launch stack,
+    and the point here is to read what it declares, not to run it.
+    """
+    tree = ast.parse(LAUNCH.read_text())
+    transforms = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call) or getattr(call.func, "id", None) != "Node":
+            continue
+        kwargs = {kw.arg: kw.value for kw in call.keywords}
+        executable = kwargs.get("executable")
+        if (
+            not isinstance(executable, ast.Constant)
+            or executable.value != "static_transform_publisher"
+        ):
+            continue
+        arguments = kwargs.get("arguments")
+        if not isinstance(arguments, ast.List):
+            continue
+        values = [
+            element.value
+            for element in arguments.elts
+            if isinstance(element, ast.Constant)
+        ]
+        # x y z yaw pitch roll parent child
+        if len(values) == 8:
+            transforms[values[-1]] = values
+    return transforms
+
+
+def mjcf_mount_positions():
+    """pos of each lidar_*_mount body, the ground truth the static TFs must match."""
+    root = ET.parse(MODEL).getroot()
+    return {
+        body.attrib["name"]: [float(value) for value in body.attrib["pos"].split()]
+        for body in root.iter("body")
+        if body.attrib.get("name", "").startswith("lidar_")
+        and body.attrib["name"].endswith("_mount")
+    }
+
+
+def lidar_cameras():
+    root = ET.parse(MODEL).getroot()
+    return {
+        camera.attrib["name"]: camera
+        for camera in root.iter("camera")
+        if int(float(camera.attrib.get("user", "0").split()[0])) == 2
+    }
+
+
+@pytest.fixture(scope="module")
+def flattener():
+    """A LidarFlattener with its declared defaults, on an initialized rclpy context."""
+    import rclpy
+
+    module = load_flattener_module()
+    rclpy.init()
+    node = module.LidarFlattener()
+    yield node
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def make_cloud(width, height, ranges_by_column, elevation_row):
+    """An organized cloud shaped like the plugin's, with one range per column.
+
+    Columns not named in ranges_by_column are NaN, which is how the plugin's stitcher
+    leaves a beam that hit nothing. Only `elevation_row` carries points, so a flattener
+    reading the wrong row sees an all-NaN scan and cannot pass by accident.
+    """
+    xyz = np.full((height, width, 3), np.nan, dtype=np.float32)
+    fov_x = 270.0
+    for column, distance in ranges_by_column.items():
+        azimuth = math.radians(column * (fov_x / (width - 1)) - fov_x / 2.0)
+        xyz[elevation_row, column] = (
+            distance * math.sin(azimuth),
+            0.0,
+            distance * math.cos(azimuth),
+        )
+
+    cloud = PointCloud2()
+    cloud.height, cloud.width = height, width
+    cloud.point_step = 12
+    cloud.row_step = width * 12
+    cloud.is_dense = False
+    cloud.fields = [
+        PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+    ]
+    cloud.data = xyz.tobytes()
+    return cloud
+
+
+def test_declared_window_matches_the_mjcf(flattener):
+    """The node's sweep and range defaults must be the ones the MJCF declares.
+
+    The plugin reads FOV_X, RANGE_MIN and RANGE_MAX off the camera and uses them to
+    build the cloud; the flattener redeclares the same three as parameters because a
+    cloud carries none of them. Two sources of truth, so they get compared.
+    """
+    cameras = lidar_cameras()
+    assert set(cameras) == {"lidar_front", "lidar_rear"}
+    for camera in cameras.values():
+        _, fov_x, range_min, range_max = (
+            float(value) for value in camera.attrib["user"].split()
+        )
+        assert flattener.angle_min == pytest.approx(0.0)
+        assert flattener.angle_max - flattener.angle_min == pytest.approx(
+            math.radians(fov_x)
+        )
+        assert flattener.range_min == pytest.approx(range_min)
+        assert flattener.range_max == pytest.approx(range_max)
+
+
+def test_declared_window_matches_the_filter_bounds():
+    """laser_filter_params.yaml's self-hit arcs assume angle_min=0, angle_max=270 deg."""
+    filters = yaml.safe_load(FILTERS.read_text())
+    for chain in ("laser_angular_filter_front", "laser_angular_filter_rear"):
+        lower = filters[chain]["ros__parameters"]["filter1"]["params"]
+        upper = filters[chain]["ros__parameters"]["filter2"]["params"]
+        # Both arcs are anchored to the ends of the sweep, and each is deliberately
+        # widened past its end so the boundary beam cannot slip through. That only
+        # holds while the flattener publishes 0 to 270 deg: a window starting
+        # anywhere else leaves the self-hits these two stages exist to remove.
+        assert lower["lower_angle"] < 0.0
+        assert upper["upper_angle"] >= math.radians(270.0)
+        assert upper["upper_angle"] - math.radians(270.0) < math.radians(1.0)
+
+
+def test_increment_is_the_tim571_datasheet_resolution(flattener):
+    """811 beams over 270 deg is exactly 1/3 deg, the TIM571's angular resolution."""
+    width = int(lidar_cameras()["lidar_front"].attrib["resolution"].split()[0])
+    assert width == 811
+    increment = (flattener.angle_max - flattener.angle_min) / (width - 1)
+    assert math.degrees(increment) == pytest.approx(1.0 / 3.0)
+
+
+@pytest.mark.parametrize("unit", UNITS)
+def test_row_is_reversed_so_beam_zero_is_the_last_column(flattener, unit):
+    """Cloud columns run clockwise; LaserScan runs counter-clockwise.
+
+    This is the one step that is easy to get backwards, and getting it backwards
+    mirrors the map rather than failing outright, so it is pinned with a distinct
+    range at each end of the sweep.
+    """
+    width, height = 811, 3
+    cloud = make_cloud(width, height, {0: 3.0, width - 1: 7.0}, elevation_row=1)
+    scan = flatten(flattener, cloud, unit)
+
+    assert len(scan.ranges) == width
+    # Column width-1 sits at the sweep's +135 deg, which is where the scan's angle_min
+    # (beam 0, X of the lidar_*_ROS frame) points.
+    assert scan.ranges[0] == pytest.approx(7.0, abs=1e-3)
+    assert scan.ranges[-1] == pytest.approx(3.0, abs=1e-3)
+    assert scan.angle_min == pytest.approx(0.0)
+    assert scan.angle_max == pytest.approx(math.radians(270.0))
+
+
+@pytest.mark.parametrize("unit", UNITS)
+def test_only_the_elevation_zero_row_is_read(flattener, unit):
+    """Rows 0 and 2 sit at +/-fovy/2 and would put floor and ceiling in the scan."""
+    width, height = 811, 3
+    for row in (0, 2):
+        cloud = make_cloud(width, height, {400: 4.0}, elevation_row=row)
+        scan = flatten(flattener, cloud, unit)
+        assert all(math.isinf(value) for value in scan.ranges)
+
+    cloud = make_cloud(width, height, {400: 4.0}, elevation_row=1)
+    scan = flatten(flattener, cloud, unit)
+    assert sum(1 for value in scan.ranges if math.isfinite(value)) == 1
+
+
+@pytest.mark.parametrize("unit", UNITS)
+def test_out_of_range_and_missing_returns_become_inf(flattener, unit):
+    """AMCL and both costmap layers only skip a reading they can compare to range_max."""
+    width, height = 811, 3
+    cloud = make_cloud(width, height, {10: 0.01, 20: 400.0, 30: 5.0}, elevation_row=1)
+    scan = flatten(flattener, cloud, unit)
+    assert not any(math.isnan(value) for value in scan.ranges)
+    assert sum(1 for value in scan.ranges if math.isfinite(value)) == 1
+    assert scan.range_min == pytest.approx(0.05)
+    assert scan.range_max == pytest.approx(25.0)
+
+
+def test_scans_are_stamped_in_the_statically_published_frames(flattener):
+    """Every frame the flattener stamps must actually be broadcast by the launch file.
+
+    A scan stamped in a frame nothing publishes is not a loud failure: tf2 simply
+    cannot transform it, and AMCL and both costmap layers drop the observation while
+    the sensor still looks alive on the topic.
+    """
+    frames = {name: frame for name, (_, frame) in flattener.publishers_by_name.items()}
+    assert frames == {"lidar_front": "lidar_front_ROS", "lidar_rear": "lidar_rear_ROS"}
+
+    transforms = launch_static_transforms()
+    for frame in frames.values():
+        assert frame in transforms, f"{frame} is stamped but never broadcast"
+        assert transforms[frame][-2] == "ridgeback_base_link"
+
+
+@pytest.mark.parametrize(
+    "unit,yaw_deg",
+    # Beam 0 is X of the _ROS frame. The front fan is centered on +X and spans 270 deg,
+    # so it starts 135 deg clockwise of center; the rear fan is centered on -X, so it
+    # starts at +45 deg. Get either wrong and the ranges stay right while the bearings
+    # rotate, which reads downstream as a map that will not close.
+    [("lidar_front", -135.0), ("lidar_rear", 45.0)],
+)
+def test_static_frames_match_the_mjcf_mounts(unit, yaw_deg):
+    """The static TFs are hand-copied from the MJCF, so they get compared to it."""
+    transform = launch_static_transforms()[f"{unit}_ROS"]
+    x, y, z, yaw = (float(value) for value in transform[:4])
+    mount = mjcf_mount_positions()[f"{unit}_mount"]
+
+    assert (x, y, z) == pytest.approx(tuple(mount)), "TF drifted from the MJCF mount"
+    assert math.degrees(yaw) == pytest.approx(yaw_deg, abs=1e-4)
+
+
+def flatten(node, cloud, unit="lidar_front"):
+    """Run one cloud through the node as `unit` and return the LaserScan published."""
+    published = []
+    publisher, frame = node.publishers_by_name[unit]
+    node.publishers_by_name[unit] = (_Capture(published), frame)
+    try:
+        node._cloud_callback(cloud, unit)
+    finally:
+        node.publishers_by_name[unit] = (publisher, frame)
+    assert len(published) == 1
+    return published[0]
+
+
+class _Capture:
+    """Stands in for a Publisher so the callback can run without a live graph."""
+
+    def __init__(self, sink):
+        self._sink = sink
+
+    def publish(self, message):
+        self._sink.append(message)


### PR DESCRIPTION
Tracking issue: PickNikRobotics/moveit_pro#22313

Ports the image-based lidar from `meta_ws` (`mike/WIP`, commit `031e691`) to `hangar_sim`.

## What changes

Both simulated SICK TIM571s were 91 MuJoCo `<rangefinder>` sensors each. MuJoCo evaluates rangefinders inside `mj_step`, so all 182 rays were charged to the physics thread and the beam count was a render-budget number rather than a property of the sensor. Each scanner is now one `<camera>` with `DEPTH_TYPE=THREE_D_LIDAR`, which `picknik_mujoco_ros` renders as depth tiles on the render thread and stitches into an organized `PointCloud2`.

| | before | after |
|---|---|---|
| sensor | 91 `<rangefinder>` per unit | one `<camera>` per unit |
| evaluated on | physics thread, in `mj_step` | render thread |
| beams | 91 at 3° | **811 at ⅓°** |
| returns in range (front / rear) | 47 / 50 | **425 / 439** |
| sweep, range | 270°, 0.05–25 m | unchanged |
| topics, types, scan frames, angular window | | unchanged |

811 beams over 270° is the TIM571's datasheet geometry — a 270° aperture at 0.33° resolution, an increment of exactly ⅓°.

`script/lidar_flattener.py` flattens the elevation-0 row of each cloud back into `/scan_front` and `/scan_rear`, so nothing downstream is touched: the two `laser_filters` chains, `dual_laser_merger`, `beluga_amcl` on `/scan_merged`, `slam_toolbox`, and both Nav2 costmap obstacle layers all see the same topics, types, `lidar_*_ROS` frames and 0–270° window as before. `params/laser_filter_params.yaml` is unchanged — its two self-hit arcs are angular, and the self-hits are unchanged.

One structural consequence worth naming: the plugin used to publish the scans itself. Now a single node stands between the sensor and every consumer, so if `lidar_flattener` dies, localization, SLAM and both costmaps go blind at once while the point clouds keep publishing and the sim still looks healthy.

## Three things this surfaced

**`nuser_cam` had to go 1 → 4.** A `THREE_D_LIDAR` camera reads `user[1..3]` as `(FOV_X, RANGE_MIN, RANGE_MAX)`, and there are two *different* failures below 4. At 0 or 1 the plugin **throws** (`"does not define the horizontal field of view"`), because `FOV_X` is `user[1]` and reading it requires `nuser_cam >= 2`. At 2 or 3 it constructs silently but takes the branch that leaves `range_min=0` and `range_max=DBL_MAX`, so the lidars quietly stop honoring the 0.05–25 m spec. Only `nuser_cam == 4` applies the declared ranges.

**The housing would have blinded both scanners.** `lidar_*_body` was one cylinder of radius 0.030 m with the sensor origin inside it. `mj_ray` skips geoms in the site's own body so the rangefinder path never saw it; the render pass has no such rule and the scene's near plane is at 0.0115 m, so every beam would have returned 0.030 m. Each housing is now two caps with a 12 mm window band on the scan plane — same radius, same height. Zero housing returns after the fix.

**32 collision meshes had to become visible.** The render pass honors `mjvOption.geomgroup` (`[1,1,1,0,0,0]`), so group 3 is invisible to it, and `class="collision"` is `group="3"`. Of the 77 `collision_*` meshes, 45 are proxies inside a visual mesh and cost the lidar nothing; the other 32 are the perimeter walls and the crates stacked along them, with no visual counterpart at the 0.175 m scan plane — the nearest visible geometry behind them is 25–59 m out (median 44 m) against a 25 m `range_max`. Left in group 3, each unit returned 209/236 of 811 beams instead of 425/439. Those 32 now carry a new `class="collision_scannable"` in `hangar.xml`: `group="2"`, `contype`/`conaffinity` stated explicitly so it is clear nothing about collision changes, plus the `walls` material.

The set was chosen by measurement, not inspection — sampled poses across the drivable floor, keeping every geom that was the first hit when nothing rendered was in range.

## Verification

**Against the compiled model, with `mj_ray`:**

- **Frames.** The static `lidar_*_ROS` transforms match the MJCF mounts exactly: translation `(±0.45, 0, 0.15)` in `ridgeback_base_link`, published beam 0 at −135° (front) and +45° (rear), elevation-0 row exactly horizontal.
- **Same world.** At a matched 811-direction sampling under both visibility rules, 811/811 beams agree on return vs no-return and the common ranges agree to 0.009 mm, front and rear. The resolution goes up 9×; the surfaces the scanner measures do not move. That is what keeps `maps/` and the AMCL tuning valid.
- **Self-hits.** Only `chassis_link` (126 beams, 0.247–0.425 m), entirely inside the two arcs `laser_filter_params.yaml` already removes.
- **Tile geometry.** `fovy=70` gives 3 tiles — the fewest a 1280×720 buffer covers 270° with — 126 px of tile margin, and 3.0× oversampling of the beam pitch.
- **Camera impact of the promotion**, over a ray grid per frustum: forward stereo 2.9%, wrist 16.4%, scene 11.7%, all far field. Nearest moved surface is 7.19 m; nothing inside 7 m changes, so manipulation perception is unaffected.

**Against a running sim** (GPU container, `nav2_mppi_controller` 1.3.13):

- Both units publish at 10 Hz, and the flattener keeps up on both: `/lidar_front/points` 10.04, `/lidar_rear/points` 9.96, `/scan_front` 10.17, `/scan_rear` 9.65, `/scan_merged` 9.78 Hz.
- Cloud shape is 3×811 in `lidar_*_optical_frame`; the scans are 811 beams in `lidar_*_ROS` with **419 / 448** valid returns, against the 425/439 predicted above (the robot is at a slightly different pose).
- Scan minimum range is **0.247 m** — exactly the `chassis_link` self-hit floor documented above, arriving independently from a live sim.
- The scene camera renders the promoted walls correctly: they read as walls, with no coarse proxy drawn over a visual mesh.

**Tests.** 15 pass (`test_lidar_flattener.py` plus the updated `test_forward_stereo_calibration.py`). The flattener tests are parametrized over *both* units, and the row-reversal, elevation-row and range-clamping cases were mutation-checked — deleting the reversal fails both units. The static TFs are compared against the MJCF mount positions and the −135°/+45° yaws by parsing the launch file, so a hand-edited transform cannot drift from the model silently. `test_base_geometry.py` needs `ridgeback_description` and was not run outside the container; it fails identically on `main`.

## Known limitations

**Visualization is worse, in two places.** Neither is a functional break, but both look like one:

1. **MuJoCo viewer no longer shows the lidar.** The viewer can draw `<rangefinder>` sensors as rays; there are none left, and it has no way to visualize a camera used as a lidar. Enabling the camera visualization flag shows the two frustums, but the beams are gone.
2. **The MoveIt Pro UI has no `LaserScan` renderer** (`LaserScan` appears only in generated type definitions). The UI's lidar entries come from `streaming_point_cloud_publisher` auto-discovering the new `PointCloud2` topics — they did not exist before this PR — and a 3×811 planar sweep renders as a thin, sparse ring up to 25 m across, which is nearly invisible zoomed in on the robot. Worth a separate issue against the UI; there is nothing to fix in `hangar_sim` for it.

**Render cost is still unprofiled.** The lidar tiles render on the render timer and there is no separate lidar render rate, so this scene goes from 3 offscreen renders per tick to 9 at `render_publish_rate=20`, each a full 1280×720 buffer. All topics hold their rates in the run above, and the objective integration test passes, but the controller-manager loop does show overruns — and without a `main` baseline measured on the same machine those cannot be attributed to this change. If the render thread turns out not to hold 20 Hz, the levers are `render_publish_rate` or `fovy=80` (still 3 tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
