### PR TITLE
Add surface coverage demo objectives

### DIFF
--- a/src/grinding_sim/objectives/cylinder_outline_poses.yaml
+++ b/src/grinding_sim/objectives/cylinder_outline_poses.yaml
@@ -1,0 +1,2976 @@
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208781
+    y: -0.236714
+    z: 0.246412
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171170
+    y: -0.236714
+    z: 0.187375
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170229
+    y: -0.226812
+    z: 0.187974
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167453
+    y: -0.217406
+    z: 0.189743
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162982
+    y: -0.208969
+    z: 0.192591
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157039
+    y: -0.201923
+    z: 0.196377
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149923
+    y: -0.196621
+    z: 0.200911
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141991
+    y: -0.193330
+    z: 0.205964
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133639
+    y: -0.192214
+    z: 0.211285
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125288
+    y: -0.193330
+    z: 0.216605
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117355
+    y: -0.196621
+    z: 0.221659
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110239
+    y: -0.201923
+    z: 0.226192
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104296
+    y: -0.208969
+    z: 0.229978
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099825
+    y: -0.217406
+    z: 0.232827
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097049
+    y: -0.226812
+    z: 0.234595
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096108
+    y: -0.236714
+    z: 0.235194
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097049
+    y: -0.246616
+    z: 0.234595
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099825
+    y: -0.256022
+    z: 0.232827
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104296
+    y: -0.264460
+    z: 0.229978
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110239
+    y: -0.271506
+    z: 0.226192
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117355
+    y: -0.276807
+    z: 0.221659
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125288
+    y: -0.280099
+    z: 0.216605
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133639
+    y: -0.281214
+    z: 0.211285
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141991
+    y: -0.280099
+    z: 0.205964
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149923
+    y: -0.276807
+    z: 0.200911
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157039
+    y: -0.271506
+    z: 0.196377
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162982
+    y: -0.264460
+    z: 0.192591
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167453
+    y: -0.256022
+    z: 0.189743
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170229
+    y: -0.246616
+    z: 0.187974
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171170
+    y: -0.236714
+    z: 0.187375
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208781
+    y: -0.236714
+    z: 0.246412
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208858
+    y: -0.141673
+    z: 0.246364
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171247
+    y: -0.141673
+    z: 0.187326
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170306
+    y: -0.131771
+    z: 0.187926
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167530
+    y: -0.122365
+    z: 0.189694
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.163059
+    y: -0.113928
+    z: 0.192542
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157116
+    y: -0.106881
+    z: 0.196328
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.150000
+    y: -0.101580
+    z: 0.200862
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.142067
+    y: -0.098289
+    z: 0.205915
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133716
+    y: -0.097173
+    z: 0.211236
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125364
+    y: -0.098289
+    z: 0.216556
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117432
+    y: -0.101580
+    z: 0.221610
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110316
+    y: -0.106881
+    z: 0.226143
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104373
+    y: -0.113928
+    z: 0.229929
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099902
+    y: -0.122365
+    z: 0.232778
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097126
+    y: -0.131771
+    z: 0.234546
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096185
+    y: -0.141673
+    z: 0.235146
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097126
+    y: -0.151575
+    z: 0.234546
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099902
+    y: -0.160981
+    z: 0.232778
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104373
+    y: -0.169418
+    z: 0.229929
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110316
+    y: -0.176464
+    z: 0.226143
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117432
+    y: -0.181766
+    z: 0.221610
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125364
+    y: -0.185057
+    z: 0.216556
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133716
+    y: -0.186173
+    z: 0.211236
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.142067
+    y: -0.185057
+    z: 0.205915
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.150000
+    y: -0.181766
+    z: 0.200862
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157116
+    y: -0.176464
+    z: 0.196328
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.163059
+    y: -0.169418
+    z: 0.192542
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167530
+    y: -0.160981
+    z: 0.189694
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170306
+    y: -0.151575
+    z: 0.187926
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171247
+    y: -0.141673
+    z: 0.187326
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208858
+    y: -0.141673
+    z: 0.246364
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208745
+    y: -0.046777
+    z: 0.246435
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171135
+    y: -0.046777
+    z: 0.187398
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170194
+    y: -0.036875
+    z: 0.187997
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167418
+    y: -0.027469
+    z: 0.189765
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162946
+    y: -0.019032
+    z: 0.192614
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157004
+    y: -0.011986
+    z: 0.196400
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149888
+    y: -0.006684
+    z: 0.200933
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141955
+    y: -0.003393
+    z: 0.205987
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133604
+    y: -0.002277
+    z: 0.211307
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125252
+    y: -0.003393
+    z: 0.216628
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117320
+    y: -0.006684
+    z: 0.221681
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110203
+    y: -0.011986
+    z: 0.226215
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104261
+    y: -0.019032
+    z: 0.230001
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099789
+    y: -0.027469
+    z: 0.232849
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097014
+    y: -0.036875
+    z: 0.234618
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096073
+    y: -0.046777
+    z: 0.235217
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097014
+    y: -0.056679
+    z: 0.234618
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099789
+    y: -0.066085
+    z: 0.232849
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104261
+    y: -0.074522
+    z: 0.230001
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110203
+    y: -0.081569
+    z: 0.226215
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117320
+    y: -0.086870
+    z: 0.221681
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125252
+    y: -0.090161
+    z: 0.216628
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133604
+    y: -0.091277
+    z: 0.211307
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141955
+    y: -0.090161
+    z: 0.205987
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149888
+    y: -0.086870
+    z: 0.200933
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157004
+    y: -0.081569
+    z: 0.196400
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162947
+    y: -0.074522
+    z: 0.192614
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167418
+    y: -0.066085
+    z: 0.189765
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170194
+    y: -0.056679
+    z: 0.187997
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171135
+    y: -0.046777
+    z: 0.187398
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208745
+    y: -0.046777
+    z: 0.246435
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208771
+    y: 0.048305
+    z: 0.246419
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171160
+    y: 0.048305
+    z: 0.187381
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170219
+    y: 0.058207
+    z: 0.187981
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167443
+    y: 0.067613
+    z: 0.189749
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162972
+    y: 0.076051
+    z: 0.192598
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157029
+    y: 0.083097
+    z: 0.196384
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149913
+    y: 0.088398
+    z: 0.200917
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141980
+    y: 0.091690
+    z: 0.205971
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133629
+    y: 0.092805
+    z: 0.211291
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125278
+    y: 0.091690
+    z: 0.216612
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117345
+    y: 0.088398
+    z: 0.221665
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110229
+    y: 0.083097
+    z: 0.226199
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104286
+    y: 0.076051
+    z: 0.229985
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099815
+    y: 0.067613
+    z: 0.232833
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097039
+    y: 0.058207
+    z: 0.234601
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096098
+    y: 0.048305
+    z: 0.235201
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097039
+    y: 0.038403
+    z: 0.234601
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099815
+    y: 0.028997
+    z: 0.232833
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104286
+    y: 0.020560
+    z: 0.229985
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110229
+    y: 0.013514
+    z: 0.226199
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117345
+    y: 0.008212
+    z: 0.221665
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125278
+    y: 0.004921
+    z: 0.216612
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133629
+    y: 0.003805
+    z: 0.211291
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141980
+    y: 0.004921
+    z: 0.205971
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149913
+    y: 0.008212
+    z: 0.200917
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157029
+    y: 0.013514
+    z: 0.196384
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162972
+    y: 0.020560
+    z: 0.192598
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167443
+    y: 0.028997
+    z: 0.189749
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170219
+    y: 0.038403
+    z: 0.187981
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171160
+    y: 0.048305
+    z: 0.187381
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208771
+    y: 0.048305
+    z: 0.246419
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208869
+    y: 0.143341
+    z: 0.246356
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171258
+    y: 0.143341
+    z: 0.187319
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170317
+    y: 0.153243
+    z: 0.187918
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167541
+    y: 0.162648
+    z: 0.189687
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.163070
+    y: 0.171086
+    z: 0.192535
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157127
+    y: 0.178132
+    z: 0.196321
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.150011
+    y: 0.183434
+    z: 0.200855
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.142079
+    y: 0.186725
+    z: 0.205908
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133727
+    y: 0.187841
+    z: 0.211229
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125376
+    y: 0.186725
+    z: 0.216549
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117443
+    y: 0.183434
+    z: 0.221603
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110327
+    y: 0.178132
+    z: 0.226136
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104384
+    y: 0.171086
+    z: 0.229922
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099913
+    y: 0.162648
+    z: 0.232771
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097137
+    y: 0.153243
+    z: 0.234539
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096196
+    y: 0.143341
+    z: 0.235138
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097137
+    y: 0.133438
+    z: 0.234539
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099913
+    y: 0.124033
+    z: 0.232771
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104384
+    y: 0.115595
+    z: 0.229922
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110327
+    y: 0.108549
+    z: 0.226136
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117443
+    y: 0.103248
+    z: 0.221603
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125376
+    y: 0.099956
+    z: 0.216549
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133727
+    y: 0.098841
+    z: 0.211229
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.142079
+    y: 0.099956
+    z: 0.205908
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.150011
+    y: 0.103248
+    z: 0.200855
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157127
+    y: 0.108549
+    z: 0.196321
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.163070
+    y: 0.115595
+    z: 0.192535
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167541
+    y: 0.124033
+    z: 0.189687
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170317
+    y: 0.133438
+    z: 0.187918
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171258
+    y: 0.143341
+    z: 0.187319
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208869
+    y: 0.143341
+    z: 0.246356
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208744
+    y: 0.238347
+    z: 0.246436
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171133
+    y: 0.238347
+    z: 0.187398
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170192
+    y: 0.248249
+    z: 0.187998
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167416
+    y: 0.257655
+    z: 0.189766
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162945
+    y: 0.266092
+    z: 0.192615
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157002
+    y: 0.273138
+    z: 0.196401
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149886
+    y: 0.278440
+    z: 0.200934
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141954
+    y: 0.281731
+    z: 0.205988
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133602
+    y: 0.282847
+    z: 0.211308
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125251
+    y: 0.281731
+    z: 0.216629
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117318
+    y: 0.278440
+    z: 0.221682
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110202
+    y: 0.273138
+    z: 0.226216
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104259
+    y: 0.266092
+    z: 0.230002
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099788
+    y: 0.257655
+    z: 0.232850
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097012
+    y: 0.248249
+    z: 0.234618
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.096071
+    y: 0.238347
+    z: 0.235218
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.097012
+    y: 0.228445
+    z: 0.234619
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.099788
+    y: 0.219039
+    z: 0.232850
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.104259
+    y: 0.210602
+    z: 0.230002
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.110202
+    y: 0.203555
+    z: 0.226216
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.117318
+    y: 0.198254
+    z: 0.221682
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.125251
+    y: 0.194963
+    z: 0.216629
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.133602
+    y: 0.193847
+    z: 0.211308
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.141954
+    y: 0.194963
+    z: 0.205988
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.149886
+    y: 0.198254
+    z: 0.200934
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.157002
+    y: 0.203555
+    z: 0.196401
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.162945
+    y: 0.210602
+    z: 0.192615
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.167416
+    y: 0.219039
+    z: 0.189766
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.170192
+    y: 0.228445
+    z: 0.187998
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.171133
+    y: 0.238347
+    z: 0.187398
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: registered_pose
+pose:
+  position:
+    x: 0.208744
+    y: 0.238347
+    z: 0.246436
+  orientation:
+    x: 0.678858
+    y: -0.678858
+    z: -0.197868
+    w: 0.197869

--- a/src/grinding_sim/objectives/grind_and_record_coverage.xml
+++ b/src/grinding_sim/objectives/grind_and_record_coverage.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Grind and Record Coverage">
+  <BehaviorTree
+    ID="Grind and Record Coverage"
+    _description="Grind the machined part and watch the ground surface fill in on the 3D view while the tool works, recorded from where the tool actually went."
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <Action ID="ClearSnapshot" />
+      <SubTree
+        ID="Move to Waypoint"
+        _collapsed="true"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        joint_group_name="manipulator"
+        waypoint_name="Retract"
+        name="View Workspace"
+      />
+      <SubTree
+        ID="Register Machined Part"
+        _collapsed="true"
+        registered_pose="{registered_pose}"
+      />
+
+      <!-- The target the coverage is accumulated against. Taken here rather than inside Take Snapshot
+           because a subtree blackboard is isolated: the parent cannot see what it captured. -->
+      <Action ID="SwitchUIPrimaryView" primary_view_name="Visualization" />
+      <Action
+        ID="GetPointCloud"
+        topic_name="/scene_camera/points"
+        message_out="{point_cloud}"
+        message_timeout_sec="15.0"
+      />
+      <Action
+        ID="SendPointCloudToUI"
+        point_cloud="{point_cloud}"
+        pcd_topic="/pcd_pointcloud_captures"
+      />
+
+      <Control ID="Fallback">
+        <Decorator ID="Timeout" msec="500">
+          <Action
+            ID="PublishTF"
+            pose="{registered_pose}"
+            publish_rate="50"
+            child_frame_id="registered_pose"
+          />
+        </Decorator>
+        <Action ID="AlwaysSuccess" />
+      </Control>
+
+      <SubTree
+        ID="Move to Waypoint"
+        _collapsed="true"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        joint_group_name="manipulator"
+        waypoint_name="Pre Grind"
+      />
+      <Action
+        ID="LoadPoseStampedVectorFromYaml"
+        output="{grinding_poses}"
+        file_path="cylinder_outline_poses.yaml"
+      />
+      <Action
+        ID="PlanCartesianPath"
+        blending_radius="0.003000"
+        ik_cartesian_space_density="0.010000"
+        ik_joint_space_density="0.100000"
+        path="{grinding_poses}"
+        planning_group_name="manipulator"
+        cartesian_constraint="[{constraint_type: position_and_orientation}]"
+        tip_links="grasp_link"
+        trajectory_timing="[{mode: cartesian_trapezoidal, max_translational_velocity: 0.05, max_rotational_velocity: 0.33, max_translational_acceleration: 0.1, max_rotational_acceleration: 1.0, trajectory_sampling_rate: 100}]"
+        debug_solution="{debug_solution}"
+        joint_trajectory_msg="{joint_trajectory_msg}"
+      />
+
+      <!-- The grind and the recording run together. A Parallel is what ends the session whether the
+           pass finishes or fails; a Sequence would leave the Runtime sampling forever. -->
+      <Control ID="Parallel" success_count="1" failure_count="1">
+        <Action
+          ID="ExecuteTrajectory"
+          joint_trajectory_msg="{joint_trajectory_msg}"
+        />
+        <Action
+          ID="AccumulateSurfaceCoverage"
+          target_cloud="{point_cloud}"
+          tool_frame="grasp_link"
+          treated_color="255;40;40"
+          footprint_radius="0.015"
+          footprint_range="0.040"
+          sample_rate_hz="20.0"
+          max_tool_speed="0.12"
+          covered_points="{covered_points}"
+        />
+      </Control>
+
+      <Action ID="LogMessage" message="Ground surface recorded." />
+      <SubTree
+        ID="Move to Waypoint"
+        _collapsed="true"
+        controller_action_server="/joint_trajectory_admittance_controller/follow_joint_trajectory"
+        controller_names="joint_trajectory_admittance_controller"
+        joint_group_name="manipulator"
+        waypoint_name="Approach"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Grind and Record Coverage">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - Grinding" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/grinding_sim/test/objectives_integration_test.py
+++ b/src/grinding_sim/test/objectives_integration_test.py
@@ -58,6 +58,8 @@ skip_objectives: set[str] = {
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
     "Register Machined Part",  # Registration flow exceeds the fixture timeout headless.
+    # Runs the same registration subtree before it grinds, so it inherits that timeout.
+    "Grind and Record Coverage",
 }
 
 

--- a/src/lab_sim/objectives/live_surface_coverage_demo.xml
+++ b/src/lab_sim/objectives/live_surface_coverage_demo.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Live Surface Coverage Demo">
+  <BehaviorTree
+    ID="Live Surface Coverage Demo"
+    _description="Watch the treated surface fill in while the tool sweeps, recorded from where the tool actually goes."
+  >
+    <Control ID="Sequence" name="root">
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+      />
+      <SubTree ID="Close Gripper" _collapsed="true" />
+
+      <!-- 180 deg about the optical X axis points the reference +Z back toward the camera, which is
+           the outward surface normal GenerateSurfaceCoveragePath assumes. -->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        orientation_xyzw="1;0;0;0"
+        pose_stamped="{region_reference_pose}"
+      />
+
+      <SubTree ID="Move to Waypoint" waypoint_name="Look at Table" />
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{point_cloud}"
+        message_timeout_sec="5.0"
+      />
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        position_xyz="0.05;-0.10;0.597"
+        pose_stamped="{crop_center}"
+      />
+      <Action
+        ID="CropPointsInSphere"
+        point_cloud="{point_cloud}"
+        crop_sphere_centroid_pose="{crop_center}"
+        crop_sphere_radius="0.08"
+        point_cloud_cropped="{region_cloud}"
+      />
+      <Action
+        ID="GetOrientedBoundingBoxFromPointCloud"
+        point_cloud="{region_cloud}"
+        reference_pose="{region_reference_pose}"
+        box_center_pose="{region_pose}"
+        box_dimensions="{region_dimensions}"
+      />
+      <Action
+        ID="GenerateSurfaceCoveragePath"
+        region_pose="{region_pose}"
+        region_dimensions="{region_dimensions}"
+        line_spacing="0.03"
+        point_spacing="0.02"
+        standoff="0.04"
+        margin="0.0"
+        coverage_path="{coverage_path}"
+      />
+      <Action
+        ID="PlanCartesianPath"
+        path="{coverage_path}"
+        planning_group_name="manipulator"
+        tip_links="grasp_link"
+        blending_radius="0.001"
+        joint_trajectory_msg="{coverage_trajectory}"
+      />
+
+      <!-- The sweep and the recording run together. A Parallel is what makes the session end whether
+           the sweep succeeds or fails; a Sequence would leave the Runtime sampling forever. -->
+      <Control ID="Parallel" success_count="1" failure_count="1">
+        <Action
+          ID="ExecuteTrajectory"
+          joint_trajectory_msg="{coverage_trajectory}"
+        />
+        <Action
+          ID="AccumulateSurfaceCoverage"
+          target_cloud="{point_cloud}"
+          tool_frame="grasp_link"
+          footprint_radius="0.02"
+          footprint_range="0.08"
+          sample_rate_hz="10.0"
+          covered_points="{covered_points}"
+        />
+      </Control>
+
+      <Action ID="LogMessage" message="Live coverage recorded." />
+      <SubTree ID="Move to Waypoint" waypoint_name="Home" />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Live Surface Coverage Demo">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - Basic Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/record_surface_coverage_demo.xml
+++ b/src/lab_sim/objectives/record_surface_coverage_demo.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Record Surface Coverage Demo">
+  <BehaviorTree
+    ID="Record Surface Coverage Demo"
+    _description="Sweep two patches of the bench in one run and watch the treated surface accumulate in the 3D view."
+  >
+    <Control ID="Sequence" name="root">
+      <!-- The sweep runs at a standoff and never contacts the surface, so compliance is unused. The
+           admittance controller would only add its 0.5 rad path tolerance, aborting the sweep whenever
+           the simulator falls behind realtime. -->
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+      />
+      <SubTree ID="Close Gripper" _collapsed="true" />
+
+      <!-- 180 deg about the optical X axis points the reference +Z back toward the camera, which is
+           the outward surface normal GenerateSurfaceCoveragePath assumes. -->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        orientation_xyzw="1;0;0;0"
+        pose_stamped="{region_reference_pose}"
+      />
+
+      <!-- Sweep 1: a patch of bench 0.597 m ahead of the wrist camera. The viewing pose is what puts
+           these fixed optical-frame offsets on the bench. -->
+      <SubTree ID="Move to Waypoint" waypoint_name="Look at Table" />
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{point_cloud}"
+        message_timeout_sec="5.0"
+      />
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        position_xyz="0.05;-0.10;0.597"
+        pose_stamped="{crop_center}"
+      />
+      <Action
+        ID="CropPointsInSphere"
+        point_cloud="{point_cloud}"
+        crop_sphere_centroid_pose="{crop_center}"
+        crop_sphere_radius="0.08"
+        point_cloud_cropped="{region_cloud}"
+      />
+      <Action
+        ID="GetOrientedBoundingBoxFromPointCloud"
+        point_cloud="{region_cloud}"
+        reference_pose="{region_reference_pose}"
+        box_center_pose="{region_pose}"
+        box_dimensions="{region_dimensions}"
+      />
+      <Action
+        ID="GenerateSurfaceCoveragePath"
+        region_pose="{region_pose}"
+        region_dimensions="{region_dimensions}"
+        line_spacing="0.03"
+        point_spacing="0.02"
+        standoff="0.04"
+        margin="0.0"
+        coverage_path="{coverage_path}"
+      />
+      <Action
+        ID="PlanCartesianPath"
+        path="{coverage_path}"
+        planning_group_name="manipulator"
+        tip_links="grasp_link"
+        blending_radius="0.001"
+        joint_trajectory_msg="{coverage_trajectory}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        joint_trajectory_msg="{coverage_trajectory}"
+      />
+      <!-- footprint_range must clear the 0.04 standoff the sweep was planned with; the 0.02 radius
+           overlaps the 0.03 line spacing, so the sweep paints a continuous band rather than stripes. -->
+      <Action
+        ID="RecordSurfaceCoverage"
+        target_cloud="{point_cloud}"
+        tool_path="{coverage_path}"
+        footprint_radius="0.02"
+        footprint_range="0.08"
+        output_frame_id="world"
+        merge_voxel_size="0.005"
+        previous_coverage="{coverage_cloud}"
+        coverage_cloud="{coverage_cloud}"
+      />
+      <Action
+        ID="SendPointCloudToUI"
+        point_cloud="{coverage_cloud}"
+        pcd_topic="/moveit_pro_ui/surface_coverage"
+      />
+
+      <!-- Sweep 2: a patch of bench 0.600 m ahead of the wrist camera. Returning to the viewing pose
+           first keeps these fixed optical-frame offsets meaningful after the previous sweep moved the arm. -->
+      <SubTree ID="Move to Waypoint" waypoint_name="Look at Table" />
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{point_cloud}"
+        message_timeout_sec="5.0"
+      />
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        position_xyz="-0.15;-0.15;0.600"
+        pose_stamped="{crop_center}"
+      />
+      <Action
+        ID="CropPointsInSphere"
+        point_cloud="{point_cloud}"
+        crop_sphere_centroid_pose="{crop_center}"
+        crop_sphere_radius="0.08"
+        point_cloud_cropped="{region_cloud}"
+      />
+      <Action
+        ID="GetOrientedBoundingBoxFromPointCloud"
+        point_cloud="{region_cloud}"
+        reference_pose="{region_reference_pose}"
+        box_center_pose="{region_pose}"
+        box_dimensions="{region_dimensions}"
+      />
+      <Action
+        ID="GenerateSurfaceCoveragePath"
+        region_pose="{region_pose}"
+        region_dimensions="{region_dimensions}"
+        line_spacing="0.03"
+        point_spacing="0.02"
+        standoff="0.04"
+        margin="0.0"
+        coverage_path="{coverage_path}"
+      />
+      <Action
+        ID="PlanCartesianPath"
+        path="{coverage_path}"
+        planning_group_name="manipulator"
+        tip_links="grasp_link"
+        blending_radius="0.001"
+        joint_trajectory_msg="{coverage_trajectory}"
+      />
+      <Action
+        ID="ExecuteTrajectory"
+        joint_trajectory_msg="{coverage_trajectory}"
+      />
+      <Action
+        ID="RecordSurfaceCoverage"
+        target_cloud="{point_cloud}"
+        tool_path="{coverage_path}"
+        footprint_radius="0.02"
+        footprint_range="0.08"
+        output_frame_id="world"
+        merge_voxel_size="0.005"
+        previous_coverage="{coverage_cloud}"
+        coverage_cloud="{coverage_cloud}"
+      />
+      <Action
+        ID="SendPointCloudToUI"
+        point_cloud="{coverage_cloud}"
+        pcd_topic="/moveit_pro_ui/surface_coverage"
+      />
+
+      <!-- Back to Home. The coverage is recorded in the world frame, so both patches stay on the
+           bench while the arm and its camera move away. -->
+      <SubTree ID="Move to Waypoint" waypoint_name="Home" />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Record Surface Coverage Demo">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - Basic Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/objectives/select_region_and_record_coverage.xml
+++ b/src/lab_sim/objectives/select_region_and_record_coverage.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Select Region and Record Coverage">
+  <BehaviorTree
+    ID="Select Region and Record Coverage"
+    _description="Draw a region on the wrist camera view, sweep a coverage path over it, and paint the treated surface into the 3D view."
+  >
+    <Control ID="Sequence" name="root">
+      <!-- 1. Show the wrist camera view, and activate the controller ExecuteTrajectory uses. The sweep
+           runs at a standoff and never contacts the surface, so compliance is unused; the admittance
+           controller would only add its 0.5 rad path tolerance, aborting whenever the simulator falls
+           behind realtime. -->
+      <Action
+        ID="SwitchUIPrimaryView"
+        primary_view_name="/wrist_camera/color"
+      />
+      <Action
+        ID="SwitchController"
+        activate_controllers="joint_trajectory_controller"
+      />
+
+      <!-- Close the gripper so a pointed tool, not open fingers, sweeps the surface. -->
+      <SubTree ID="Close Gripper" _collapsed="true" />
+
+      <!-- 2. Take up the viewing pose before prompting. The operator then draws on the same view every
+           run, and the sweep is planned from a configuration that can reach what they drew. -->
+      <SubTree ID="Move to Waypoint" waypoint_name="Look at Table" />
+
+      <!-- 3. User draws a bounding box on the wrist camera image. -->
+      <Action
+        ID="GetRegionFromUser"
+        region_name="selected_region"
+        prompt="Draw a box over the area to cover"
+        region="{selected_region}"
+      />
+
+      <!-- 4. Wrist camera cloud + intrinsics (camera_info denormalizes the region into pixels). -->
+      <Action
+        ID="GetPointCloud"
+        topic_name="/wrist_camera/points"
+        message_out="{point_cloud}"
+        message_timeout_sec="5.0"
+      />
+      <Action
+        ID="GetCameraInfo"
+        topic_name="/wrist_camera/camera_info"
+        message_out="{camera_info}"
+        message_timeout_sec="5.0"
+      />
+
+      <!-- 5. Rasterize the normalized region into a mask (lab_sim_behaviors). -->
+      <Action
+        ID="GetMask2DFromRegion"
+        region="{selected_region}"
+        camera_info="{camera_info}"
+        masks2d="{masks2d}"
+      />
+
+      <!-- 6. Lift the 2D mask onto the cloud -> 3D mask(s). -->
+      <Action
+        ID="GetMasks3DFromMasks2D"
+        masks2d="{masks2d}"
+        point_cloud="{point_cloud}"
+        camera_info="{camera_info}"
+        masks3d="{masks3d}"
+      />
+
+      <!-- Reference pose to disambiguate the OBB orientation: 180 deg about the optical X axis points
+           the reference +Z back toward the camera, which is the outward surface normal
+           GenerateSurfaceCoveragePath assumes. -->
+      <Action
+        ID="CreatePoseStamped"
+        reference_frame="wrist_camera_optical_frame"
+        orientation_xyzw="1;0;0;0"
+        pose_stamped="{region_reference_pose}"
+      />
+
+      <!-- 7-10. One mask in, one out: recover the 3D region, fit a box, sweep it, plan, execute, record. -->
+      <Decorator
+        ID="ForEachUntilSuccess"
+        index="{index}"
+        out="{mask3d}"
+        vector_in="{masks3d}"
+      >
+        <Control ID="Sequence">
+          <Action
+            ID="GetPointCloudFromMask3D"
+            mask3d="{mask3d}"
+            point_cloud="{point_cloud}"
+            point_cloud_fragment="{region_cloud}"
+          />
+          <Action
+            ID="GetOrientedBoundingBoxFromPointCloud"
+            point_cloud="{region_cloud}"
+            reference_pose="{region_reference_pose}"
+            box_center_pose="{region_pose}"
+            box_dimensions="{region_dimensions}"
+          />
+          <Action
+            ID="GenerateSurfaceCoveragePath"
+            region_pose="{region_pose}"
+            region_dimensions="{region_dimensions}"
+            line_spacing="0.03"
+            point_spacing="0.02"
+            standoff="0.04"
+            margin="0.0"
+            coverage_path="{coverage_path}"
+          />
+          <Action
+            ID="VisualizePath"
+            path="{coverage_path}"
+            marker_name="coverage_path"
+            line_color_rgb="0;255;0"
+            line_width="0.005"
+            marker_lifetime="0"
+          />
+          <Action
+            ID="PlanCartesianPath"
+            path="{coverage_path}"
+            planning_group_name="manipulator"
+            tip_links="grasp_link"
+            blending_radius="0.001"
+            joint_trajectory_msg="{coverage_trajectory}"
+          />
+          <SubTree
+            ID="Wait for Joint Trajectory Approval"
+            _collapsed="true"
+            joint_trajectory_msg="{coverage_trajectory}"
+          />
+          <Action
+            ID="ExecuteTrajectory"
+            joint_trajectory_msg="{coverage_trajectory}"
+          />
+
+          <!-- Mark the part of the wrist camera cloud the tool just passed over. The whole cloud goes
+               in, not just the selected region, so the painted patch reads against untouched surface.
+               footprint_range must clear the 0.04 standoff above; the 0.02 radius overlaps the 0.03
+               line spacing, so the sweep paints a continuous band rather than stripes. previous_coverage
+               reads the same key this writes, which chains sweeps within one run; the blackboard is
+               rebuilt per execution, so a re-run starts from an empty history. -->
+          <Action
+            ID="RecordSurfaceCoverage"
+            target_cloud="{point_cloud}"
+            tool_path="{coverage_path}"
+            footprint_radius="0.02"
+            footprint_range="0.08"
+            output_frame_id="world"
+            merge_voxel_size="0.005"
+            previous_coverage="{coverage_cloud}"
+            coverage_cloud="{coverage_cloud}"
+          />
+
+          <!-- Latched, so the Surface Coverage layer keeps showing the history after the Objective
+               ends and after a browser reload. -->
+          <Action
+            ID="SendPointCloudToUI"
+            point_cloud="{coverage_cloud}"
+            pcd_topic="/moveit_pro_ui/surface_coverage"
+          />
+        </Control>
+      </Decorator>
+
+      <!-- Return the arm to Home. The painted surface is recorded in the world frame, so it stays put
+           while the arm and its camera move away. -->
+      <SubTree ID="Move to Waypoint" waypoint_name="Home" />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Select Region and Record Coverage">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Application - Basic Examples" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -308,6 +308,7 @@ skip_objectives = {
     "Marker Visualization Example",  # Server not available for GetTextFromUser
     "Register CAD Part",  # TODO: remove this for 9.2.0 and fix it correctly
     "Select Region for Coverage Path",  # Server not available for GetRegionFromUser (needs a UI prompt)
+    "Select Region and Record Coverage",  # Server not available for GetRegionFromUser (needs a UI prompt)
     # DoTeleoperateAction immediately rejects the goal when no UI tab is subscribed to
     # /moveit_pro_ui/do_teleoperate/goal. The objective never reaches RUNNING status, so
     # the cancel flow times out. This is a headless-CI limitation, not a bug in the objective.


### PR DESCRIPTION
[written by AI]

needs: [moveit_pro/#22344](https://github.com/PickNikRobotics/moveit_pro/pull/22344)

## Motivation

Gives the surface-coverage feature from PickNikRobotics/moveit_pro#22344 something runnable to demonstrate it. Without a shipped Objective, the only way to see coverage painted on a target is to hand-write the Behavior wiring.

## Brief description

Four Objectives — two for the snapshot Behavior, two for the live one — plus the CI classification for the ones headless CI cannot answer.

- **Record Surface Coverage Demo** (`lab_sim`) — sweeps two patches of the bench in one run and accumulates the treated surface in the 3D view. Non-interactive, so CI runs it.
- **Select Region and Record Coverage** (`lab_sim`) — the operator picks the region with `GetRegionFromUser`, then the sweep is planned, executed, and recorded.
- **Live Surface Coverage Demo** (`lab_sim`) — the same bench sweep through `AccumulateSurfaceCoverage`, so the surface fills in *while* the tool moves rather than after it stops.
- **Grind and Record Coverage** (`grinding_sim`) — a UR20 with a grinder traces the six cylinder bores of an engine block, recording where the tool actually went. This is the demo that matches what the feature is for: a registered part, a Cartesian tool path, and a treated band you can check against the geometry.

The two snapshot Objectives capture the target with the wrist camera, crop to a region, fit an oriented bounding box, generate a coverage path, execute it as a Cartesian plan, and feed the executed tool poses to `RecordSurfaceCoverage`. Feeding the result back through `previous_coverage` is what accumulates the two patches within a run. The two live Objectives instead open a session in the Runtime and let it sample the tool frame, so nothing has to be fed back at all.

All three `lab_sim` Objectives name `joint_trajectory_controller` on every motion — on each `Move to Waypoint` and on the sweep's own `ExecuteTrajectory` — rather than taking the `Move to Waypoint` subtree's `joint_trajectory_admittance_controller` default. The sweep travels at a 0.04 m standoff and never contacts the surface, so compliance is unused, while the admittance controller's `default_path_tolerance: 0.5` (`picknik_ur.ros2_control.yaml`, set only in its block; plain JTC configures a `goal` tolerance and no path constraint) aborts the trajectory whenever tracking drifts — observed once as `Path tolerance violated on shoulder_lift_joint (deviation 0.5001 > tolerance 0.5000)` mid-sweep.

The `lab_sim` Objectives sweep under `joint_trajectory_admittance_controller`, which the `Move to Waypoint` subtree activates by default. Compliance is unused at a 0.04 m standoff, and that controller's `default_path_tolerance: 0.5` (`picknik_ur.ros2_control.yaml`, set only in its block; plain JTC configures a `goal` tolerance and no path constraint) can abort a sweep when tracking drifts — seen once as `Path tolerance violated on shoulder_lift_joint (deviation 0.5001 > tolerance 0.5000)`.

Naming `joint_trajectory_controller` on every motion removes those aborts, and was tried: locally the admittance controller stayed inactive for the whole sweep and both demos succeeded. It is not kept, because on a simulator running behind realtime it more than doubles the run — `Record Surface Coverage Demo` went from 36.6 s to past the integration test's 90 s budget, while measuring 35 s on a machine keeping up. The tolerance is lived with instead, and the Objectives say so where a reader will meet it.

An earlier revision claimed the opposite, on the strength of a single `SwitchController` at the top and a 3-of-5 versus 3-of-3 reliability measurement. Both were wrong: `lab_sim` already starts with plain JTC active, so that call changed nothing, and the first `Move to Waypoint` then activated the admittance controller through its own default. The measurement was taken on a configuration the tree never produced, so it is withdrawn rather than restated.

`select_region_and_record_coverage.xml` also takes up the `Look at Table` viewing pose before prompting. Without it the operator drew on whatever view the previous run happened to leave behind, and the sweep was planned from an arbitrary configuration — the cause of the `PlanCartesianPath` "maximum allowed deviation exceeded" failures seen while testing.

### Notes for the reviewer

- **Two Objectives are in `skip_objectives`, for different reasons.** `Select Region and Record Coverage` (`src/lab_sim/test/objectives_integration_test.py`) sits next to the existing `Select Region for Coverage Path` entry and for the same reason: `GetRegionFromUser` needs a UI prompt headless CI cannot answer. `Grind and Record Coverage` (`src/grinding_sim/test/objectives_integration_test.py`) runs the same registration subtree as `Grind Machined Part`, which is already skipped there because the registration flow exceeds the fixture timeout headless — so it inherits that, not a new limitation.
- **`grinding_sim` is exercised by the weekly job, not the PR job.** `ci.yaml:302` runs it on `schedule`/`workflow_dispatch` only; the PR matrix at `:249` is `lab_sim` and `hangar_sim`. So the grinding demo will not be run by this PR's CI, and the skip entry above is what keeps the weekly run green.
- **`Select Region and Record Coverage`'s description was overstating what it does.** It promised the history accumulates when you re-run it. `ObjectiveServer::createTree` resets the tree and builds a fresh blackboard per execution, so `{coverage_cloud}` starts empty every run and nothing carries over; the `ForEachUntilSuccess` around the body runs once for a single drawn region, so the `previous_coverage` chain never has a prior value to read either. The description and the code comment now say what actually happens. The Behavior that genuinely keeps history across runs is `AccumulateSurfaceCoverage`, because the Runtime owns the session — switching this demo to it would make the original claim true, but it would also change which Behavior the demo demonstrates, so it is left as a snapshot demo.
- **No Objective is favorited.** `scripts/check_objective_favorites.sh` caps `lab_sim` at 8. Unfavoriting existing Objectives to make room would be an unrelated change.
- **`Record Surface Coverage Demo` is left in the CI suite deliberately.** It calls `GetPointCloud` on `/wrist_camera/points` twice, and several existing entries in `skip_objectives` are there because that topic times out on CI runners without a camera warmup delay. Rather than pre-emptively skipping it on suspicion, it runs — if it turns out to be flaky, the skip can be added then with evidence.

## How it was tested

`Record Surface Coverage Demo` was run end to end in `lab_sim` against a MuJoCo backend: the Objective succeeded, both bench patches were painted green in the 3D view, the Surface Coverage layer appeared in the View menu, and the legend reported 2,240 treated points. The coverage stayed in place after the arm moved away, which is what recording in the robot model frame is for.

`Grind and Record Coverage` was run end to end in `grinding_sim`, twice. The published cloud was decoded and checked against the block's geometry rather than eyeballed: 957 treated points, every one within 4 mm of the head's plane, distributed around all six bores at 0.043–0.075 m from each centre against a measured bore radius of 0.0444 m. The bore centres themselves were derived from the shipped mesh (six bores, 95.0 mm pitch, 88.9 mm diameter) rather than guessed, and `registered_pose` was confirmed from TF to sit within 1 mm and 0.03° of `engine_block_pose`, which is what lets mesh-derived coordinates be used for the tool path.

Setting `treated_color="255;40;40"` on that demo was not cosmetic: `grinding_sim`'s captured part cloud is itself green, so the default green treated points were invisible against it. The legend swatch followed the change, which also confirms it reads the colour from the published cloud rather than hardcoding it.

## Release notes

None


