### PR TITLE
Add a drift report for vendored dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -831,6 +831,8 @@ jobs:
   validate-workspace-dependencies:
     name: Validate workspace dependencies
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -843,11 +845,21 @@ jobs:
       - name: Install dependency policy test requirements
         run: python3 -m pip install pytest==9.0.3
       - name: Test dependency policy validator
-        run: python3 -m pytest bin/tests/test_validate_workspace_dependencies.py -v
+        run: python3 -m pytest bin/tests -v
       - name: Validate dependency policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: python3 bin/validate_workspace_dependencies.py --verify-upstream
+      # Drift is a report, not a gate. A failed lookup exits 1 and shows "?"
+      # in its row; pipefail lets that reach continue-on-error, which marks
+      # the step with a warning instead of failing the PR.
+      - name: Report vendored dependency drift
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          python3 bin/vendored_dependency.py status --markdown | tee -a "$GITHUB_STEP_SUMMARY"
 
   validate_objectives:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ The hardware-only `kinova_gen3_site_config` and `picknik_ur_site_config` configu
 
 ## Updating vendored dependencies
 
-Each `UPSTREAM.yaml` file under `src/external_dependencies` records the exact upstream commit and retained paths. Refresh a dependency from that commit, preserve its license files, reapply the documented pruning, and validate every config that consumes the package.
+Each `UPSTREAM.yaml` file under `src/external_dependencies` records the exact upstream commit and retained paths. Run `bin/vendored_dependency.py status` to see how many commits each pinned upstream branch has moved past its recorded commit; CI publishes the same table in the job summary of the `Validate workspace dependencies` job. Refresh a dependency from that commit, preserve its license files, reapply the documented pruning, and validate every config that consumes the package.
 
 The optional ML model submodules can be advanced independently when their demonstration Objectives need a newer model package.

--- a/bin/tests/test_vendored_dependency.py
+++ b/bin/tests/test_vendored_dependency.py
@@ -1,0 +1,260 @@
+"""Tests for the vendored dependency drift report."""
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request
+
+from pytest import CaptureFixture, MonkeyPatch, mark
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "vendored_dependency.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("vendored_dependency", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+tool = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(tool)
+
+REPOSITORY = "https://github.com/example/repository.git"
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def mock_compare(monkeypatch: MonkeyPatch, payload: object) -> list[Request]:
+    """Replace urlopen with a canned compare response and record the requests."""
+    requests: list[Request] = []
+
+    def fake_urlopen(request: Request, **_: object) -> FakeResponse:
+        requests.append(request)
+        return FakeResponse(json.dumps(payload).encode())
+
+    monkeypatch.setattr(tool, "urlopen", fake_urlopen)
+    return requests
+
+
+def test_fetch_drift_compares_pin_against_branch(monkeypatch: MonkeyPatch) -> None:
+    """Ask GitHub for the commits on the branch that the pinned commit lacks."""
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    requests = mock_compare(monkeypatch, {"ahead_by": 4, "behind_by": 0})
+    assert tool.fetch_drift(REPOSITORY, COMMIT, "main") == (4, None)
+    assert requests[0].full_url == (
+        f"https://api.github.com/repos/example/repository/compare/{COMMIT}...main"
+    )
+    assert requests[0].get_header("Authorization") == "Bearer token"
+
+
+def test_fetch_drift_encodes_branch_names(monkeypatch: MonkeyPatch) -> None:
+    """A slash in a branch name must not read as a path separator."""
+    requests = mock_compare(monkeypatch, {"ahead_by": 0, "behind_by": 0})
+    assert tool.fetch_drift(REPOSITORY, COMMIT, "release/1.0") == (0, None)
+    assert requests[0].full_url.endswith(f"/compare/{COMMIT}...release%2F1.0")
+
+
+def test_fetch_drift_reports_pin_off_branch(monkeypatch: MonkeyPatch) -> None:
+    """A pin with commits the branch lacks is not on that branch."""
+    mock_compare(monkeypatch, {"ahead_by": 4, "behind_by": 2})
+    behind, error = tool.fetch_drift(REPOSITORY, COMMIT, "main")
+    assert behind is None
+    assert error == f"pinned commit {COMMIT} is not on upstream branch main"
+
+
+def test_fetch_drift_reports_http_failure(monkeypatch: MonkeyPatch) -> None:
+    """Surface the HTTP status so a missing branch or bad token is recognizable."""
+
+    def fail(request: Request, **_: object) -> FakeResponse:
+        raise HTTPError(request.full_url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(tool, "urlopen", fail)
+    behind, error = tool.fetch_drift(REPOSITORY, COMMIT, "main")
+    assert behind is None
+    assert error is not None
+    assert "main" in error
+    assert "404" in error
+
+
+def test_fetch_drift_rejects_oversized_response(monkeypatch: MonkeyPatch) -> None:
+    """Stop reading past the response cap instead of parsing an unbounded body."""
+    monkeypatch.setattr(tool, "COMPARE_MAX_RESPONSE_BYTES", 4)
+    mock_compare(monkeypatch, {"ahead_by": 4, "behind_by": 0})
+    assert tool.fetch_drift(REPOSITORY, COMMIT, "main") == (
+        None,
+        "upstream compare response exceeds the size limit",
+    )
+
+
+@mark.parametrize(
+    "payload",
+    [
+        {"ahead_by": "many"},
+        {"ahead_by": True, "behind_by": False},
+        {"ahead_by": 4},
+        ["not", "a", "dict"],
+    ],
+)
+def test_fetch_drift_rejects_malformed_payload(
+    monkeypatch: MonkeyPatch, payload: object
+) -> None:
+    mock_compare(monkeypatch, payload)
+    assert tool.fetch_drift(REPOSITORY, COMMIT, "main") == (
+        None,
+        "upstream compare response is malformed",
+    )
+
+
+def mock_manifests(
+    monkeypatch: MonkeyPatch, tmp_path: Path, drift: dict[str, int | str]
+) -> None:
+    """Create one manifest per source and answer drift lookups from a table."""
+    manifests: list[Path] = []
+    for source in drift:
+        root = tmp_path / "src" / "external_dependencies" / source
+        root.mkdir(parents=True)
+        (root / "UPSTREAM.yaml").write_text(
+            "upstream:\n"
+            f"  repository: {REPOSITORY}\n"
+            f"  commit: {COMMIT}\n"
+            f"  branch: {source}-branch\n"
+            "vendored_paths:\n  - description\n",
+            encoding="utf-8",
+        )
+        manifests.append(root / "UPSTREAM.yaml")
+    monkeypatch.setattr(tool.validator, "REPOSITORY_ROOT", tmp_path)
+    monkeypatch.setattr(
+        tool.validator, "discover_vendoring_manifests", lambda: (manifests, [])
+    )
+    monkeypatch.setattr(tool.validator, "validate_vendor_manifest", lambda _: [])
+
+    def fake_fetch(*arguments: str) -> tuple[int | None, str | None]:
+        result = drift[arguments[2].removesuffix("-branch")]
+        return (result, None) if isinstance(result, int) else (None, result)
+
+    monkeypatch.setattr(tool, "fetch_drift", fake_fetch)
+
+
+def test_status_lists_most_drifted_first(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    mock_manifests(monkeypatch, tmp_path, {"alpha": 2, "beta": 89, "gamma": 0})
+    assert tool.main(["status"]) == 0
+    assert capsys.readouterr().out == (
+        "Vendored source  Pinned commit  Upstream branch  Commits behind\n"
+        "beta             012345678      beta-branch                  89\n"
+        "alpha            012345678      alpha-branch                  2\n"
+        "gamma            012345678      gamma-branch                  0\n"
+    )
+
+
+def test_status_markdown_is_a_step_summary(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    mock_manifests(monkeypatch, tmp_path, {"alpha": 2})
+    assert tool.main(["status", "--markdown"]) == 0
+    assert capsys.readouterr().out == (
+        "## Vendored dependency drift\n\n"
+        "| Vendored source | Pinned commit | Upstream branch | Commits behind |\n"
+        "|---|---|---|---:|\n"
+        "| alpha | 012345678 | alpha-branch | 2 |\n"
+    )
+
+
+def test_status_markdown_escapes_table_syntax(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """A pipe or backslash in a cell must not add columns to the summary table."""
+    monkeypatch.setattr(
+        tool,
+        "collect_drift",
+        lambda: [tool.Drift("src/external_dependencies/a|b", COMMIT, "rel\\x|y", 2)],
+    )
+    assert tool.main(["status", "--markdown"]) == 0
+    assert capsys.readouterr().out.splitlines()[-1] == (
+        "| a\\|b | 012345678 | rel\\\\x\\|y | 2 |"
+    )
+
+
+def test_status_writes_github_output_when_requested(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """A workflow keys on these outputs rather than parsing the rendered table."""
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    mock_manifests(monkeypatch, tmp_path, {"alpha": 0, "beta": 3, "gamma": "boom"})
+    assert tool.main(["status"]) == 1
+    capsys.readouterr()
+    assert output.read_text() == "drifted=true\nresolved=2\nunresolved=1\n"
+    output.unlink()
+    mock_manifests(monkeypatch, tmp_path / "second", {"alpha": 0})
+    assert tool.main(["status"]) == 0
+    assert output.read_text() == "drifted=false\nresolved=1\nunresolved=0\n"
+
+
+def test_status_reports_discovery_and_manifest_errors(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """Broken manifests take the error column instead of hiding behind the table."""
+    mock_manifests(monkeypatch, tmp_path, {"alpha": 1})
+    manifest = tmp_path / "src" / "external_dependencies" / "alpha" / "UPSTREAM.yaml"
+    scalar = tmp_path / "src" / "external_dependencies" / "scalar" / "UPSTREAM.yaml"
+    scalar.parent.mkdir()
+    scalar.write_text("vendored_paths:\n  - description\n")
+    real_parse = tool.validator.parse_vendor_manifest
+    monkeypatch.setattr(
+        tool.validator,
+        "parse_vendor_manifest",
+        lambda path: {"upstream": "nope"} if path == scalar else real_parse(path),
+    )
+    discovery_error = (
+        "vendored source has no UPSTREAM.yaml: src/external_dependencies/empty"
+    )
+    monkeypatch.setattr(
+        tool.validator,
+        "discover_vendoring_manifests",
+        lambda: ([manifest, scalar], [discovery_error]),
+    )
+    monkeypatch.setattr(
+        tool.validator,
+        "validate_vendor_manifest",
+        lambda path: ["bad manifest"] if path == manifest else [],
+    )
+    assert tool.main(["status"]) == 1
+    captured = capsys.readouterr()
+    assert captured.err == (
+        f"ERROR: src/external_dependencies {discovery_error}\n"
+        "ERROR: src/external_dependencies/alpha bad manifest\n"
+        "ERROR: src/external_dependencies/scalar has invalid upstream metadata\n"
+    )
+    assert captured.out.count("?") == 3
+
+
+def test_status_with_no_vendored_sources(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """An empty inventory still reports its verdict to a workflow."""
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(
+        tool.validator, "discover_vendoring_manifests", lambda: ([], [])
+    )
+    assert tool.main(["status"]) == 0
+    assert capsys.readouterr().out == "No vendored dependencies found.\n"
+    assert output.read_text() == "drifted=false\nresolved=0\nunresolved=0\n"
+
+
+def test_status_fails_when_a_lookup_fails(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """A failed lookup still prints the table but exits non-zero, last in the table."""
+    mock_manifests(monkeypatch, tmp_path, {"alpha": 2, "beta": "boom"})
+    assert tool.main(["status"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out.splitlines()[-1].startswith("beta")
+    assert captured.out.splitlines()[-1].endswith("?")
+    assert captured.err == "ERROR: src/external_dependencies/beta boom\n"

--- a/bin/vendored_dependency.py
+++ b/bin/vendored_dependency.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Report how far each vendored dependency has drifted from its upstream branch."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import argparse
+import json
+import os
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import validate_workspace_dependencies as validator  # noqa: E402
+
+COMPARE_TIMEOUT_SECONDS = 30
+COMPARE_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+TABLE_HEADER = ("Vendored source", "Pinned commit", "Upstream branch", "Commits behind")
+
+
+@dataclass(frozen=True)
+class Drift:
+    """Drift of one vendored source relative to its pinned upstream branch."""
+
+    source: str
+    commit: str = ""
+    branch: str = ""
+    behind: int | None = None
+    error: str | None = None
+
+
+def fetch_drift(
+    repository: str, commit: str, branch: str
+) -> tuple[int | None, str | None]:
+    """Return how many commits the upstream branch has beyond the pinned commit."""
+    repository_path = urlparse(repository).path.removeprefix("/").removesuffix(".git")
+    basehead = f"{quote(commit, safe='')}...{quote(branch, safe='')}"
+    url = f"https://api.github.com/repos/{repository_path}/compare/{basehead}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "moveit-pro-workspace-vendored-dependency",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        with urlopen(
+            Request(url, headers=headers), timeout=COMPARE_TIMEOUT_SECONDS
+        ) as response:
+            payload = response.read(COMPARE_MAX_RESPONSE_BYTES + 1)
+    except (HTTPError, URLError, OSError, TimeoutError, ValueError) as error:
+        return None, f"could not compare against upstream branch {branch}: {error}"
+    if len(payload) > COMPARE_MAX_RESPONSE_BYTES:
+        return None, "upstream compare response exceeds the size limit"
+    try:
+        data = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "upstream compare response is malformed"
+    if not isinstance(data, dict):
+        return None, "upstream compare response is malformed"
+    ahead_by = data.get("ahead_by")
+    behind_by = data.get("behind_by")
+    # bool is an int subclass, so check the exact type: a count must be a number.
+    if type(ahead_by) is not int or type(behind_by) is not int:
+        return None, "upstream compare response is malformed"
+    if behind_by:
+        return None, f"pinned commit {commit} is not on upstream branch {branch}"
+    return ahead_by, None
+
+
+def collect_drift() -> list[Drift]:
+    """Look up drift for every vendored source that has a valid manifest."""
+    manifests, discovery_errors = validator.discover_vendoring_manifests()
+    rows = [
+        Drift(source="src/external_dependencies", error=e) for e in discovery_errors
+    ]
+    for manifest_path in manifests:
+        source = manifest_path.parent.relative_to(validator.REPOSITORY_ROOT).as_posix()
+        if manifest_errors := validator.validate_vendor_manifest(manifest_path):
+            rows.append(Drift(source=source, error="; ".join(manifest_errors)))
+            continue
+        upstream = validator.parse_vendor_manifest(manifest_path)["upstream"]
+        if not isinstance(upstream, dict):
+            rows.append(Drift(source=source, error="has invalid upstream metadata"))
+            continue
+        repository = str(upstream["repository"])
+        commit = str(upstream["commit"])
+        branch = str(upstream["branch"])
+        behind, error = fetch_drift(repository, commit, branch)
+        rows.append(Drift(source, commit, branch, behind, error))
+    rows.sort(key=lambda row: (row.behind is None, -(row.behind or 0), row.source))
+    return rows
+
+
+def escape_markdown_cell(cell: str) -> str:
+    """Keep a literal backslash or pipe from being read as table syntax."""
+    return cell.replace("\\", "\\\\").replace("|", "\\|")
+
+
+def render_table(rows: list[Drift], *, markdown: bool) -> str:
+    """Render drift rows as an aligned text table or a GitHub Markdown table."""
+    body = [
+        (
+            row.source.removeprefix("src/external_dependencies/"),
+            row.commit[:9] or "-",
+            row.branch or "-",
+            "?" if row.behind is None else str(row.behind),
+        )
+        for row in rows
+    ]
+    if markdown:
+        lines = [
+            "## Vendored dependency drift",
+            "",
+            "| " + " | ".join(TABLE_HEADER) + " |",
+            "|---|---|---|---:|",
+        ]
+        lines.extend(
+            "| " + " | ".join(escape_markdown_cell(cell) for cell in cells) + " |"
+            for cells in body
+        )
+        return "\n".join(lines) + "\n"
+    widths = [
+        max(len(cells[column]) for cells in (TABLE_HEADER, *body))
+        for column in range(len(TABLE_HEADER))
+    ]
+    lines = []
+    for cells in (TABLE_HEADER, *body):
+        *left, right = cells
+        padded = [cell.ljust(width) for cell, width in zip(left, widths[:-1])]
+        lines.append("  ".join([*padded, right.rjust(widths[-1])]).rstrip())
+    return "\n".join(lines) + "\n"
+
+
+def status(*, markdown: bool) -> int:
+    rows = collect_drift()
+    write_github_output(rows)
+    if not rows:
+        print("No vendored dependencies found.")
+        return 0
+    print(render_table(rows, markdown=markdown), end="")
+    failures = [row for row in rows if row.error is not None]
+    for row in failures:
+        print(f"ERROR: {row.source} {row.error}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+def write_github_output(rows: list[Drift]) -> None:
+    """Expose the verdict to a GitHub Actions step when GITHUB_OUTPUT is set."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    resolved = [row for row in rows if row.behind is not None]
+    drifted = any(row.behind for row in resolved)
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"drifted={str(drifted).lower()}\n")
+        output.write(f"resolved={len(resolved)}\n")
+        output.write(f"unresolved={len(rows) - len(resolved)}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argument_parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = argument_parser.add_subparsers(dest="command", required=True)
+    status_parser = subparsers.add_parser(
+        "status",
+        help="report how many upstream commits each vendored source is behind",
+    )
+    status_parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="emit a GitHub Markdown table, for example for GITHUB_STEP_SUMMARY",
+    )
+    arguments = argument_parser.parse_args(argv)
+    return status(markdown=arguments.markdown)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
[written by AI]

Part of PickNikRobotics/moveit_pro#22309 (first of three stacked PRs: this one, then #902 for the `update` script, then #903 for the weekly drift issue).

## Motivation

PR #887 replaced seven source submodules with vendored copies under `src/external_dependencies`, each pinned by an `UPSTREAM.yaml`. `bin/validate_workspace_dependencies.py --verify-upstream` proves a copy still matches its pin, but nothing says when the pin has fallen behind. Today franka_description is 89 commits behind `main` and nobody would know without checking by hand.

## Brief description

`bin/vendored_dependency.py status` prints one row per vendored source: pinned commit, upstream branch, and how many commits that branch has moved past the pin, most stale first. `--markdown` emits a GitHub table, and the `validate-workspace-dependencies` CI job tees it into the job summary so it shows up on every check run without opening logs.

Design choices:

- The count comes from the GitHub compare API (`/compare/<pin>...<branch>`), not from a clone. One request per source, about two seconds for all eight, reusing the validator's token and response-size conventions from `fetch_upstream_tree_metadata`. Adding a `git rev-list --count` inside `fetch_and_validate_upstream` was weighed and rejected: that function returns only error strings, and drift is a report, not an error, so it would have needed a second output channel threaded through three layers.
- Drift is measured against the branch the manifest pins. Five manifests pin a fork or side branch, so this understates drift against the upstream default branch (phoebe_ws reads 4 behind `for-example-ws-no-dups` while its `main` moves far more). The pinned branch is the contract the validator enforces, so it is the number reported here; a second column can follow if the table shows it is needed.
- Drift never fails CI, per the issue. The command itself exits 1 when a lookup fails (network, bad token, branch gone) so a person running it notices. The CI step runs with `pipefail` and `continue-on-error`, so a flaky compare marks the step with a warning instead of failing an unrelated PR; the failed row shows `?` with the reason in the step log.
- When `GITHUB_OUTPUT` is set, `status` also writes `drifted=`, `resolved=`, and `unresolved=` so a workflow can key on the verdict without parsing the rendered table. The weekly issue job in the third PR uses this.

Tests mock the HTTP call and manifest discovery: request URL and token header, a pin that is not on its branch, HTTP 404, an oversized response, malformed JSON, sort order, the markdown table, the Actions outputs, discovery and manifest errors, and the failure exit code. The pytest CI step now runs the whole `bin/tests` directory.

## Release notes

None

## Claude agent checks

- [x] `picknik:moveitpro-code-reviewer` — findings applied: PR-facing step made non-gating, `commit:` rewrite verified up front (second PR), git return codes distinguished (second PR)
- [x] `picknik:moveitpro-documentation-bot` — no documentation impact
- [x] `picknik:moveitpro-platform-architect-bot` — findings applied: pipefail comment accuracy, machine-readable `GITHUB_OUTPUT`, explicit upstream-metadata check
- [x] CodeRabbit — `permissions: contents: read` on the job; Actions outputs written for an empty inventory too; JSON booleans rejected as commit counts; compare references URL-encoded; Markdown table cells escaped
- [x] `picknik:moveitpro-sonar-bot` — SonarCloud does not analyze this repo; predictions applied where cheap (composite asserts split, unused stub parameters, coverage of error branches); `--quiet`/`utf-8` literal constants and `import pytest` form deferred to stay consistent with the sibling validator and its tests
- [x] `picknik:moveitpro-test-runner` — `python3 -m pytest bin/tests`, validator offline run, and pre-commit; two pre-existing validator tests fail locally on Python 3.14 only (CI pins 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
