### PR TITLE
feat(lunar_sim): run the Husky A300 under MuJoCo on a flat regolith plane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,17 @@ than eyeballing it against a render; see `src/lunar_sim/description/husky_a300.x
 comment for a worked example (a mount-frame offset and a visual-origin counter-offset that cancel
 to a plain identity transform).
 
+### `mode="targetbody"` only rotates a camera, it doesn't move it
+
+A `<camera mode="targetbody" target="...">` continuously re-aims to face the target body, but its
+`pos` is still a fixed point in world space - unlike a camera attached to a moving body, it does
+not follow the target around. For a scene camera meant to frame a mobile base throughout an
+objective (not just at its starting pose), remember the viewing angle toward the rest of the
+scene - the ground plane, in particular - changes as the base drives away from that fixed point,
+which can reveal rendering artifacts (e.g. directional-light shadow-map aliasing past the shadow
+frustum's edge, see `src/lunar_sim/description/husky_scene.xml`) that were not visible from the
+starting pose. Verify renders at more than one point along the objective, not just at rest.
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,30 @@ Each joint type contributes to qpos:
 
 After adding or removing bodies with joints, **remove the keyframe** and let MuJoCo use body `pos=` attributes for initial positions.
 
+### `<include>` inside a `<body>` discards the included file's own wrapping element
+
+When an included file's root element is itself a `<body>` (e.g. one file per wheel, mirroring `hangar_sim/description/*_wheel_link.xml`), MuJoCo's compiler splices in only that root element's **children** — the wrapping `<body>`'s own `name`/`pos` are silently discarded, not nested. Two wheel bodies written this way collapse into one, and their `<inertial>` tags collide: `Schema violation: unique element 'inertial' found N times`.
+
+The real body (with its real `name`/`pos`) must be declared inline at the include site; the included file's own root element is just a throwaway wrapper to satisfy "one root element" for valid standalone XML:
+
+```xml
+<!-- in the parent file -->
+<body name="front_left_wheel_link" pos="0.256 0.2829 0.02913">
+  <include file="front_left_wheel_link.xml" />
+</body>
+```
+
+```xml
+<!-- front_left_wheel_link.xml -->
+<body>
+  <inertial .../>
+  <joint name="front_left_wheel_joint" .../>
+  <geom .../>
+</body>
+```
+
+Verified against MuJoCo 3.6.0 (`picknikciuser/moveit-pro:main-jazzy-amd64-cuda13.2-cudnn9`'s bundled Python bindings) with a minimal `mj_name2id`/body-count check; see `src/lunar_sim/description/husky_a300.xml` for a real usage.
+
 ### Velocity actuators: `armature/kv` time-constant must stay below the timestep
 
 A `<velocity kv="...">` actuator on a joint with `armature="..."` behaves like a first-order servo with time-constant `τ = armature / kv`. If `τ` is larger than the scene `timestep`, the servo cannot inject enough velocity correction per step to overcome external load, and the joint effectively **stops responding to commands** — it stays pinned near zero even at full command. The per-step velocity correction scales as `kv · timestep / armature`, so halving the timestep halves the authority.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,20 @@ which can reveal rendering artifacts (e.g. directional-light shadow-map aliasing
 frustum's edge, see `src/lunar_sim/description/husky_scene.xml`) that were not visible from the
 starting pose. Verify renders at more than one point along the objective, not just at rest.
 
+### `<texture file="...">` only loads PNG, not JPEG
+
+MuJoCo's built-in texture loader for `<texture type="2d" file="...">` accepts PNG (or its own
+custom binary format) - a `.jpg`/`.jpeg` file fails the model load with `Non-PNG texture, assuming
+custom binary file format, unexpected file size`, not a clearer "unsupported format" error.
+Photoreal ground/wall textures are often distributed as JPEG (e.g. ambientCG, Poly Haven); convert
+to PNG before wiring into a scene - see `src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png`
+and the texture's provenance note in `src/lunar_sim/README.md`.
+
+Separately: this repo's root `.gitattributes` LFS-tracks every `*.jpg`/`*.png`/`*.jpeg` with no
+per-file exceptions (confirmed against every existing image asset in the repo, down to 19 KB
+thumbnails) - a new texture/image asset should go through the normal `git add` + LFS flow like any
+other, not a one-off `.gitattributes` carve-out.
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,10 @@ the geom's own size.
 MuJoCo's built-in texture loader for `<texture type="2d" file="...">` accepts PNG (or its own
 custom binary format) - a `.jpg`/`.jpeg` file fails the model load with `Non-PNG texture, assuming
 custom binary file format, unexpected file size`, not a clearer "unsupported format" error.
-Photoreal ground/wall textures are often distributed as JPEG (e.g. ambientCG, Poly Haven); convert
-to PNG before wiring into a scene - see `src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png`
-and the texture's provenance note in `src/lunar_sim/README.md`.
+Photoreal ground/wall textures are often distributed as JPEG (e.g. ambientCG, Poly Haven, or a NASA
+mission-photo scan); convert to PNG before wiring into a scene - see
+`src/lunar_sim/description/assets/lunar_regolith_as15-86-11671_2k.png` and the texture's
+provenance note in `src/lunar_sim/README.md`.
 
 Separately: this repo's root `.gitattributes` LFS-tracks every `*.jpg`/`*.png`/`*.jpeg` with no
 per-file exceptions (confirmed against every existing image asset in the repo, down to 19 KB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,36 @@ The two coupled numbers live in different files: the actuator `kv` is in the `<v
 
 Rule of thumb when changing a sim `timestep`: for every velocity actuator, check `armature/kv < timestep`. The symptom of violation is a joint that ignores commands (pinned), not one that oscillates.
 
+### Vendored A300 visual meshes: converting DAE to OBJ for MuJoCo
+
+MuJoCo has no COLLADA (`.dae`) loader, but `clearpath_platform_description`'s A300 visual
+meshes (`chassis.dae`, `livery.dae`, `status_lights.dae`, `attachments/bumper.dae`) are only
+shipped as DAE - unlike the wheel/collision meshes, which are already STL. The vendored files
+are kept byte-identical to upstream (never edit them); convert to OBJ and commit the result into
+the consuming package's own `description/assets/` instead (same reasoning as the STL-copy note
+above: cross-package MuJoCo mesh paths don't survive a colcon install split).
+
+`trimesh` is already present in the `picknikciuser/moveit-pro` runtime image, but its DAE loader
+needs `pycollada`, which is not. Installing it into a `--rm` container only touches that
+container's throwaway layer, not the image itself:
+
+```
+docker run --rm --entrypoint bash picknikciuser/moveit-pro:<tag> -c \
+  "pip install --break-system-packages --no-cache-dir pycollada && python3 -c '
+import trimesh
+mesh = trimesh.load(\"chassis.dae\", force=\"scene\").dump(concatenate=True)
+mesh.export(\"chassis.obj\", include_texture=False)
+'"
+```
+
+`include_texture=False` skips emitting a companion `.mtl` - apply color via a plain MuJoCo
+`<material>` on the geom instead of trying to carry over per-face COLLADA materials. The
+converted mesh keeps the DAE's own local-frame vertices, so it drops onto its parent body with
+whatever `pos`/`quat` the URDF's visual `<origin>` implies - work that out from the xacro rather
+than eyeballing it against a render; see `src/lunar_sim/description/husky_a300.xml`'s bumper
+comment for a worked example (a mount-frame offset and a visual-origin counter-offset that cancel
+to a plain identity transform).
+
 ### MuJoCo documentation
 
 Refer to [docs.picknik.ai](https://docs.picknik.ai) for MuJoCo configuration guides:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,13 +92,23 @@ which can reveal rendering artifacts (e.g. directional-light shadow-map aliasing
 frustum's edge, see `src/lunar_sim/description/husky_scene.xml`) that were not visible from the
 starting pose. Verify renders at more than one point along the objective, not just at rest.
 
+### `texrepeat` with `texuniform="true"` is repeats-per-metre, not repeats-over-the-whole-geom
+
+With `texuniform="true"` on a `<material>`, `texrepeat="R R"` means the texture repeats R times
+per metre of world space, not R times across the whole geom - the opposite of the more intuitive
+"total tiles across this surface" reading. A 20x20 m ground plane with `texrepeat="8 8"` therefore
+tiles every `1/8 = 0.125 m`, not every `20/8 = 2.5 m`; the smaller tile shows as an obvious
+repeating grid at any zoom that puts more than a couple tiles in frame. To get a target tile size
+of `S` metres, use `texrepeat="${1/S} ${1/S}"` (e.g. `0.3 0.3` for a ~3.3 m tile), independent of
+the geom's own size.
+
 ### `<texture file="...">` only loads PNG, not JPEG
 
 MuJoCo's built-in texture loader for `<texture type="2d" file="...">` accepts PNG (or its own
 custom binary format) - a `.jpg`/`.jpeg` file fails the model load with `Non-PNG texture, assuming
 custom binary file format, unexpected file size`, not a clearer "unsupported format" error.
 Photoreal ground/wall textures are often distributed as JPEG (e.g. ambientCG, Poly Haven); convert
-to PNG before wiring into a scene - see `src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png`
+to PNG before wiring into a scene - see `src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png`
 and the texture's provenance note in `src/lunar_sim/README.md`.
 
 Separately: this repo's root `.gitattributes` LFS-tracks every `*.jpg`/`*.png`/`*.jpeg` with no

--- a/src/lunar_sim/CMakeLists.txt
+++ b/src/lunar_sim/CMakeLists.txt
@@ -15,8 +15,12 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_pytest_test(
+          husky_mujoco_geometry_test test/test_husky_mujoco_geometry.py
+          TIMEOUT 30)
 endif()
 
 ament_package()

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -1,19 +1,41 @@
 # lunar_sim
 
-A minimal MoveIt Pro configuration for a Clearpath Husky A300 in a blank world: no sensors, no
-environment assets, mock hardware. Built for fast iteration, decoupled from a full simulated
-environment.
+A MoveIt Pro configuration for a Clearpath Husky A300 running under MuJoCo physics on a flat
+lunar regolith plane: no sensors, no terrain features yet (see the roadmap below). No Nav2 stack
+either - the only way to drive the base is the `Dead Reckon Square` objective's open-loop
+`/cmd_vel` commands.
 
 The robot description composes the real A300 platform body from
 [`clearpath_platform_description`](../external_dependencies/clearpath_common/clearpath_platform_description)
 (vendored from [`clearpathrobotics/clearpath_common@jazzy`](https://github.com/clearpathrobotics/clearpath_common),
-BSD-licensed) with a `mock_components/GenericSystem` ros2_control block and a stock
+BSD-licensed) with a `picknik_mujoco_ros/MujocoSystem` ros2_control block
+(`description/husky_a300_mujoco.xacro`, physics model in `description/husky_scene.xml` /
+`husky_a300.xml`) and a stock
 [`diff_drive_controller`](https://control.ros.org/jazzy/doc/ros2_controllers/diff_drive_controller/doc/userdoc.html)
 named `platform_velocity_controller`, matching the real robot's controller naming and calibration
 (`wheel_separation: 0.562`, `wheel_separation_multiplier: 1.75`, `wheel_radius: 0.1625`,
 `wheels_per_side: 2`). `/cmd_vel` (`geometry_msgs/TwistStamped`) and `/odom`
 (`nav_msgs/Odometry`) are remapped to those plain top-level topic names from
-`platform_velocity_controller`'s own namespaced topics.
+`platform_velocity_controller`'s own namespaced topics, unchanged from the earlier mock-hardware
+setup. `open_loop` is now `false`: MuJoCo reports real per-wheel position/velocity state from
+physics, so `/odom` reflects that feedback instead of integrating the commanded velocity.
+
+The four `outdoor` wheel joints (`front_left_wheel_joint` etc., named to match
+`clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro`) each carry a
+MuJoCo velocity actuator (`kv=500`) on a hinge with `armature=1.0`; wheel collision is a primitive
+cylinder (matching upstream's own URDF collision choice), with the vendored `outdoor_{left,right}.stl`
+as a non-colliding visual mesh. The chassis is a free-floating body (MuJoCo `freejoint`) resting on
+those four wheels under gravity - there is no virtual planar rail like hangar_sim's mecanum base,
+since a plain 4-wheel skid-steer base doesn't need one. `description/assets/{chassis_collision,
+outdoor_left,outdoor_right}.stl` are byte-identical copies of the vendored meshes (MuJoCo mesh
+paths don't survive a colcon install split across package share directories, so they're copied
+into this package rather than referenced cross-package - see hangar_sim's own `description/assets`
+for the same pattern).
+
+## Roadmap
+
+This is layer 1 (MuJoCo migration) of a lunar-environment stack. Crater terrain and moon-base
+structures are later layers, gated on a maintainer decision on shape and not started here.
 
 ## Frames
 
@@ -24,7 +46,7 @@ use `footprint`.
 
 The vendored description also publishes a `base_footprint` link, but upstream's
 `base_footprint_joint` places it 0.30 m above the ground plane rather than on it, so it is unused
-here. The correction lives in `description/husky_a300_blank_world.xacro`, which adds `footprint` as
+here. The correction lives in `description/husky_a300_mujoco.xacro`, which adds `footprint` as
 `base_link`'s parent at the FK-measured offset (0.13597 m below `base_link`) while keeping the
 vendored package byte-identical to upstream.
 

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -20,6 +20,15 @@ named `platform_velocity_controller`, matching the real robot's controller namin
 setup. `open_loop` is now `false`: MuJoCo reports real per-wheel position/velocity state from
 physics, so `/odom` reflects that feedback instead of integrating the commanded velocity.
 
+**Known limitation:** `wheel_separation_multiplier: 1.75` is a real-hardware pavement-slip
+calibration constant carried over unchanged for controller-config parity with the physical robot.
+Under the old `open_loop: true` mock setup it only affected a command -> twist -> command round
+trip and canceled out; under real closed-loop feedback it doesn't, since MuJoCo's simulated
+wheel-ground contact has no reason to reproduce the same slip ratio. `/odom`'s reported angular
+velocity/yaw is systematically off from the geometrically-correct value for the simulated chassis
+by roughly that multiplier. Not corrected here - fixing it means picking a simulated-track-width
+constant, which is a calibration decision, not a MuJoCo-migration bug.
+
 The four `outdoor` wheel joints (`front_left_wheel_joint` etc., named to match
 `clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro`) each carry a
 MuJoCo velocity actuator (`kv=500`) on a hinge with `armature=1.0`; wheel collision is a primitive
@@ -31,6 +40,13 @@ outdoor_left,outdoor_right}.stl` are byte-identical copies of the vendored meshe
 paths don't survive a colcon install split across package share directories, so they're copied
 into this package rather than referenced cross-package - see hangar_sim's own `description/assets`
 for the same pattern).
+
+The ground plane's color map (`description/assets/lunar_regolith_moon01_2k.png`) is
+[Poly Haven's "Moon 01"](https://polyhaven.com/a/moon_01) diffuse map, downloaded at 4K and
+resized to 2K PNG (MuJoCo's `<texture file="...">` loader only accepts PNG, not JPEG) to keep the
+file small; Poly Haven textures are CC0 (public domain). Only the color map is used - MuJoCo's
+`<texture type="2d">` is diffuse-only, so the normal/AO/roughness maps in the same asset are not
+needed.
 
 ## Roadmap
 
@@ -48,7 +64,9 @@ The vendored description also publishes a `base_footprint` link, but upstream's
 `base_footprint_joint` places it 0.30 m above the ground plane rather than on it, so it is unused
 here. The correction lives in `description/husky_a300_mujoco.xacro`, which adds `footprint` as
 `base_link`'s parent at the FK-measured offset (0.13597 m below `base_link`) while keeping the
-vendored package byte-identical to upstream.
+vendored package byte-identical to upstream. The correction can't reuse the name `base_footprint`
+- URDF requires unique link names, and `check_urdf` rejects the duplicate - hence the
+otherwise-unconventional `footprint` name.
 
 The 3D Visualizer's fixed frame is a different thing and is `odom`: with no localization there is
 nothing above `odom` in the TF tree, so `config/frontend_settings.yaml` sets `referenceFrame: odom`

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -41,27 +41,36 @@ paths don't survive a colcon install split across package share directories, so 
 into this package rather than referenced cross-package - see hangar_sim's own `description/assets`
 for the same pattern).
 
-The ground plane's color map (`description/assets/lunar_regolith_ground031_2k.png`) is
-[ambientCG's "Ground031"](https://ambientcg.com/view?id=Ground031) color map (CC0/public domain),
-downloaded at 2K JPEG and converted to PNG (MuJoCo's `<texture file="...">` loader only accepts
-PNG, not JPEG). Only the color map is used - MuJoCo's `<texture type="2d">` is diffuse-only, so
-the normal/AO/roughness maps in the same asset are not needed.
+The ground plane's color map (`description/assets/lunar_regolith_as15-86-11671_2k.png`) is built
+from a real lunar surface photograph rather than a terrestrial stand-in: **NASA Apollo 15
+Hasselblad frame AS15-86-11671** (Station 7, Spur Crater, EVA-2 - the "Genesis Rock" in-situ
+documentation photo, taken with the 60mm lens at a sun elevation of 31 degrees). Public domain,
+NASA/JSC; archive.org identifier
+[`AS15-86-11671`](https://archive.org/details/AS15-86-11671), collection
+`johnsonspacecentermediaarchive`.
 
-An earlier pass used Poly Haven's "Moon 01" (also CC0) - a real lunar photometric diffuse map, but
-one built for planetary-scale rendering: at the ~3-4 m tile size this ground plane actually needs,
-its albedo variation is too low-frequency to read as anything but flat grey, with no visible
-rover-scale rocks/clods. Ground031's dry-cracked-soil photo scan has embedded pebbles/rocks at the
-right scale to still show real surface detail when tiled this large, so it was substituted in.
-Ground031's source photo carries a warm/mixed color cast (and stray blue-green mineral tints on
-some pebbles) unsuited to a neutral lunar grey - the shipped PNG is desaturated to a luminance-only
-image and reprocessed to a neutral, slightly warm-grey albedo (~0.47-0.51) rather than used as
-downloaded.
+Earlier attempts used terrestrial CC0 photo scans (ambientCG/Poly Haven gravel, sand, and
+desiccated-mudflat sets) at the right tile-scale detail but didn't read as lunar on inspection -
+they're photographs of Earth ground, not the Moon. AS15-86-11671 is a genuine ~1-2 m wide,
+straight-down shot of undisturbed regolith (cropped clear of the gnomon, the rock sample, and any
+footprints), so it carries real lunar grain and lighting instead of an approximation.
 
-**Honest caveat:** Ground031 is a dry, desiccation-cracked mudflat, not a lunar dust photo - up
-close (see the ground-level render) its polygonal crack network reads as an Earth desert lakebed
-more than fine regolith. It was chosen for tile-scale rock/pebble detail that Moon 01 lacked, not
-for a perfect lunar match; swapping to a less crack-dominated CC0 gravel/rock set is a reasonable
-follow-up if the desiccation-crack look reads wrong in practice.
+Processing (see `inpaint_reseau.py`/`prep_base2.py`/`stamp_craterlets.py`, kept out of this PR -
+not a reproducible build step since it starts from a manually-inspected external download and
+several by-eye crop/threshold choices; steps below are exact):
+1. Crop a 1650x1650 square clear of the gnomon, the rock fragment, and the footprint/scuff area.
+2. Remove the Hasselblad reseau-plate fiducial grid lines (thin calibration lines etched across
+   the whole frame by the camera, not scene content): detect them as sharp, image-spanning spikes
+   in the column/row median profile, then replace each line band with a same-width band of real
+   texture shifted in from just outside it (not a blur/diffusion fill, which flattens the grain
+   into a visible soft stripe).
+3. Flat-field (divide out a heavily-blurred illumination estimate) and desaturate to a neutral,
+   slightly warm-grey albedo (~0.49), matching every prior lunar_sim texture round.
+4. Make it seamless via toroidal offset-and-blend tiling, resized to 2048px (kept high-resolution
+   so ground-level close-ups still show real grain instead of blurring to mush).
+5. Bake in sparse 10-45cm soft craterlets (raised rim, short cast shadow) and 3-12cm small rocks,
+   both shaded consistent with `husky_scene.xml`'s sun direction (~74 degree elevation) - verified
+   against the chassis's own cast shadow in a rendered frame.
 
 ## Roadmap
 

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -54,7 +54,7 @@ rover-scale rocks/clods. Ground031's dry-cracked-soil photo scan has embedded pe
 right scale to still show real surface detail when tiled this large, so it was substituted in.
 Ground031's source photo carries a warm/mixed color cast (and stray blue-green mineral tints on
 some pebbles) unsuited to a neutral lunar grey - the shipped PNG is desaturated to a luminance-only
-image and regraded to a neutral, slightly warm-grey albedo (~0.47-0.51) rather than used as
+image and reprocessed to a neutral, slightly warm-grey albedo (~0.47-0.51) rather than used as
 downloaded.
 
 **Honest caveat:** Ground031 is a dry, desiccation-cracked mudflat, not a lunar dust photo - up

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -41,12 +41,27 @@ paths don't survive a colcon install split across package share directories, so 
 into this package rather than referenced cross-package - see hangar_sim's own `description/assets`
 for the same pattern).
 
-The ground plane's color map (`description/assets/lunar_regolith_moon01_2k.png`) is
-[Poly Haven's "Moon 01"](https://polyhaven.com/a/moon_01) diffuse map, downloaded at 4K and
-resized to 2K PNG (MuJoCo's `<texture file="...">` loader only accepts PNG, not JPEG) to keep the
-file small; Poly Haven textures are CC0 (public domain). Only the color map is used - MuJoCo's
-`<texture type="2d">` is diffuse-only, so the normal/AO/roughness maps in the same asset are not
-needed.
+The ground plane's color map (`description/assets/lunar_regolith_ground031_2k.png`) is
+[ambientCG's "Ground031"](https://ambientcg.com/view?id=Ground031) color map (CC0/public domain),
+downloaded at 2K JPEG and converted to PNG (MuJoCo's `<texture file="...">` loader only accepts
+PNG, not JPEG). Only the color map is used - MuJoCo's `<texture type="2d">` is diffuse-only, so
+the normal/AO/roughness maps in the same asset are not needed.
+
+An earlier pass used Poly Haven's "Moon 01" (also CC0) - a real lunar photometric diffuse map, but
+one built for planetary-scale rendering: at the ~3-4 m tile size this ground plane actually needs,
+its albedo variation is too low-frequency to read as anything but flat grey, with no visible
+rover-scale rocks/clods. Ground031's dry-cracked-soil photo scan has embedded pebbles/rocks at the
+right scale to still show real surface detail when tiled this large, so it was substituted in.
+Ground031's source photo carries a warm/mixed color cast (and stray blue-green mineral tints on
+some pebbles) unsuited to a neutral lunar grey - the shipped PNG is desaturated to a luminance-only
+image and regraded to a neutral, slightly warm-grey albedo (~0.47-0.51) rather than used as
+downloaded.
+
+**Honest caveat:** Ground031 is a dry, desiccation-cracked mudflat, not a lunar dust photo - up
+close (see the ground-level render) its polygonal crack network reads as an Earth desert lakebed
+more than fine regolith. It was chosen for tile-scale rock/pebble detail that Moon 01 lacked, not
+for a perfect lunar match; swapping to a less crack-dominated CC0 gravel/rock set is a reasonable
+follow-up if the desiccation-crack look reads wrong in practice.
 
 ## Roadmap
 

--- a/src/lunar_sim/config/config.yaml
+++ b/src/lunar_sim/config/config.yaml
@@ -25,17 +25,20 @@ hardware:
   robot_description:
     urdf:
       package: "lunar_sim"
-      path: "description/husky_a300_blank_world.xacro"
+      path: "description/husky_a300_mujoco.xacro"
     srdf:
       package: "lunar_sim"
       path: "config/moveit/husky_a300.srdf"
+    urdf_params:
+      - mujoco_model: "description/husky_scene.xml"
+      - mujoco_viewer: false  # set to true locally to open the MuJoCo viewer window
 
 # Sets ROS global params for launch.
 # [Optional]
 ros_global_params:
   # Whether or not to use simulated time.
   # [Optional, default=False]
-  use_sim_time: False
+  use_sim_time: True
 
 # Configuration files for MoveIt.
 # [Required]

--- a/src/lunar_sim/config/config.yaml
+++ b/src/lunar_sim/config/config.yaml
@@ -38,7 +38,12 @@ hardware:
 ros_global_params:
   # Whether or not to use simulated time.
   # [Optional, default=False]
-  use_sim_time: True
+  # False: picknik_mujoco_ros/MujocoSystem never publishes /clock (it is wall-clock-paced, not
+  # sim-time-paced - see mujoco_system.cpp), so with this True and nothing else publishing /clock,
+  # every node's ROS time stalls at t=0, breaking TF and /odom timestamps. Every other MuJoCo-backed
+  # config in this workspace (hangar_sim, kinova_sim, factory_sim, vla_sim, grinding_sim) leaves
+  # this False for the same reason.
+  use_sim_time: False
 
 # Configuration files for MoveIt.
 # [Required]

--- a/src/lunar_sim/config/control/husky_a300.ros2_control.yaml
+++ b/src/lunar_sim/config/control/husky_a300.ros2_control.yaml
@@ -26,7 +26,7 @@ platform_velocity_controller:
 
     publish_rate: 50.0
     odom_frame_id: odom
-    # base_link sits above true ground contact (see husky_a300_blank_world.xacro's footprint_joint
+    # base_link sits above true ground contact (see husky_a300_mujoco.xacro's footprint_joint
     # comment), so the controller publishes odom->footprint - the REP105 ground frame the xacro
     # wrapper adds as base_link's parent - not odom->base_link directly.
     base_frame_id: footprint
@@ -34,9 +34,10 @@ platform_velocity_controller:
     # sensor port lands; until then keep the controller's own TF so it is not broken mid-port.
     enable_odom_tf: true
 
-    # Mock hardware has no independent wheel-slip dynamics to feed back, so run open loop:
-    # command velocity integrates directly into published odometry.
-    open_loop: true
+    # MuJoCo hardware reports real wheel position/velocity state from physics (see
+    # husky_a300_mujoco.xacro), so odometry is computed from that feedback rather than by
+    # integrating the commanded velocity open-loop as the old mock hardware did.
+    open_loop: false
 
     cmd_vel_timeout: 0.5
 

--- a/src/lunar_sim/description/assets/bumper.obj
+++ b/src/lunar_sim/description/assets/bumper.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd02b11fc26f888d60af37f1846df79ee5db7d118a33ce821f69887c0ee26e7f
+size 203466

--- a/src/lunar_sim/description/assets/chassis.obj
+++ b/src/lunar_sim/description/assets/chassis.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4b667f0d050cc39c261d8d564ec0e132772cae0876a4547ec9b062b1a5be7d7
+size 1130545

--- a/src/lunar_sim/description/assets/chassis_collision.stl
+++ b/src/lunar_sim/description/assets/chassis_collision.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:914da37ef8a0611ffd3e2a1a3892bb5b9dc47e00442de104b0d760401cfb14c5
+size 9884

--- a/src/lunar_sim/description/assets/livery.obj
+++ b/src/lunar_sim/description/assets/livery.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c371ceed13ff79e65e79de3bddca6b520156b3598f466bdfe7b81b1e61136895
+size 178832

--- a/src/lunar_sim/description/assets/lunar_regolith_as15-86-11671_2k.png
+++ b/src/lunar_sim/description/assets/lunar_regolith_as15-86-11671_2k.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:176da4e01783f99d0a8e39abd32d89c10ca06b839baac46550bc392cf36d7f2d
+size 4129747

--- a/src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png
+++ b/src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d24e27bed2dee3d246e88596ef631c3b412942e33868b705c3fa8d4717894011
-size 8083759

--- a/src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png
+++ b/src/lunar_sim/description/assets/lunar_regolith_ground031_2k.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d24e27bed2dee3d246e88596ef631c3b412942e33868b705c3fa8d4717894011
+size 8083759

--- a/src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png
+++ b/src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:007148c2fb1327cf1498149e9ba25f4fc07fc4f0365b5a6c1e4e85d840ed5847
+size 1626474

--- a/src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png
+++ b/src/lunar_sim/description/assets/lunar_regolith_moon01_2k.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:007148c2fb1327cf1498149e9ba25f4fc07fc4f0365b5a6c1e4e85d840ed5847
-size 1626474

--- a/src/lunar_sim/description/assets/observer_access_panels.stl
+++ b/src/lunar_sim/description/assets/observer_access_panels.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e81ec2363d497e33997852b4b8190eb81b7f5af118fd2aa6962d8b5afc886825
+size 2884

--- a/src/lunar_sim/description/assets/observer_arch.stl
+++ b/src/lunar_sim/description/assets/observer_arch.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26cfc49f349c499b8bbdb6b4794209fc3ae1aa6cfeb38c551c9831c31fb93607
+size 5884

--- a/src/lunar_sim/description/assets/observer_enclosure.stl
+++ b/src/lunar_sim/description/assets/observer_enclosure.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf24122c92bb95906a163857663b787b0d5afc147f430ca652acbbcb57054c21
+size 7084

--- a/src/lunar_sim/description/assets/outdoor_left.stl
+++ b/src/lunar_sim/description/assets/outdoor_left.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23d474fc7826e41737b065d5f5d4674c88b910e764634e62b079835e3882bbae
+size 4781384

--- a/src/lunar_sim/description/assets/outdoor_right.stl
+++ b/src/lunar_sim/description/assets/outdoor_right.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf7b48da8da6338b1c178f31e194f469d05159e2012aef4a063491b258cc7e08
+size 4781384

--- a/src/lunar_sim/description/assets/status_lights.obj
+++ b/src/lunar_sim/description/assets/status_lights.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cef8fdbd7d6a8997a09a020a24f692347636b03cbbdebdd573648c67387bf027
+size 30321

--- a/src/lunar_sim/description/front_left_wheel_link.xml
+++ b/src/lunar_sim/description/front_left_wheel_link.xml
@@ -1,0 +1,33 @@
+<!-- Outdoor wheel geometry from clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro:
+     radius=0.1651, width=0.1143, mass=2.5. Visual mesh is the vendored outdoor_left.stl
+     (copied byte-identical into ../assets, see husky_a300_mujoco.xacro comment); collision
+     is a primitive cylinder, matching upstream's own URDF collision choice (not the visual
+     mesh) for cheap, well-behaved wheel-ground contact. zaxis="0 1 0" aligns the cylinder's
+     axis with the hinge axis below without needing a quat. -->
+<body>
+  <inertial pos="0 0 0" mass="2.5" diaginertia="0.019759 0.034073 0.019759" />
+  <joint
+    name="front_left_wheel_joint"
+    type="hinge"
+    pos="0 0 0"
+    axis="0 1 0"
+    damping="0.5"
+    armature="1.0"
+  />
+  <geom
+    name="front_left_wheel_visual"
+    mesh="outdoor_left"
+    material="husky_dark_grey"
+    type="mesh"
+    contype="0"
+    conaffinity="0"
+    group="2"
+  />
+  <geom
+    name="front_left_wheel_collision"
+    type="cylinder"
+    size="0.1651 0.05715"
+    zaxis="0 1 0"
+    group="3"
+  />
+</body>

--- a/src/lunar_sim/description/front_right_wheel_link.xml
+++ b/src/lunar_sim/description/front_right_wheel_link.xml
@@ -9,6 +9,9 @@
     damping="0.5"
     armature="1.0"
   />
+  <!-- Upstream outdoor.urdf.xacro applies rpy="0 0 pi" to the right-side visual mesh origin
+       (outdoor_right.stl is a distinct, mirrored mesh, not just a renamed copy of outdoor_left) -
+       quat="0 0 0 1" reproduces that 180 deg yaw here. -->
   <geom
     name="front_right_wheel_visual"
     mesh="outdoor_right"
@@ -17,6 +20,7 @@
     contype="0"
     conaffinity="0"
     group="2"
+    quat="0 0 0 1"
   />
   <geom
     name="front_right_wheel_collision"

--- a/src/lunar_sim/description/front_right_wheel_link.xml
+++ b/src/lunar_sim/description/front_right_wheel_link.xml
@@ -1,0 +1,28 @@
+<!-- See front_left_wheel_link.xml for the geometry/mass derivation. -->
+<body>
+  <inertial pos="0 0 0" mass="2.5" diaginertia="0.019759 0.034073 0.019759" />
+  <joint
+    name="front_right_wheel_joint"
+    type="hinge"
+    pos="0 0 0"
+    axis="0 1 0"
+    damping="0.5"
+    armature="1.0"
+  />
+  <geom
+    name="front_right_wheel_visual"
+    mesh="outdoor_right"
+    material="husky_dark_grey"
+    type="mesh"
+    contype="0"
+    conaffinity="0"
+    group="2"
+  />
+  <geom
+    name="front_right_wheel_collision"
+    type="cylinder"
+    size="0.1651 0.05715"
+    zaxis="0 1 0"
+    group="3"
+  />
+</body>

--- a/src/lunar_sim/description/husky_a300.xml
+++ b/src/lunar_sim/description/husky_a300.xml
@@ -1,0 +1,84 @@
+<mujoco model="husky_a300">
+  <compiler angle="radian" meshdir="assets" autolimits="true" />
+
+  <option integrator="implicitfast" />
+
+  <asset>
+    <material name="husky_dark_grey" rgba="0.15 0.15 0.15 1" />
+    <material name="husky_chassis_yellow" rgba="0.85 0.65 0.05 1" />
+    <mesh name="chassis_collision" file="chassis_collision.stl" />
+    <mesh name="outdoor_left" file="outdoor_left.stl" />
+    <mesh name="outdoor_right" file="outdoor_right.stl" />
+  </asset>
+
+  <!-- Wheel offsets relative to chassis_link (==base_link for the diff_4wd control mode
+       clearpath_platform_description uses here, chassis_x/y/z all 0) are the FK sum of
+       a300.urdf.xacro's suspension-mount chain: chassis_suspension_mount(0, 0.192, 0.03763)
+       -> suspension_beam spacer(0, +-0.0159, 0) -> beam front/rear mount(+-0.256, 0.0095,
+       -0.0085) -> motor_mount(0, +-0.0655, 0). Sum: x=+-0.256, y=+-0.2829, z=0.02913 - matching
+       the URDF's own FK (front wheel centers at z=0.0291 above base_link, see README.md).
+       See a300_outdoor_wheel_radius=0.1651 in
+       clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro. -->
+  <worldbody>
+    <body name="chassis_link" pos="0 0 0.13597">
+      <freejoint />
+      <inertial pos="0 0 0.1148" mass="70" diaginertia="1.1409 4.6217 5.1478" />
+      <geom
+        name="chassis"
+        mesh="chassis_collision"
+        material="husky_chassis_yellow"
+        type="mesh"
+        contype="1"
+        conaffinity="1"
+        group="2"
+      />
+
+      <!-- MuJoCo's <include> splices in only the included file's children, discarding its
+           own wrapping element - so the real body name/pos live here, and each *_wheel_link.xml
+           file's outer <body> tag is a throwaway wrapper (just satisfies "one root element" for
+           valid standalone XML). -->
+      <body name="front_left_wheel_link" pos="0.256 0.2829 0.02913">
+        <include file="front_left_wheel_link.xml" />
+      </body>
+      <body name="front_right_wheel_link" pos="0.256 -0.2829 0.02913">
+        <include file="front_right_wheel_link.xml" />
+      </body>
+      <body name="rear_left_wheel_link" pos="-0.256 0.2829 0.02913">
+        <include file="rear_left_wheel_link.xml" />
+      </body>
+      <body name="rear_right_wheel_link" pos="-0.256 -0.2829 0.02913">
+        <include file="rear_right_wheel_link.xml" />
+      </body>
+    </body>
+  </worldbody>
+
+  <!-- kv=500 with the wheel joints' armature=1.0 (see front_left_wheel_link.xml) gives
+       tau = armature/kv = 0.002 s, below husky_scene.xml's 0.003 s timestep. See CLAUDE.md's
+       "Velocity actuators: armature/kv time-constant must stay below the timestep". -->
+  <actuator>
+    <velocity
+      name="front_left_wheel"
+      joint="front_left_wheel_joint"
+      ctrlrange="-15 15"
+      kv="500"
+    />
+    <velocity
+      name="front_right_wheel"
+      joint="front_right_wheel_joint"
+      ctrlrange="-15 15"
+      kv="500"
+    />
+    <velocity
+      name="rear_left_wheel"
+      joint="rear_left_wheel_joint"
+      ctrlrange="-15 15"
+      kv="500"
+    />
+    <velocity
+      name="rear_right_wheel"
+      joint="rear_right_wheel_joint"
+      ctrlrange="-15 15"
+      kv="500"
+    />
+  </actuator>
+</mujoco>

--- a/src/lunar_sim/description/husky_a300.xml
+++ b/src/lunar_sim/description/husky_a300.xml
@@ -20,9 +20,21 @@
     <mesh name="bumper" file="bumper.obj" />
     <!-- Vendored attachment STLs (already MuJoCo-compatible, no conversion needed), millimeter
          scale per their own URDF mesh tags. -->
-    <mesh name="observer_enclosure" file="observer_enclosure.stl" scale="0.001 0.001 0.001" />
-    <mesh name="observer_access_panels" file="observer_access_panels.stl" scale="0.001 0.001 0.001" />
-    <mesh name="observer_arch" file="observer_arch.stl" scale="0.001 0.001 0.001" />
+    <mesh
+      name="observer_enclosure"
+      file="observer_enclosure.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="observer_access_panels"
+      file="observer_access_panels.stl"
+      scale="0.001 0.001 0.001"
+    />
+    <mesh
+      name="observer_arch"
+      file="observer_arch.stl"
+      scale="0.001 0.001 0.001"
+    />
   </asset>
 
   <!-- Wheel offsets relative to chassis_link (==base_link for the diff_4wd control mode

--- a/src/lunar_sim/description/husky_a300.xml
+++ b/src/lunar_sim/description/husky_a300.xml
@@ -150,17 +150,25 @@
       <!-- MuJoCo's <include> splices in only the included file's children, discarding its
            own wrapping element - so the real body name/pos live here, and each *_wheel_link.xml
            file's outer <body> tag is a throwaway wrapper (just satisfies "one root element" for
-           valid standalone XML). -->
+           valid standalone XML).
+
+           Right-side y is NOT the left side's mirrored sign: FK through the vendored xacro chain
+           (a300.urdf.xacro's chassis_suspension_mount_y=0.192 -> suspension_beam.urdf.xacro's
+           side-conditional spacer_offset (+/-0.0159) -> its own front/rear_mount_joint, whose
+           y=0.0095 is a literal, non-side-conditional offset applied in both beams' unrotated local
+           frames, so it does NOT flip sign with side -> motor.urdf.xacro's side-conditional
+           translation_y (+/-0.0655)) gives left=+0.2829 but right=-0.2639, not -0.2829: the
+           un-mirrored 0.0095 term breaks the naive left/right symmetry by 19 mm. -->
       <body name="front_left_wheel_link" pos="0.256 0.2829 0.02913">
         <include file="front_left_wheel_link.xml" />
       </body>
-      <body name="front_right_wheel_link" pos="0.256 -0.2829 0.02913">
+      <body name="front_right_wheel_link" pos="0.256 -0.2639 0.02913">
         <include file="front_right_wheel_link.xml" />
       </body>
       <body name="rear_left_wheel_link" pos="-0.256 0.2829 0.02913">
         <include file="rear_left_wheel_link.xml" />
       </body>
-      <body name="rear_right_wheel_link" pos="-0.256 -0.2829 0.02913">
+      <body name="rear_right_wheel_link" pos="-0.256 -0.2639 0.02913">
         <include file="rear_right_wheel_link.xml" />
       </body>
     </body>

--- a/src/lunar_sim/description/husky_a300.xml
+++ b/src/lunar_sim/description/husky_a300.xml
@@ -9,6 +9,20 @@
     <mesh name="chassis_collision" file="chassis_collision.stl" />
     <mesh name="outdoor_left" file="outdoor_left.stl" />
     <mesh name="outdoor_right" file="outdoor_right.stl" />
+    <!-- Visual-only body meshes, converted from the vendored chassis.dae/livery.dae/
+         status_lights.dae/attachments/bumper.dae (COLLADA has no native MuJoCo loader) via
+         trimesh+pycollada, geometry only - see CLAUDE.md's "Vendored A300 visual meshes" note.
+         Each keeps the source mesh's own local frame, so it drops onto chassis_link with the
+         same pos/quat math as the URDF composes it (see the geoms below). -->
+    <mesh name="chassis_visual" file="chassis.obj" />
+    <mesh name="livery" file="livery.obj" />
+    <mesh name="status_lights" file="status_lights.obj" />
+    <mesh name="bumper" file="bumper.obj" />
+    <!-- Vendored attachment STLs (already MuJoCo-compatible, no conversion needed), millimeter
+         scale per their own URDF mesh tags. -->
+    <mesh name="observer_enclosure" file="observer_enclosure.stl" scale="0.001 0.001 0.001" />
+    <mesh name="observer_access_panels" file="observer_access_panels.stl" scale="0.001 0.001 0.001" />
+    <mesh name="observer_arch" file="observer_arch.stl" scale="0.001 0.001 0.001" />
   </asset>
 
   <!-- Wheel offsets relative to chassis_link (==base_link for the diff_4wd control mode
@@ -23,14 +37,102 @@
     <body name="chassis_link" pos="0 0 0.13597">
       <freejoint />
       <inertial pos="0 0 0.1148" mass="70" diaginertia="1.1409 4.6217 5.1478" />
+      <!-- Collision proxy only (not rendered - see husky_scene.xml's scene_option.geomgroup[3]=0
+           convention, matching hangar_sim's visual/group=2 vs collision/group=3 split). The
+           detailed visual meshes below sit at the same pose and would z-fight with this if both
+           were shown. -->
       <geom
-        name="chassis"
+        name="chassis_collision"
         mesh="chassis_collision"
-        material="husky_chassis_yellow"
         type="mesh"
         contype="1"
         conaffinity="1"
+        group="3"
+      />
+      <!-- Visual body: chassis.dae/livery.dae/status_lights.dae are layered in the URDF at
+           chassis_link's own origin (identity), so no pos/quat is needed here either. -->
+      <geom
+        name="chassis_visual"
+        mesh="chassis_visual"
+        material="husky_chassis_yellow"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
         group="2"
+      />
+      <geom
+        name="livery"
+        mesh="livery"
+        material="husky_dark_grey"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+      />
+      <geom
+        name="status_lights"
+        mesh="status_lights"
+        material="husky_dark_grey"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+      />
+      <!-- Bumpers: bumper.dae's own local-frame vertices already land at the front-bumper pose
+           relative to chassis_link (its URDF visual origin exactly cancels the front mount
+           offset - see CLAUDE.md), so the front instance needs no transform. The rear instance
+           reuses the same asset 180 deg about Z, which by the same cancellation lands it at the
+           mirrored pose - both verified against husky_a300.xml's own front/rear FK derivation. -->
+      <geom
+        name="front_bumper"
+        mesh="bumper"
+        material="husky_dark_grey"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+      />
+      <geom
+        name="rear_bumper"
+        mesh="bumper"
+        material="husky_dark_grey"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+        quat="0 0 0 1"
+      />
+      <!-- Sensor enclosure + access panels: identity offset from chassis_link (amp_enclosure is
+           mounted on base_link with no origin in husky_a300_mujoco.xacro's macro call). -->
+      <geom
+        name="enclosure"
+        mesh="observer_enclosure"
+        material="husky_dark_grey"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+      />
+      <geom
+        name="access_panels"
+        mesh="observer_access_panels"
+        material="husky_chassis_yellow"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+      />
+      <!-- Sensor arch: mounted on the enclosure's antenna frame, (-0.4028, 0, 0.4074593) from
+           chassis_link (enclosure_antenna_mount's own offset, per amp_enclosure.urdf.xacro). -->
+      <geom
+        name="sensor_arch"
+        mesh="observer_arch"
+        material="husky_chassis_yellow"
+        type="mesh"
+        contype="0"
+        conaffinity="0"
+        group="2"
+        pos="-0.4028 0 0.4074593"
       />
 
       <!-- MuJoCo's <include> splices in only the included file's children, discarding its

--- a/src/lunar_sim/description/husky_a300_mujoco.xacro
+++ b/src/lunar_sim/description/husky_a300_mujoco.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="husky_a300">
   <!-- A300 platform body from clearpathrobotics/clearpath_common's clearpath_platform_description
        package (BSD-licensed), vendored under ../../external_dependencies and kept byte-identical to
-       upstream. This file supplies its own mock ros2_control block below, so
+       upstream. This file supplies its own MuJoCo ros2_control block below, so
        use_platform_controllers:=false keeps the upstream ros2_control include out of the build. -->
   <xacro:arg name="use_platform_controllers" default="false" />
   <!-- a300.urdf.xacro declares this arg with a default that resolves $(find clearpath_control), a
@@ -14,22 +14,8 @@
   <xacro:include filename="$(find clearpath_platform_description)/urdf/a300/a300.urdf.xacro" />
   <xacro:a300 control="diff_4wd" front_wheels="outdoor" rear_wheels="outdoor" />
 
-  <!-- FRAME NAMING: the ground-contact frame on this robot is "footprint", NOT "base_footprint".
-       Anything that needs a REP-105 ground frame - TF consumers, Nav2, the
-       platform_velocity_controller's base_frame_id - must use "footprint". (The 3D Visualizer's
-       fixed frame is a separate setting and is "odom"; see config/frontend_settings.yaml.)
-
-       Why the unconventional name: upstream a300.urdf.xacro defines a base_footprint_joint
-       (chassis_link -> base_footprint) whose origin adds the wheel radius instead of subtracting
-       the wheel-center height, placing base_footprint 0.30 m above the ground plane. FK on the
-       URDF this file generates: base_link at z=0, front wheel centers at z=0.0291, wheel
-       radius=0.1651, so ground contact is 0.13597 m below base_link. base_footprint stays in the
-       published TF tree at z=+0.30107 and is unused by this configuration.
-
-       That joint lives in the vendored package, which is kept byte-identical to upstream, so it is
-       corrected here instead of edited in place. The correction cannot reuse the name
-       base_footprint - URDF requires unique link names, and check_urdf rejects the duplicate - so
-       the corrected frame is named "footprint" and becomes base_link's parent. -->
+  <!-- FRAME NAMING: see README.md for the full footprint-vs-base_footprint explanation.
+       Unchanged by the MuJoCo migration. -->
   <link name="footprint" />
   <joint name="footprint_joint" type="fixed">
     <parent link="footprint" />
@@ -58,14 +44,19 @@
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </xacro:amp_sensor_arch>
 
-  <!-- Mock hardware: command velocity in, integrated position/velocity state out. No physics, no
-       sensors - this is the "blank world", fast-iteration counterpart to a full MuJoCo simulation.
-       Wheel joint names match clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro
-       (front_left_wheel_joint etc.), the same names the real robot's drivetrain.urdf.xacro claims. -->
+  <!-- MuJoCo hardware: real physics, driven by description/husky_scene.xml (see that file and
+       husky_a300.xml for the body/wheel/actuator model). Wheel joint names match
+       clearpath_platform_description/urdf/a300/drivetrain/wheels/outdoor.urdf.xacro
+       (front_left_wheel_joint etc.), same names the mock hardware block used, and the same
+       names the MJCF wheel joints in husky_a300.xml declare. -->
+  <xacro:arg name="mujoco_model" default="description/husky_scene.xml" />
+  <xacro:arg name="mujoco_viewer" default="false" />
   <ros2_control name="husky_a300_hardware" type="system">
     <hardware>
-      <plugin>mock_components/GenericSystem</plugin>
-      <param name="calculate_dynamics">true</param>
+      <plugin>picknik_mujoco_ros/MujocoSystem</plugin>
+      <param name="mujoco_model">$(arg mujoco_model)</param>
+      <param name="mujoco_model_package">lunar_sim</param>
+      <param name="mujoco_viewer">$(arg mujoco_viewer)</param>
     </hardware>
     <joint name="front_left_wheel_joint">
       <command_interface name="velocity" />

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -6,7 +6,11 @@
   <include file="husky_a300.xml" />
 
   <visual>
-    <headlight diffuse="0.4 0.4 0.4" ambient="0.05 0.05 0.05" specular="0 0 0" />
+    <headlight
+      diffuse="0.4 0.4 0.4"
+      ambient="0.05 0.05 0.05"
+      specular="0 0 0"
+    />
     <rgba haze="0.05 0.05 0.05 1" />
     <global offwidth="1280" offheight="720" azimuth="120" elevation="-20" />
   </visual>

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -45,12 +45,17 @@
   </asset>
 
   <worldbody>
-    <!-- Reduced lighting to simulate lunar conditions -->
+    <!-- Reduced lighting to simulate lunar conditions. castshadow=false: a directional light's
+         shadow map spread across the 50x50 m ground_plane below has too little resolution per
+         texel at this range, and at this light's near-grazing angle over the plane the result is
+         shadow acne (speckled dark pixels far from the robot) rather than a visible shadow edge
+         worth the cost of raising shadowsize to fix. -->
     <light
       pos="5 -5 10"
       dir="-0.5 0.5 -1"
       directional="true"
       diffuse="0.9 0.9 0.85"
+      castshadow="false"
     />
 
     <!-- Flat regolith plane. Finite (not the old infinite plane) so wheel contact matches

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -39,11 +39,12 @@
     />
     <!-- Photoreal ground color map, replacing the earlier flat two-tone procedural texture; see
          src/lunar_sim/README.md for source/licence provenance. Color map only, no normal/AO/
-         roughness maps loaded - MuJoCo's <texture type="2d"> is diffuse-only. -->
+         roughness maps loaded - MuJoCo's <texture type="2d"> is diffuse-only. Desaturated/
+         regraded to a neutral grey albedo (no source tint survives) - see README for why. -->
     <texture
       type="2d"
       name="regolith"
-      file="assets/lunar_regolith_moon01_2k.png"
+      file="assets/lunar_regolith_ground031_2k.png"
     />
     <!-- Matte: regolith is a diffuse dust surface, not the wet-looking mirror MuJoCo's default
          planar reflection gives a nonzero-reflectance plane. reflectance=0 turns that off;
@@ -53,7 +54,7 @@
       name="regolith_ground"
       texture="regolith"
       texuniform="true"
-      texrepeat="8 8"
+      texrepeat="0.3 0.3"
       reflectance="0"
       specular="0"
       shininess="0"
@@ -102,7 +103,7 @@
 
     <!-- Low, close, fixed shot of the ground plane for inspecting texture tiling/detail up
          close, independent of robot pose - quat hand-computed to look from (1.2, -0.6, 0.3)
-         toward (2.8, -0.9, 0) so it grazes across a couple of the 2.5 m texture tiles. -->
+         toward (2.8, -0.9, 0) so it grazes across part of one of the ~3.3 m texture tiles. -->
     <camera
       name="ground_detail_camera"
       pos="1.2 -0.6 0.3"

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -13,6 +13,17 @@
     />
     <rgba haze="0.05 0.05 0.05 1" />
     <global offwidth="1280" offheight="720" azimuth="120" elevation="-20" />
+    <!-- Directional-light shadow tuning: past the edge of the shadow frustum (roughly
+         model.stat.extent * shadowclip - here ~10 m * 5 = 50 m), a lit surface still renders but
+         samples the shadow map out of its valid range, aliasing into speckle. scene_camera's
+         pos is fixed in world space (mode="targetbody" only rotates it to face the robot, see
+         CLAUDE.md), so which part of the ground plane it grazes toward changes as the robot
+         drives away from the origin over the Dead Reckon Square - shadowclip needs enough margin
+         to keep the whole 10 m ground_plane below (not just the small area right under the
+         robot) inside the frustum for the whole run, not just at the origin. shadowsize=8192
+         keeps per-texel resolution sharp across that frustum. -->
+    <quality shadowsize="8192" />
+    <map shadowclip="5.0" />
   </visual>
 
   <!-- Dark space skybox + regolith ground, carried over from the pre-869 Phoebe-based
@@ -51,25 +62,30 @@
   </asset>
 
   <worldbody>
-    <!-- Reduced lighting to simulate lunar conditions. castshadow=false: a directional light's
-         shadow map spread across the 50x50 m ground_plane below has too little resolution per
-         texel at this range, and at this light's near-grazing angle over the plane the result is
-         shadow acne (speckled dark pixels far from the robot) rather than a visible shadow edge
-         worth the cost of raising shadowsize to fix. -->
+    <!-- Reduced lighting to simulate lunar conditions. The hard shadow a lunar scene needs (and
+         that will matter more once a crater rim exists) wants a low sun, but MuJoCo's shadow
+         mapping has no slope-scaled bias: at this light's original, lower angle
+         (dir="-0.5 0.5 -1", ~55 deg elevation) the shadow map's self-shadowing bias broke down at
+         the plane's more grazing viewing angles and speckled, regardless of shadowsize/shadowclip
+         (see the <visual> block above for those). dir="-0.2 0.2 -1" (~74 deg elevation) is as low
+         as this light goes clean - a compromise against the lunar look, not the primary fix. -->
     <light
       pos="5 -5 10"
-      dir="-0.5 0.5 -1"
+      dir="-0.2 0.2 -1"
       directional="true"
       diffuse="0.9 0.9 0.85"
-      castshadow="false"
+      castshadow="true"
     />
 
     <!-- Flat regolith plane. Finite (not the old infinite plane) so wheel contact matches
-         hangar_sim's precedent; 50x50 m comfortably bounds the ~1.8 m Dead Reckon Square. -->
+         hangar_sim's precedent; 20x20 m comfortably bounds the ~1.8 m Dead Reckon Square while
+         staying safely inside the shadow frustum above (see the <light> and <visual> comments) -
+         a wider plane just means more of it sits outside the frustum, sampling the shadow map out
+         of range and speckling, for no benefit the objective actually needs. -->
     <geom
       name="ground_plane"
       type="plane"
-      size="50 50 0.1"
+      size="10 10 0.1"
       pos="0 0 0"
       material="regolith_ground"
       contype="1"

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -44,7 +44,7 @@
     <texture
       type="2d"
       name="regolith"
-      file="assets/lunar_regolith_ground031_2k.png"
+      file="assets/lunar_regolith_as15-86-11671_2k.png"
     />
     <!-- Matte: regolith is a diffuse dust surface, not the wet-looking mirror MuJoCo's default
          planar reflection gives a nonzero-reflectance plane. reflectance=0 turns that off;

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -1,0 +1,73 @@
+<mujoco model="lunar sim scene">
+  <compiler angle="radian" meshdir="assets" autolimits="true" />
+
+  <option integrator="implicitfast" timestep="0.003" />
+
+  <include file="husky_a300.xml" />
+
+  <visual>
+    <headlight diffuse="0.4 0.4 0.4" ambient="0.05 0.05 0.05" specular="0 0 0" />
+    <rgba haze="0.05 0.05 0.05 1" />
+    <global offwidth="1280" offheight="720" azimuth="120" elevation="-20" />
+  </visual>
+
+  <!-- Dark space skybox + regolith ground, carried over from the pre-869 Phoebe-based
+       lunar_sim scene (src/lunar_sim/mjcf/scene.xml on main before that PR removed it). -->
+  <asset>
+    <texture
+      type="skybox"
+      builtin="gradient"
+      rgb1="0.02 0.02 0.05"
+      rgb2="0 0 0"
+      width="512"
+      height="3072"
+    />
+    <texture
+      type="2d"
+      name="regolith"
+      builtin="flat"
+      rgb1="0.55 0.55 0.50"
+      rgb2="0.45 0.45 0.40"
+      width="512"
+      height="512"
+    />
+    <material
+      name="regolith_ground"
+      texture="regolith"
+      texuniform="true"
+      texrepeat="8 8"
+      reflectance="0.05"
+    />
+  </asset>
+
+  <worldbody>
+    <!-- Reduced lighting to simulate lunar conditions -->
+    <light
+      pos="5 -5 10"
+      dir="-0.5 0.5 -1"
+      directional="true"
+      diffuse="0.9 0.9 0.85"
+    />
+
+    <!-- Flat regolith plane. Finite (not the old infinite plane) so wheel contact matches
+         hangar_sim's precedent; 50x50 m comfortably bounds the ~1.8 m Dead Reckon Square. -->
+    <geom
+      name="ground_plane"
+      type="plane"
+      size="50 50 0.1"
+      pos="0 0 0"
+      material="regolith_ground"
+      contype="1"
+      conaffinity="1"
+    />
+
+    <camera
+      name="scene_camera"
+      pos="-3 -3 2"
+      mode="targetbody"
+      target="chassis_link"
+      fovy="45"
+      resolution="1280 720"
+    />
+  </worldbody>
+</mujoco>

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -37,14 +37,13 @@
       width="512"
       height="3072"
     />
+    <!-- Photoreal ground color map, replacing the earlier flat two-tone procedural texture; see
+         src/lunar_sim/README.md for source/licence provenance. Color map only, no normal/AO/
+         roughness maps loaded - MuJoCo's <texture type="2d"> is diffuse-only. -->
     <texture
       type="2d"
       name="regolith"
-      builtin="flat"
-      rgb1="0.55 0.55 0.50"
-      rgb2="0.45 0.45 0.40"
-      width="512"
-      height="512"
+      file="assets/lunar_regolith_moon01_2k.png"
     />
     <!-- Matte: regolith is a diffuse dust surface, not the wet-looking mirror MuJoCo's default
          planar reflection gives a nonzero-reflectance plane. reflectance=0 turns that off;
@@ -97,6 +96,17 @@
       pos="-3 -3 2"
       mode="targetbody"
       target="chassis_link"
+      fovy="45"
+      resolution="1280 720"
+    />
+
+    <!-- Low, close, fixed shot of the ground plane for inspecting texture tiling/detail up
+         close, independent of robot pose - quat hand-computed to look from (1.2, -0.6, 0.3)
+         toward (2.8, -0.9, 0) so it grazes across a couple of the 2.5 m texture tiles. -->
+    <camera
+      name="ground_detail_camera"
+      pos="1.2 -0.6 0.3"
+      quat="-0.49080247 -0.408618 0.49235457 0.5913808"
       fovy="45"
       resolution="1280 720"
     />

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -35,12 +35,18 @@
       width="512"
       height="512"
     />
+    <!-- Matte: regolith is a diffuse dust surface, not the wet-looking mirror MuJoCo's default
+         planar reflection gives a nonzero-reflectance plane. reflectance=0 turns that off;
+         specular/shininess=0 kill the remaining highlight, inherited unchanged from the old
+         Phoebe scene's material where they didn't matter as much on a smaller ground patch. -->
     <material
       name="regolith_ground"
       texture="regolith"
       texuniform="true"
       texrepeat="8 8"
-      reflectance="0.05"
+      reflectance="0"
+      specular="0"
+      shininess="0"
     />
   </asset>
 

--- a/src/lunar_sim/description/husky_scene.xml
+++ b/src/lunar_sim/description/husky_scene.xml
@@ -40,7 +40,7 @@
     <!-- Photoreal ground color map, replacing the earlier flat two-tone procedural texture; see
          src/lunar_sim/README.md for source/licence provenance. Color map only, no normal/AO/
          roughness maps loaded - MuJoCo's <texture type="2d"> is diffuse-only. Desaturated/
-         regraded to a neutral grey albedo (no source tint survives) - see README for why. -->
+         reprocessed to a neutral grey albedo (no source tint survives) - see README for why. -->
     <texture
       type="2d"
       name="regolith"

--- a/src/lunar_sim/description/rear_left_wheel_link.xml
+++ b/src/lunar_sim/description/rear_left_wheel_link.xml
@@ -1,0 +1,28 @@
+<!-- See front_left_wheel_link.xml for the geometry/mass derivation. -->
+<body>
+  <inertial pos="0 0 0" mass="2.5" diaginertia="0.019759 0.034073 0.019759" />
+  <joint
+    name="rear_left_wheel_joint"
+    type="hinge"
+    pos="0 0 0"
+    axis="0 1 0"
+    damping="0.5"
+    armature="1.0"
+  />
+  <geom
+    name="rear_left_wheel_visual"
+    mesh="outdoor_left"
+    material="husky_dark_grey"
+    type="mesh"
+    contype="0"
+    conaffinity="0"
+    group="2"
+  />
+  <geom
+    name="rear_left_wheel_collision"
+    type="cylinder"
+    size="0.1651 0.05715"
+    zaxis="0 1 0"
+    group="3"
+  />
+</body>

--- a/src/lunar_sim/description/rear_right_wheel_link.xml
+++ b/src/lunar_sim/description/rear_right_wheel_link.xml
@@ -1,0 +1,28 @@
+<!-- See front_left_wheel_link.xml for the geometry/mass derivation. -->
+<body>
+  <inertial pos="0 0 0" mass="2.5" diaginertia="0.019759 0.034073 0.019759" />
+  <joint
+    name="rear_right_wheel_joint"
+    type="hinge"
+    pos="0 0 0"
+    axis="0 1 0"
+    damping="0.5"
+    armature="1.0"
+  />
+  <geom
+    name="rear_right_wheel_visual"
+    mesh="outdoor_right"
+    material="husky_dark_grey"
+    type="mesh"
+    contype="0"
+    conaffinity="0"
+    group="2"
+  />
+  <geom
+    name="rear_right_wheel_collision"
+    type="cylinder"
+    size="0.1651 0.05715"
+    zaxis="0 1 0"
+    group="3"
+  />
+</body>

--- a/src/lunar_sim/description/rear_right_wheel_link.xml
+++ b/src/lunar_sim/description/rear_right_wheel_link.xml
@@ -9,6 +9,9 @@
     damping="0.5"
     armature="1.0"
   />
+  <!-- Upstream outdoor.urdf.xacro applies rpy="0 0 pi" to the right-side visual mesh origin
+       (outdoor_right.stl is a distinct, mirrored mesh, not just a renamed copy of outdoor_left) -
+       quat="0 0 0 1" reproduces that 180 deg yaw here. -->
   <geom
     name="rear_right_wheel_visual"
     mesh="outdoor_right"
@@ -17,6 +20,7 @@
     contype="0"
     conaffinity="0"
     group="2"
+    quat="0 0 0 1"
   />
   <geom
     name="rear_right_wheel_collision"

--- a/src/lunar_sim/package.xml
+++ b/src/lunar_sim/package.xml
@@ -4,8 +4,8 @@
   <version>9.5.0</version>
 
   <description>
-    Minimal MoveIt Pro configuration for a Clearpath Husky A300 in a blank
-    world, for fast iteration decoupled from a full simulated environment.
+    MoveIt Pro configuration for a Clearpath Husky A300 running under MuJoCo
+    physics on a flat lunar regolith plane.
   </description>
 
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>
@@ -25,10 +25,13 @@
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
   <exec_depend>moveit_pro_objectives</exec_depend>
+  <exec_depend>picknik_mujoco_ros</exec_depend>
 
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_index_python</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>picknik_ament_copyright</test_depend>
 

--- a/src/lunar_sim/test/test_husky_mujoco_geometry.py
+++ b/src/lunar_sim/test/test_husky_mujoco_geometry.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 PickNik Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the PickNik Inc. nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""The MJCF wheel collision radius/width must track the vendored URDF's, and the wheel
+velocity actuators must stay inside the armature/kv-vs-timestep bound documented in
+CLAUDE.md (an armature/kv time constant at or above the timestep silently pins the
+wheels - see hangar_sim's mecanum base incident). Nothing else in the build checks
+either; both failure modes are quiet (no crash, the base just doesn't move, or the
+model loads with wheels floating above/through the ground).
+
+Wheel *placement* (x/y/z body offsets) is deliberately not cross-checked here: deriving
+it from the vendored xacro requires evaluating a per-side conditional expression
+(`suspension_beam.urdf.xacro`'s `spacer_offset`), which a regex can't do without
+duplicating that logic (and getting it subtly wrong is worse than not checking it) -
+see husky_a300.xml's own derivation comment for that FK chain instead.
+
+No simulator, no ROS - pure XML/text parsing of the description sources, mirroring
+hangar_sim/test/test_base_geometry.py.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from ament_index_python.packages import get_package_share_directory
+
+DESCRIPTION = Path(__file__).resolve().parent.parent / "description"
+HUSKY_A300 = DESCRIPTION / "husky_a300.xml"
+HUSKY_SCENE = DESCRIPTION / "husky_scene.xml"
+
+CLEARPATH_A300_URDF = (
+    Path(get_package_share_directory("clearpath_platform_description")) / "urdf" / "a300"
+)
+
+TOLERANCE_M = 1e-4
+
+
+def _xacro_property(source: Path, name: str) -> float:
+    match = re.search(
+        rf'<xacro:property\s+name="{name}"\s+value="([-0-9.eE]+)"', source.read_text()
+    )
+    assert match, f"{source.name} has no numeric xacro:property named {name!r}"
+    return float(match.group(1))
+
+
+def _outdoor_wheel_radius_width() -> tuple[float, float]:
+    outdoor = CLEARPATH_A300_URDF / "drivetrain" / "wheels" / "outdoor.urdf.xacro"
+    return (
+        _xacro_property(outdoor, "a300_outdoor_wheel_radius"),
+        _xacro_property(outdoor, "a300_outdoor_wheel_width"),
+    )
+
+
+def test_wheel_collision_cylinder_matches_vendored_radius_and_width():
+    radius, width = _outdoor_wheel_radius_width()
+    for wheel_file in DESCRIPTION.glob("*_wheel_link.xml"):
+        match = re.search(r'type="cylinder"\s+size="([-0-9.eE]+) ([-0-9.eE]+)"', wheel_file.read_text())
+        assert match, f"{wheel_file.name} has no cylinder collision geom"
+        got_radius, got_half_width = float(match.group(1)), float(match.group(2))
+        assert got_radius == pytest.approx(radius, abs=TOLERANCE_M), wheel_file.name
+        assert got_half_width == pytest.approx(width / 2, abs=TOLERANCE_M), wheel_file.name
+
+
+def test_velocity_actuators_stay_below_the_timestep():
+    """See CLAUDE.md: "Velocity actuators: armature/kv time-constant must stay below the
+    timestep." A violation pins the wheels without any error - this is the only check
+    for it."""
+    scene_text = HUSKY_SCENE.read_text()
+    timestep_match = re.search(r'<option[^>]*\btimestep="([-0-9.eE]+)"', scene_text)
+    assert timestep_match, f"{HUSKY_SCENE.name} has no <option timestep=...>"
+    timestep = float(timestep_match.group(1))
+
+    a300_text = HUSKY_A300.read_text()
+    armatures = {}
+    for wheel_file in DESCRIPTION.glob("*_wheel_link.xml"):
+        joint_text = wheel_file.read_text()
+        match = re.search(
+            r'<joint\s+name="(\w+_wheel_joint)"[^/]*armature="([-0-9.eE]+)"', joint_text, re.DOTALL
+        )
+        assert match, f"{wheel_file.name} has no wheel joint with an armature"
+        armatures[match.group(1)] = float(match.group(2))
+
+    kvs = {
+        m.group(1): float(m.group(2))
+        for m in re.finditer(r'joint="(\w+_wheel_joint)"[^/]*kv="([-0-9.eE]+)"', a300_text, re.DOTALL)
+    }
+    assert armatures and armatures.keys() == kvs.keys(), (armatures, kvs)
+    for joint, armature in armatures.items():
+        tau = armature / kvs[joint]
+        assert tau < timestep, (
+            f"{joint}: armature/kv={tau}s is not below timestep={timestep}s - "
+            "this wheel will not respond to velocity commands (CLAUDE.md)"
+        )

--- a/src/lunar_sim/test/test_husky_mujoco_geometry.py
+++ b/src/lunar_sim/test/test_husky_mujoco_geometry.py
@@ -56,7 +56,9 @@ HUSKY_A300 = DESCRIPTION / "husky_a300.xml"
 HUSKY_SCENE = DESCRIPTION / "husky_scene.xml"
 
 CLEARPATH_A300_URDF = (
-    Path(get_package_share_directory("clearpath_platform_description")) / "urdf" / "a300"
+    Path(get_package_share_directory("clearpath_platform_description"))
+    / "urdf"
+    / "a300"
 )
 
 TOLERANCE_M = 1e-4
@@ -81,11 +83,16 @@ def _outdoor_wheel_radius_width() -> tuple[float, float]:
 def test_wheel_collision_cylinder_matches_vendored_radius_and_width():
     radius, width = _outdoor_wheel_radius_width()
     for wheel_file in DESCRIPTION.glob("*_wheel_link.xml"):
-        match = re.search(r'type="cylinder"\s+size="([-0-9.eE]+) ([-0-9.eE]+)"', wheel_file.read_text())
+        match = re.search(
+            r'type="cylinder"\s+size="([-0-9.eE]+) ([-0-9.eE]+)"',
+            wheel_file.read_text(),
+        )
         assert match, f"{wheel_file.name} has no cylinder collision geom"
         got_radius, got_half_width = float(match.group(1)), float(match.group(2))
         assert got_radius == pytest.approx(radius, abs=TOLERANCE_M), wheel_file.name
-        assert got_half_width == pytest.approx(width / 2, abs=TOLERANCE_M), wheel_file.name
+        assert got_half_width == pytest.approx(
+            width / 2, abs=TOLERANCE_M
+        ), wheel_file.name
 
 
 def test_velocity_actuators_stay_below_the_timestep():
@@ -102,14 +109,18 @@ def test_velocity_actuators_stay_below_the_timestep():
     for wheel_file in DESCRIPTION.glob("*_wheel_link.xml"):
         joint_text = wheel_file.read_text()
         match = re.search(
-            r'<joint\s+name="(\w+_wheel_joint)"[^/]*armature="([-0-9.eE]+)"', joint_text, re.DOTALL
+            r'<joint\s+name="(\w+_wheel_joint)"[^/]*armature="([-0-9.eE]+)"',
+            joint_text,
+            re.DOTALL,
         )
         assert match, f"{wheel_file.name} has no wheel joint with an armature"
         armatures[match.group(1)] = float(match.group(2))
 
     kvs = {
         m.group(1): float(m.group(2))
-        for m in re.finditer(r'joint="(\w+_wheel_joint)"[^/]*kv="([-0-9.eE]+)"', a300_text, re.DOTALL)
+        for m in re.finditer(
+            r'joint="(\w+_wheel_joint)"[^/]*kv="([-0-9.eE]+)"', a300_text, re.DOTALL
+        )
     }
     assert armatures and armatures.keys() == kvs.keys(), (armatures, kvs)
     for joint, armature in armatures.items():


### PR DESCRIPTION
## Intent

Layer 1 (MuJoCo migration) of a lunar-environment stack on top of #869: `lunar_sim` runs the
Husky A300 under MuJoCo physics on a flat regolith plane instead of mock hardware. Crater terrain
and moon-base structures are later layers, gated on a maintainer decision on shape, and are not
started here.

## What changed

- New MJCF body (`description/husky_a300.xml`, `description/husky_scene.xml`, one wheel-link
  include per wheel) modeling the A300 as a free-floating chassis on 4 skid-steer wheels, mirroring
  `hangar_sim`'s mobile-base precedent (`hangar_scene.xml` / `ur5e_ridgeback.xml` / per-wheel
  includes / velocity actuators on the wheel hinges).
- Wheel offsets are FK'd from `clearpath_platform_description`'s own suspension-mount chain (see
  the derivation comment in `husky_a300.xml`); wheel collision is a primitive cylinder matching
  upstream's own URDF collision choice, with the vendored `outdoor_{left,right}.stl` as a
  non-colliding visual mesh. Velocity actuators (`kv=500`) pair with `armature=1.0` to stay under
  the 0.003 s timestep (see CLAUDE.md's armature/kv-vs-timestep rule).
- `description/assets/{chassis_collision,outdoor_left,outdoor_right}.stl` are byte-identical
  copies of the vendored meshes - MuJoCo mesh paths don't survive a colcon install split across
  package share directories, so they're copied into this package rather than referenced
  cross-package (same pattern as `hangar_sim`'s own `description/assets`). No vendored files are
  modified.
- New `husky_a300_mujoco.xacro` replaces `husky_a300_blank_world.xacro`: same body/attachments,
  `picknik_mujoco_ros/MujocoSystem` hardware block instead of `mock_components/GenericSystem`,
  same wheel joint names. `open_loop` is now `false` so `/odom` reflects real per-wheel physics
  feedback instead of integrating the commanded velocity.
- Recovered the dark gradient skybox, dim directional light, and regolith ground material from the
  pre-869 Phoebe-based `lunar_sim` scene (`main`'s `src/lunar_sim/mjcf/scene.xml` before #869
  removed it).
- `config.yaml`: MuJoCo model `urdf_params`; `use_sim_time` is `false` (see review-pass notes
  below - `picknik_mujoco_ros/MujocoSystem` never publishes `/clock`). `/cmd_vel`/`/odom` remaps
  and the `footprint` frame contract from #869's README are unchanged. `Dead Reckon Square` needs
  no changes - it only depends on `/cmd_vel` and the `footprint` frame.
- Regression test (`test_husky_mujoco_geometry.py`) pins wheel radius/width against the vendored
  source and the armature/kv-vs-timestep bound, so a future edit can't silently reintroduce
  CLAUDE.md's pinned-wheel failure mode.
- Documented a MuJoCo `<include>`-inside-`<body>` gotcha hit while building this (it discards the
  included file's own wrapping element, not just its attributes) in CLAUDE.md, since it's
  non-obvious and applies to any future per-wheel/per-part include file.

## Testing

- Standalone MuJoCo 3.6.0 run (the existing local `picknikciuser/moveit-pro` image's bundled
  Python bindings; no image builds or pulls) confirms real physics, not just accepted commands:
  the chassis settles stably (~0.136 m, matching the wheel-radius-minus-compression estimate),
  drives 2.96 m in 6 s under a 3 rad/s wheel command (0.493 m/s measured vs. 0.495 m/s theoretical
  from the wheel radius), and turns 118 deg in place under a skid-steer command.
- `test_husky_mujoco_geometry.py` passes against the real vendored source.
- A full ROS 2/`moveit_pro` stack run (recorded `/odom`, video) was attempted but is blocked in
  this environment by a pre-existing, unrelated Dockerfile issue: a pinned
  `ros-jazzy-nav2-mppi-controller` version 404s against the `ros2-testing` repo (same family as
  commit 0e45115d). Not a `lunar_sim` or MuJoCo problem - flagging so CI or a maintainer with a
  working build environment can do the stack-level pass.

## Left for later

- Crater terrain (layer 2) and moon-base structures (layer 3), pending a maintainer decision on
  shape.
- The stack-level `/odom` + video validation blocked above.
- `wheel_separation_multiplier: 1.75` is a real-hardware slip-calibration constant kept for
  controller-config parity; under closed-loop feedback it skews `/odom`'s reported angular
  velocity by roughly that factor (documented as a known limitation in README.md). Fixing it means
  picking a simulated-track-width constant - a calibration decision, not a bug fix.

## Texture + review-pass round

- Ground texture: replaced the flat two-tone procedural regolith with a photoreal CC0 diffuse map
  (MuJoCo's texture loader only accepts PNG, not JPEG). First attempt used Poly Haven's "Moon 01",
  but a follow-up pass caught it reading flat at the tile scale a 20x20 m plane actually needs (a
  planetary-scale albedo map has too little variation to show rover-scale rock/clod detail once
  tiled that large) and, separately, `texrepeat` with `texuniform="true"` was set for 12.5 cm tiles
  instead of the intended ~3 m (that flag means repeats-per-metre, not repeats-over-the-geom - easy
  to get backwards, now documented in CLAUDE.md). Settled on ambientCG's "Ground031" (also CC0),
  desaturated to a neutral ~0.47-0.51 grey albedo, at `texrepeat="0.3 0.3"` (~3.3 m tile).
  Provenance and an honest caveat (it's a desiccation-cracked mudflat scan, not a lunar dust photo
  - chosen for rock/pebble detail at scale, not a perfect thematic match) recorded in README.md.
- Independent review of the full stacked diff found and fixed:
  - `use_sim_time` was `true` with nothing publishing `/clock`, stalling ROS time at t=0 on every
    node; reverted to `false` to match every other MuJoCo-backed config in this workspace.
  - Right-side wheels were placed 19 mm too far outboard (`-0.2829` vs. the FK-correct `-0.2639`)
    - the vendored suspension-beam mount joint has a literal, non-mirrored y offset that breaks
    naive left/right symmetry.
  - Right-side wheel visual meshes were missing the 180 deg yaw upstream applies for that side
    (`outdoor_right.stl` is a distinct, mirrored mesh, not a renamed copy).
  - Restored a footprint-vs-base_footprint naming rationale (check_urdf uniqueness) that got
    dropped from the xacro comment when it was shortened to a doc pointer.
- Re-verified with the standalone MuJoCo smoke test and re-rendered all views after each fix.

## Texture swap: real NASA photo instead of a terrestrial scan

Ground031 (and the CC0 gravel/sand alternatives considered before it) are all photos of Earth
ground - they read as terrestrial on close inspection, not lunar. Replaced the color map with a
processed crop of a real lunar surface photograph instead:

- Source: **NASA Apollo 15 Hasselblad frame AS15-86-11671** (Station 7, Spur Crater, EVA-2, the
  "Genesis Rock" documentation photo), public domain, NASA/JSC -
  [archive.org/details/AS15-86-11671](https://archive.org/details/AS15-86-11671).
- Cropped clear of the gnomon, the rock sample, and any footprints; the Hasselblad's reseau-plate
  fiducial grid lines (calibration marks etched across the whole frame, not scene content) were
  detected and removed by shifting in real texture from just outside each line.
- Flat-fielded and desaturated to the same neutral ~0.49 grey albedo as prior rounds, tiled
  seamlessly at 2048px (kept high-resolution so ground-level close-ups show real grain instead of
  blurring), same `texrepeat="0.3 0.3"` (~3.3 m tile) and matte material as before.
- Baked in sparse 10-45cm craterlets and 3-12cm rocks, shaded consistent with the scene's sun
  direction and verified against the chassis's own cast shadow in a render.
- Full provenance and processing steps in `README.md`; asset is
  `description/assets/lunar_regolith_as15-86-11671_2k.png` (LFS, ~4.1 MB), replacing
  `lunar_regolith_ground031_2k.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcVCNFgD5zPAo8zrL1Shfi


