### PR TITLE
Fix: Skip the hand-eye calibration Objectives in the config integration tests

### DIFF
--- a/src/april_tag_sim/test/objectives_integration_test.py
+++ b/src/april_tag_sim/test/objectives_integration_test.py
@@ -61,6 +61,12 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
 }
 
 

--- a/src/dual_arm_sim/test/objectives_integration_test.py
+++ b/src/dual_arm_sim/test/objectives_integration_test.py
@@ -56,6 +56,12 @@ cancel_objectives: set[str] = set()
 skip_objectives: set[str] = {
     "Teleoperate",  # Waits on UI teleoperation input.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     "Writing Demo",  # Long-running drawing objective times out on the CI backend.
     "Find Green Block",  # ML text-prompt segmentation.
     "Find Red Block",  # ML text-prompt segmentation.

--- a/src/factory_sim/test/objectives_integration_test.py
+++ b/src/factory_sim/test/objectives_integration_test.py
@@ -70,6 +70,12 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     # Factory demos are not deterministic as standalone success checks in
     # headless CI: planning-scene setup is not idempotent across the sweep,
     # reachability loops exceed the fixture timeout, and surface-planning demos

--- a/src/grinding_sim/test/objectives_integration_test.py
+++ b/src/grinding_sim/test/objectives_integration_test.py
@@ -57,6 +57,12 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     "Register Machined Part",  # Registration flow exceeds the fixture timeout headless.
 }
 

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -113,6 +113,12 @@ skip_objectives = {
     # reasons.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     # Intermittent Jazzy CI-runner flakes. Skipped so the suite is deterministic.
     #
     # "Solution - Draw Picknik" is the suite's longest objective and sits on

--- a/src/kitchen_sim/test/objectives_integration_test.py
+++ b/src/kitchen_sim/test/objectives_integration_test.py
@@ -63,6 +63,12 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     "Writing Demo",  # Long-running drawing objective times out on the CI backend.
 }
 

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -275,6 +275,12 @@ cancel_objectives = {
 # Objectives to skip entirely from integration testing
 skip_objectives = {
     "AddBottlesToPlanningScene",
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
+    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # hand_eye_calibration_sim provides.
+    "Calibrate Eye In Hand Camera",
+    "Calibrate Eye To Hand Camera",
+    "Calibrate Multiple Cameras",
     "Collect Training Data with Behaviors",  # Requires setup for data collection (recording infrastructure not available in CI)
     "Grasp Planning",
     "Joint Diagnostic",


### PR DESCRIPTION
[written by AI]

## Motivation

The scheduled and push CI runs on `main` have been red since moveit_pro #22066 landed (for example [run 34121980243](https://github.com/PickNikRobotics/moveit_pro_example_ws/actions/runs/34121980243)). Both failing jobs fail on one parametrized test, the core `Calibrate Eye In Hand Camera` Objective. Each config's integration test runs every runnable Objective the system config resolves, core ones included, and this Objective moves through taught `calibration_*` waypoints and detects a ChArUco board. lab_sim and hangar_sim have neither, so `GetWaypointNames` fails with "No waypoint name starts with 'calibration'" and the Objective fails.

## Brief description

Adds the hand-eye calibration Objectives to `skip_objectives` in the seven configs that have an integration test, in the existing "core-library Objectives aggregated into every config" group next to `Teleoperate` and `Marker Visualization Example`. `Calibrate Eye To Hand Camera` and `Calibrate Multiple Cameras` are listed too; they ship with moveit_pro #22111 and would otherwise break the same tests on their first image. The fixture only marks IDs it enumerates, so the two entries are inert until then. `hand_eye_calibration_sim` is the config that provides the waypoints and boards and has no integration test, so nothing changes there.

A fixture-level default for core Objectives that need site-specific setup, so future additions need no per-config edit, is a separate moveit_pro change.
