### PR TITLE
Add Move to Home Objective to hand_eye_calibration_sim

### DIFF
--- a/src/hand_eye_calibration_sim/objectives/move_to_home.xml
+++ b/src/hand_eye_calibration_sim/objectives/move_to_home.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root BTCPP_format="4" main_tree_to_execute="Move to Home">
+  <!--//////////-->
+  <BehaviorTree
+    ID="Move to Home"
+    _description="Moves the robot to the Home waypoint, where the wrist camera sees the world board and the scene cameras see the board on the wrist."
+    _favorite="true"
+  >
+    <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Move to Named Waypoint"
+        _collapsed="true"
+        waypoint_name="Home"
+      />
+    </Control>
+  </BehaviorTree>
+  <TreeNodesModel>
+    <SubTree ID="Move to Home">
+      <MetadataFields>
+        <Metadata runnable="true" />
+        <Metadata subcategory="Motion - Execute" />
+      </MetadataFields>
+    </SubTree>
+  </TreeNodesModel>
+</root>


### PR DESCRIPTION
[written by AI]

Adds a `Move to Home` Objective to `hand_eye_calibration_sim`. It moves the arm to the `Home` waypoint, the pose the calibration Objectives start from. Tested in the Desktop App against the running simulation.
