### PR TITLE
Fix: Prepare Kinova admittance path from the reset posture

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/objectives/move_along_path_admittance.xml
@@ -8,6 +8,11 @@
     _hardcoded="false"
   >
     <Control ID="Sequence" name="TopLevelSequence">
+      <SubTree
+        ID="Move to Named Waypoint"
+        _collapsed="true"
+        waypoint_name="View Satellite"
+      />
       <Control ID="Sequence">
         <Action
           ID="SwitchController"


### PR DESCRIPTION
[written by AI]

Fixes PickNikRobotics/moveit_pro#22397.

After a `kinova_sim` reset, `Move Along Path Admittance` tries to plan its constrained Cartesian approach from a singular, straight-arm posture and fails before executing the rectangle. Start with a move to the saved `View Satellite` waypoint, matching the existing `Move Along Path` example. The preparation runs once before the repeating loop and its path-approval prompt; the rectangle, admittance settings, and trajectory validation remain unchanged.

## How it was tested

- `pre-commit run -a` passed on the v10.1 candidate.
- `kinova_sim` built in isolated build/install directories in the development container. `colcon test` and `colcon test-result` exited successfully but registered zero tests. The active Runtime's supported Objective verification endpoint returned `is_valid=true`; its XML matched the candidate byte for byte.
- An offline probe using the production `path_ik` library reproduced the reported error from the reset posture and solved the same path from `View Satellite`, including three subsequent planned cycles.
- The user tested the exact XML through the local browser on `kinova_sim`. Runtime logs show six completed loop iterations before cancellation by a reset Objective, followed by a completed iteration after resetting the simulator to its default keyframe. Completion is established by the enclosing Sequence reaching the next Cartesian planning iteration, rather than by the repeating Objective merely remaining `RUNNING`.
- The visual execution used a development Runtime reporting 10.2.0. A packaged 10.1.0-rc4 replay and cancellation while awaiting approval remain unverified. Kinova still has no Objective integration test in CI; this PR contains only the missing preparation step.

## Release notes

- Bug Fix: Fixed `Move Along Path Admittance` failing to plan from the `kinova_sim` reset posture.

## Claude agent checks

Candidate: `d9e417311b98a0374e23126e2ad10ccc460fab9d`; base: `v10.1` at `ab7e95fa2322f78744721978e0bf65e74149fa05`.

- [x] `code-reviewer`
  - No required changes; verified the release subtree and waypoint.
- [x] `documentation-bot`
  - No documentation impact.
- [x] SKIPPED `licensing-privacy-bot`
  - No third-party components, licensing, or data-collection changes.
- [x] `platform-architect-bot`
  - No required changes; verified setup failure propagation and loop placement.
- [x] `roboticist-bot`
  - No required changes; the existing setup subtree plans with the planning scene and preserves collision checks.
- [x] SKIPPED `frontend-noah-bot`
  - No frontend files changed.
- [x] SKIPPED `security-auditor`
  - Only config-local Objective composition changed; no security-sensitive paths.
- [x] `compatibility-bot`
  - No public API impact; the referenced subtree and port exist in v10.1.
- [x] SKIPPED `sonar-bot`
  - XML-only change; no SonarCloud-analyzed source changed.
- [x] `test-runner`
  - Scoped package build and canonical Objective verification passed. The package registers zero tests; live user execution evidence and remaining coverage limits are recorded above.
