### PR TITLE
Fix: Convert behavior-collected lab_sim data with next-state action labels

### DIFF
--- a/src/lab_sim/objectives/collect_training_data_with_behaviors.xml
+++ b/src/lab_sim/objectives/collect_training_data_with_behaviors.xml
@@ -34,10 +34,14 @@
           delay_duration="1.0"
         />
         <Action ID="StopRecording" name="Finish recording session" />
+        <!--The robot performs the task on its own, so nothing is recorded on
+             the commanded-joint topic; label actions with the next recorded
+             joint state instead of refusing the episode.-->
         <Action
           ID="ConvertDataset"
           name="Convert to LeRobot dataset"
           dataset_name="behavior_bottle_pick"
+          action_source="next_state"
         />
       </Control>
       <!--Cleanup, not a forced success: if the task fails before SaveEpisode,


### PR DESCRIPTION
[written by AI]

needs: moveit_pro/#22467

Pairs with PickNikRobotics/moveit_pro#22467, which adds the `action_source` port to `ConvertDataset`. Fixes the last step of the [Collect Training Data with Behaviors](https://docs.picknik.ai/how_to/vla/collect_training_data_with_behaviors/) tutorial for PickNikRobotics/moveit_pro#22429.

The shipped `lab_sim` objective `collect_training_data_with_behaviors.xml` runs the pick on its own, so nothing is recorded on the commanded-joint topic and the default command labels refuse every episode at conversion. Set `action_source="next_state"` on its `ConvertDataset` node so the conversion labels each frame's action with the next recorded state.

Merge order: the moveit_pro PR first. BT.CPP rejects an XML attribute for an unregistered port, so this objective needs a Runtime that has the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
