### PR TITLE
chore(hangar_sim): remove four inert AMCL beam-skip params from nav2_params.yaml

### DIFF
--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -21,10 +21,6 @@ amcl:
     alpha4: 0.05
     alpha5: 0.05
     base_frame_id: "ridgeback_base_link"
-    beam_skip_distance: 0.5
-    beam_skip_error_threshold: 0.9
-    beam_skip_threshold: 0.3
-    do_beamskip: false
     global_frame_id: "map"
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0


### PR DESCRIPTION
## Intent

Delete four dead parameters from src/hangar_sim/params/nav2_params.yaml: do_beamskip, beam_skip_distance, beam_skip_error_threshold, beam_skip_threshold, which sat under the AMCL/beluga block. They were carried over from nav2_amcl, which declares them; beluga_amcl, which is what hangar_sim actually loads (localization_launch.py loads the beluga_amcl::AmclNode plugin), does not declare any of them, so all four lines were inert.

This is deliberately the smallest PR in a sequence re-landing hangar_sim localization work off main, and is scoped to exactly this deletion and nothing else.

The finding was verified empirically before deleting rather than taken on faith. beluga is not installed on the host, so a beluga_amcl node (version 2.1.1) was run directly in the shipped image (moveit-pro-drivers:main-jazzy-). 'ros2 param list' on the live node returned 60 parameters, and max_beams is the only beam-named parameter it declares - none of the four appear, and 'ros2 param get' on each returns 'Parameter not set'. The node was also started with this very nav2_params.yaml as its --params-file: it came up and stayed alive with no startup warning and no failure, confirming beluga silently ignores the undeclared names, which is why they went unnoticed. Additionally, 'ros2 param describe laser_model_type' reports the supported values are only [beam, likelihood_field], so the likelihood_field_prob sensor model that would need beam skipping is not available in the version we ship at all - removing these does not close off an option we had.

Rationale for a standalone PR: the four lines read as active localization tuning and have already misled documentation (a since-closed docs PR wrote beam-skip tuning guidance around parameters that do nothing). Leaving them in place is a trap for the next person to retune this file.

Explicit scope boundary, deliberately chosen by the user and not an oversight: max_beams, update_min_d, update_min_a, sigma_hit, z_hit, z_rand, resample_interval, max_particles and wz_max all do need retuning, but that is a separate PR gated on a simulator measurement session and must not be pre-empted here. Nothing else in nav2_params.yaml is touched. In particular, do not expect this change to adjust max_beams - that is the real beam-density lever and is being addressed in a later PR with measurements behind it.

No test is added: the change deletes inert configuration lines that no code reads, and the verification is a runtime property of the third-party beluga_amcl node in the shipped image rather than of this repository's code.

## What Changed

- Deleted `do_beamskip`, `beam_skip_distance`, `beam_skip_error_threshold`, and `beam_skip_threshold` from the `amcl` block of `src/hangar_sim/params/nav2_params.yaml`.
- These four keys come from `nav2_amcl`, but `hangar_sim` loads the `beluga_amcl::AmclNode` plugin, which does not declare them — the lines were silently ignored at runtime, so localization behavior is unchanged.
- No other parameters in the file are touched; remaining AMCL tuning values (including `max_beams`) are left as-is.

## Risk Assessment

✅ Low: The change deletes four configuration lines that no code in the repo references and that the loaded beluga_amcl node does not declare, with no other file or parameter touched.

## Testing

I validated this by exercising the real consumer rather than the YAML text: the shipped moveit-pro-drivers image's `beluga_amcl` node was launched twice, once with the pre-change nav2_params.yaml and once with the post-change one, and queried live. Both runs start cleanly with no startup warning, declare the exact same 65 parameters, report `Parameter not set` for all four deleted names (before the deletion too, which is the whole point), and apply identical values for everything that is real tuning — including max_beams: 60, confirming the change did not pre-empt the later retuning PR. The declared-parameter diff between the two runs is empty, and `laser_model_type` only offers [beam, likelihood_field], so no capability is lost. No repository test covers this file and none was added, consistent with the intent: the property being verified belongs to the third-party node, not to this repo's code. No UI surface is involved, so no visual artifact applies. Worktree left clean; all evidence written to the evidence directory.

<details>
<summary>Evidence: Live beluga_amcl parameter verification transcript (before vs after)</summary>

<code>=== [before] params-file: nav2_params_before.yaml ===&#10;[before] node alive after startup: YES&#10;[before] node startup output (stdout+stderr, verbatim):&#10;| (empty - no warning about the undeclared names)&#10;[before] declared parameter count: 65&#10;[before] beam-named parameters declared: max_beams&#10;[before] ros2 param get for each deleted name:&#10;do_beamskip -&gt; Parameter not set&#10;beam_skip_distance -&gt; Parameter not set&#10;beam_skip_error_threshold -&gt; Parameter not set&#10;beam_skip_threshold -&gt; Parameter not set&#10;[before] values the node DID take from the file:&#10;max_beams -&gt; Integer value is: 60&#10;laser_model_type -&gt; String value is: likelihood_field&#10;z_hit -&gt; Double value is: 0.5&#10;sigma_hit -&gt; Double value is: 0.2&#10;update_min_d -&gt; Double value is: 0.25&#10;max_particles -&gt; Integer value is: 5000&#10;resample_interval -&gt; Integer value is: 1&#10;[before] laser_model_type supported values:&#10;Parameter name: laser_model_type&#10;Type: string&#10;Description: Which observation model to use [beam, likelihood_field].&#10;&#10;=== [after] params-file: nav2_params_after.yaml ===&#10;[after] node alive after startup: YES&#10;[after] node startup output (stdout+stderr, verbatim):&#10;| (empty - no warning about the undeclared names)&#10;[after] declared parameter count: 65&#10;[after] beam-named parameters declared: max_beams&#10;[after] ros2 param get for each deleted name:&#10;do_beamskip -&gt; Parameter not set&#10;beam_skip_distance -&gt; Parameter not set&#10;beam_skip_error_threshold -&gt; Parameter not set&#10;beam_skip_threshold -&gt; Parameter not set&#10;[after] values the node DID take from the file:&#10;max_beams -&gt; Integer value is: 60&#10;laser_model_type -&gt; String value is: likelihood_field&#10;z_hit -&gt; Double value is: 0.5&#10;sigma_hit -&gt; Double value is: 0.2&#10;update_min_d -&gt; Double value is: 0.25&#10;max_particles -&gt; Integer value is: 5000&#10;resample_interval -&gt; Integer value is: 1&#10;[after] laser_model_type supported values:&#10;Parameter name: laser_model_type&#10;Type: string&#10;Description: Which observation model to use [beam, likelihood_field].&#10;&#10;=== diff of declared parameter sets: before vs after the deletion ===&#10;IDENTICAL parameter sets - removing the four lines changed nothing the node sees</code>

```text
=== [before] params-file: nav2_params_before.yaml ===
[before] node alive after startup: YES
[before] node startup output (stdout+stderr, verbatim):
    | (empty - no warning about the undeclared names)
[before] declared parameter count: 65
[before] beam-named parameters declared: max_beams 
[before] ros2 param get for each deleted name:
    do_beamskip                  -> Parameter not set
    beam_skip_distance           -> Parameter not set
    beam_skip_error_threshold    -> Parameter not set
    beam_skip_threshold          -> Parameter not set
[before] values the node DID take from the file:
    max_beams          -> Integer value is: 60
    laser_model_type   -> String value is: likelihood_field
    z_hit              -> Double value is: 0.5
    sigma_hit          -> Double value is: 0.2
    update_min_d       -> Double value is: 0.25
    max_particles      -> Integer value is: 5000
    resample_interval  -> Integer value is: 1
[before] laser_model_type supported values:
    Parameter name: laser_model_type
      Type: string
      Description: Which observation model to use [beam, likelihood_field].
      Constraints:

=== [after] params-file: nav2_params_after.yaml ===
[after] node alive after startup: YES
[after] node startup output (stdout+stderr, verbatim):
    | (empty - no warning about the undeclared names)
[after] declared parameter count: 65
[after] beam-named parameters declared: max_beams 
[after] ros2 param get for each deleted name:
    do_beamskip                  -> Parameter not set
    beam_skip_distance           -> Parameter not set
    beam_skip_error_threshold    -> Parameter not set
    beam_skip_threshold          -> Parameter not set
[after] values the node DID take from the file:
    max_beams          -> Integer value is: 60
    laser_model_type   -> String value is: likelihood_field
    z_hit              -> Double value is: 0.5
    sigma_hit          -> Double value is: 0.2
    update_min_d       -> Double value is: 0.25
    max_particles      -> Integer value is: 5000
    resample_interval  -> Integer value is: 1
[after] laser_model_type supported values:
    Parameter name: laser_model_type
      Type: string
      Description: Which observation model to use [beam, likelihood_field].
      Constraints:

=== diff of declared parameter sets: before vs after the deletion ===
IDENTICAL parameter sets - removing the four lines changed nothing the node sees
```
</details>
<details>
<summary>Evidence: Reproducible verification script (runs beluga_amcl in the shipped image)</summary>

```text
#!/bin/bash
# Runs the real beluga_amcl::AmclNode from the shipped drivers image against
# hangar_sim's nav2_params.yaml (before and after the deletion) and reports the
# parameters the node actually declares and applies.
set +u
source /opt/ros/jazzy/setup.bash
cd /ev

run_case () {
  local tag=$1 file=$2
  ros2 run beluga_amcl amcl_node --ros-args -r __node:=amcl --params-file "$file" \
      > "/ev/node_${tag}.log" 2>&1 &
  local pid=$!
  for i in $(seq 1 30); do
    ros2 node list 2>/dev/null | grep -qx /amcl && break
    sleep 1
  done
  echo "=== [$tag] params-file: $(basename $file) ==="
  echo "[$tag] node alive after startup: $(kill -0 $pid 2>/dev/null && echo YES || echo NO)"
  echo "[$tag] node startup output (stdout+stderr, verbatim):"
  sed 's/^/    | /' "/ev/node_${tag}.log"
  [ -s "/ev/node_${tag}.log" ] || echo "    | (empty - no warning about the undeclared names)"
  ros2 param list /amcl | sed 's/^ *//' | sort > "/ev/params_${tag}.txt"
  echo "[$tag] declared parameter count: $(wc -l < /ev/params_${tag}.txt)"
  echo "[$tag] beam-named parameters declared: $(grep -i beam /ev/params_${tag}.txt | tr '\n' ' ')"
  echo "[$tag] ros2 param get for each deleted name:"
  for p in do_beamskip beam_skip_distance beam_skip_error_threshold beam_skip_threshold; do
    printf '    %-28s -> %s\n' "$p" "$(ros2 param get /amcl $p 2>&1 | tail -1)"
  done
  echo "[$tag] values the node DID take from the file:"
  for p in max_beams laser_model_type z_hit sigma_hit update_min_d max_particles resample_interval; do
    printf '    %-18s -> %s\n' "$p" "$(ros2 param get /amcl $p 2>&1 | tail -1)"
  done
  echo "[$tag] laser_model_type supported values:"
  ros2 param describe /amcl laser_model_type | sed 's/^/    /'
  kill -9 $pid 2>/dev/null; wait $pid 2>/dev/null
  for i in $(seq 1 20); do ros2 node list 2>/dev/null | grep -qx /amcl || break; sleep 1; done
  echo
}

run_case before /ev/nav2_params_before.yaml
run_case after  /ev/nav2_params_after.yaml

echo "=== diff of declared parameter sets: before vs after the deletion ==="
if diff -u /ev/params_before.txt /ev/params_after.txt; then
  echo "IDENTICAL parameter sets - removing the four lines changed nothing the node sees"
fi
```
</details>
<details>
<summary>Evidence: Declared parameter list, pre-change params file</summary>

```text
alpha1
alpha2
alpha3
alpha4
alpha5
always_reset_initial_pose
autostart
autostart_delay
base_frame_id
bond_timeout
debug
execution_policy
first_map_only
global_frame_id
initial_pose.covariance_x
initial_pose.covariance_xy
initial_pose.covariance_xyaw
initial_pose.covariance_y
initial_pose.covariance_yaw
initial_pose.covariance_yyaw
initial_pose.x
initial_pose.y
initial_pose.yaw
initial_pose_topic
lambda_short
laser_likelihood_max_dist
laser_max_range
laser_min_range
laser_model_type
map_path
map_topic
max_beams
max_particles
min_particles
model_unknown_space
odom_frame_id
only_obstacle_boundaries
pf_err
pf_z
point_cloud_topic
qos_overrides./clock.subscription.depth
qos_overrides./clock.subscription.durability
qos_overrides./clock.subscription.history
qos_overrides./clock.subscription.reliability
recovery_alpha_fast
recovery_alpha_slow
resample_interval
robot_model_type
scan_topic
selective_resampling
set_initial_pose
sigma_hit
spatial_resolution_theta
spatial_resolution_x
spatial_resolution_y
start_type_description_service
tf_broadcast
transform_tolerance
update_min_a
update_min_d
use_sim_time
z_hit
z_max
z_rand
z_short
```
</details>
<details>
<summary>Evidence: Declared parameter list, post-change params file (identical)</summary>

```text
alpha1
alpha2
alpha3
alpha4
alpha5
always_reset_initial_pose
autostart
autostart_delay
base_frame_id
bond_timeout
debug
execution_policy
first_map_only
global_frame_id
initial_pose.covariance_x
initial_pose.covariance_xy
initial_pose.covariance_xyaw
initial_pose.covariance_y
initial_pose.covariance_yaw
initial_pose.covariance_yyaw
initial_pose.x
initial_pose.y
initial_pose.yaw
initial_pose_topic
lambda_short
laser_likelihood_max_dist
laser_max_range
laser_min_range
laser_model_type
map_path
map_topic
max_beams
max_particles
min_particles
model_unknown_space
odom_frame_id
only_obstacle_boundaries
pf_err
pf_z
point_cloud_topic
qos_overrides./clock.subscription.depth
qos_overrides./clock.subscription.durability
qos_overrides./clock.subscription.history
qos_overrides./clock.subscription.reliability
recovery_alpha_fast
recovery_alpha_slow
resample_interval
robot_model_type
scan_topic
selective_resampling
set_initial_pose
sigma_hit
spatial_resolution_theta
spatial_resolution_x
spatial_resolution_y
start_type_description_service
tf_broadcast
transform_tolerance
update_min_a
update_min_d
use_sim_time
z_hit
z_max
z_rand
z_short
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"00711e710b13b2e9634e37738224ba2e3f2d1737","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat cd5c8fff..00711e71` — confirmed the change is exactly 4 deletions in src/hangar_sim/params/nav2_params.yaml and nothing else</code>
- <code>`grep -rn &#39;beam_skip|do_beamskip&#39; src/` — no references remain anywhere in the workspace</code>
- <code>Confirmed hangar_sim loads `beluga_amcl::AmclNode` (not nav2_amcl) in src/hangar_sim/launch/sim/localization_launch.py:154</code>
- <code>`docker run --rm --entrypoint bash -v &lt;evidence&gt;:/ev moveit-pro-drivers:main-jazzy- -lc /ev/verify_beluga_params.sh` — starts `ros2 run beluga_amcl amcl_node --ros-args -r __node:=amcl --params-file &lt;before|after&gt;` and captures startup output</code>
- <code>`ros2 param list /amcl` for both before/after params files — identical 65-parameter sets, `max_beams` the only beam-named parameter</code>
- <code>`ros2 param get /amcl {do_beamskip,beam_skip_distance,beam_skip_error_threshold,beam_skip_threshold}` — &#39;Parameter not set&#39; in both the before and after runs</code>
- <code>`ros2 param get /amcl {max_beams,laser_model_type,z_hit,sigma_hit,update_min_d,max_particles,resample_interval}` — values applied from the file are identical before and after</code>
- <code>`ros2 param describe /amcl laser_model_type` — supported values are only [beam, likelihood_field]</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
