### PR TITLE
Fix: mock_sim and multi_arm_sim launch abort from Robotiq mimic-joint command interfaces

### DIFF
--- a/src/external_dependencies/ros2_robotiq_gripper/UPSTREAM.yaml
+++ b/src/external_dependencies/ros2_robotiq_gripper/UPSTREAM.yaml
@@ -20,7 +20,10 @@ modified_paths:
   - robotiq_controllers/src/reactivation.cpp
   - robotiq_controllers/test/reactivation_test.cpp
   - robotiq_description/config/robotiq_controllers.yaml
+  - robotiq_description/urdf/2f_85.ros2_control.xacro
+  - robotiq_description/urdf/2f_140.ros2_control.xacro
 notes:
+  - The 2f_85/2f_140 ros2_control xacros port upstream PR #54: mock/Isaac simulation joints carry state interfaces only, because ros2_control on Jazzy derives mimic joints from the URDF and rejects command interfaces on them.
   - PickNik ports the retained activation controller to ROS 2 Jazzy while preserving Humble compatibility.
   - The retained controller preserves the reactivation service as a deterministic simulation no-op without hardware command interfaces and fails lifecycle activation unless simulation_only is explicitly true.
   - Binary files matching workspace Git LFS patterns are stored as LFS objects; checked-out bytes match upstream.

--- a/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -49,46 +49,31 @@
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${use_fake_hardware or sim_isaac or sim_ignition}">
                 <joint name="${prefix}left_inner_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}left_inner_finger_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_outer_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_inner_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_inner_finger_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>

--- a/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -54,46 +54,31 @@
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${use_fake_hardware or sim_isaac or sim_ignition}">
                 <joint name="${prefix}robotiq_85_right_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_left_inner_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_right_inner_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_left_finger_tip_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_right_finger_tip_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>


### PR DESCRIPTION
[written by AI]

Fixes PickNikRobotics/moveit_pro#22387

## Problem

`mock_sim` and `multi_arm_sim` abort at launch: `ros2_control_node` throws `Joint 'robotiq_85_right_knuckle_joint' has mimic attribute not set to false: Activated mimic joints cannot have command interfaces.` and dies with SIGABRT, taking the drivers container down.

## Root cause

The vendored `robotiq_description` xacros (`2f_85.ros2_control.xacro`, `2f_140.ros2_control.xacro`) still declare the gripper's five mimic joints with `<param name="mimic">` plus command interfaces under mock hardware — the pre-Jazzy idiom. ros2_control 4.13.0 (July 2024, ros-controls/ros2_control#1553) removed that deprecated path: on Jazzy, mimic joints are derived from the URDF `<mimic>` tags and command interfaces on them are rejected at parse time.

This was never a 10.0→10.1 regression: the same URDF fails identically against the 10.0.0 image's `hardware_interface` 4.45.2. The configs last worked on Humble (its ros2_control never removed the param path); they broke when the workspace went Jazzy-only, and no CI exercises either config. Upstream fixed the description in `ros2_robotiq_gripper` PR #54 (July 2024) — on `main`, ten days after the ros2_control change — but our vendored copy was cut from the `humble` branch, which never took that fix.

## Fix

Port upstream PR #54 into the vendored copy: the five simulation-only mimic joints keep their state interfaces and lose the `mimic`/`multiplier` params and `<command_interface>`. `mock_components/GenericSystem` on Jazzy propagates mimics from the URDF natively, so behavior is preserved. `UPSTREAM.yaml` records the modification. No macro signatures change, so no callers are touched.

## How it was tested

- `hardware_interface::parse_control_resources_from_urdf` (the exact function that threw) now accepts both generated URDFs, run against the release image's own libraries: `mock_sim` registers the gripper with 6 joints / 5 mimic joints; `multi_arm_sim` registers all 8 hardware components, each gripper with 5 mimic joints.
- Live `ros2_control_node` run with the fixed `mock_sim` URDF: `joint_state_broadcaster` and `robotiq_gripper_controller` (`position_controllers/GripperActionController`) configure and activate, a `gripper_cmd` goal to 0.5 rad SUCCEEDS, and `/joint_states` shows the mimic joints tracking with their URDF multipliers (right knuckle −0.5, left inner knuckle +0.5, right finger tip +0.5).
- `bin/validate_workspace_dependencies.py` passes.
