### PR TITLE
Fix: mock_sim and multi_arm_sim launch abort from Robotiq mimic-joint command interfaces (v10.1)

### DIFF
--- a/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -49,46 +49,31 @@
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${use_fake_hardware or sim_isaac or sim_ignition}">
                 <joint name="${prefix}left_inner_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}left_inner_finger_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_outer_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_inner_knuckle_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}right_inner_finger_joint">
-                    <param name="mimic">${prefix}finger_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>

--- a/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/src/external_dependencies/ros2_robotiq_gripper/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -54,46 +54,31 @@
             <!-- When simulating we need to include the rest of the gripper joints -->
             <xacro:if value="${use_fake_hardware or sim_isaac or sim_ignition}">
                 <joint name="${prefix}robotiq_85_right_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_left_inner_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_right_inner_knuckle_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_left_finger_tip_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">-1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>
                 </joint>
                 <joint name="${prefix}robotiq_85_right_finger_tip_joint">
-                    <param name="mimic">${prefix}robotiq_85_left_knuckle_joint</param>
-                    <param name="multiplier">1</param>
                     <xacro:unless value="${sim_ignition}">
-                        <command_interface name="position"/>
                         <state_interface name="position"/>
                         <state_interface name="velocity"/>
                     </xacro:unless>


### PR DESCRIPTION
[written by AI]

v10.1 release-branch PR for PickNikRobotics/moveit_pro#22387. Same change as #915 (which targets `main`), minus the `UPSTREAM.yaml` bookkeeping that only exists on `main`.

## Problem

`mock_sim` and `multi_arm_sim` abort at launch on every 10.x Jazzy build: `ros2_control_node` throws `Joint 'robotiq_85_right_knuckle_joint' has mimic attribute not set to false: Activated mimic joints cannot have command interfaces.` and dies with SIGABRT, taking the drivers container down.

## Root cause and fix

ros2_control 4.13.0 (Jul 2024, ros-controls/ros2_control#1553) removed the deprecated `<param name="mimic">` path; on Jazzy, mimic joints come from the URDF and command interfaces on them are rejected at parse time. The vendored `robotiq_description` xacros were cut from the upstream `humble` branch, which never took upstream's corresponding fix (`ros2_robotiq_gripper` PR #54). This PR ports that fix: the five simulation-only mimic joints keep state interfaces and lose the mimic params and command interfaces. `mock_components/GenericSystem` propagates URDF mimics natively, so gripper behavior is unchanged.

## How it was tested

Validated on `main` (identical xacros): `parse_control_resources_from_urdf` from the release image accepts both generated URDFs (gripper components register 5 mimic joints each), and a live `ros2_control_node` run activates `joint_state_broadcaster` + `robotiq_gripper_controller`, executes a `gripper_cmd` goal, and `/joint_states` shows the mimic fingers tracking with their URDF multipliers. See #915 for details.
