### PR TITLE
Fix: Keep phoebe_sim lift joint limit overrides within the physical range

### DIFF
--- a/src/external_dependencies/phoebe_ws/UPSTREAM.yaml
+++ b/src/external_dependencies/phoebe_ws/UPSTREAM.yaml
@@ -28,6 +28,7 @@ modified_paths:
   - src/phoebe_sim/CMakeLists.txt
   - src/phoebe_sim/package.xml
   - src/phoebe_sim/config/control/dual_arm.ros2_control.yaml
+  - src/phoebe_sim/config/moveit/joint_limits.yaml
 apache_paths:
   - src/phoebe_sim/description/assets/trainer_hatch
 apache_excluded_paths:

--- a/src/external_dependencies/phoebe_ws/src/phoebe_sim/config/moveit/joint_limits.yaml
+++ b/src/external_dependencies/phoebe_ws/src/phoebe_sim/config/moveit/joint_limits.yaml
@@ -42,9 +42,9 @@ joint_limits:
     has_velocity_limits: true
     max_acceleration: 1.0
     max_effort: 150.0
-    max_position: 0.40
+    max_position: 0.25
     max_velocity: 0.025
-    min_position: -0.10
+    min_position: 0.0
   left_shoulder_pan_joint:
     has_acceleration_limits: true
     has_effort_limits: true
@@ -128,9 +128,9 @@ joint_limits:
     has_velocity_limits: true
     max_acceleration: 1.0
     max_effort: 150.0
-    max_position: 0.40
+    max_position: 0.25
     max_velocity: 0.025
-    min_position: -0.10
+    min_position: 0.0
   right_shoulder_pan_joint:
     has_acceleration_limits: true
     has_effort_limits: true


### PR DESCRIPTION
[written by AI]

## Motivation

`phoebe_sim/config/moveit/joint_limits.yaml` overrides `lift_left_upper_joint` and `lift_right_upper_joint` to [-0.10, 0.40], but the Ewellix TLT500 URDF bounds the lift's `upper_joint` at [0, 0.25] (and `hard_joint_limits.yaml` agrees), so the override extends past the physical travel. It also breaks the mimic relationship: `lift_*_lower_joint` follows `upper_joint` with multiplier 0.5 and keeps its URDF limits [0, 0.4], so the overridden driver range maps to [-0.05, 0.20], below the mimic's minimum.

PickNikRobotics/moveit_pro#22410 adds load-time validation of mimic joint position limits, including after `joint_limits.yaml` overrides are applied — with it, `phoebe_sim` (and `lunar_sim`, which inherits via `based_on_package`) refuses to load until this override is corrected.

## Brief description

Set both lift overrides back to the physical range [0, 0.25]. This restores mimic consistency (mapped range [0, 0.125] within the lower joint's [0, 0.4]) and is valid on current releases too, independent of moveit_pro#22410.
