### PR TITLE
Skip the Generate Calibration Waypoints Objective in the config integration tests

### DIFF
--- a/src/april_tag_sim/test/objectives_integration_test.py
+++ b/src/april_tag_sim/test/objectives_integration_test.py
@@ -61,12 +61,13 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
 }
 
 

--- a/src/dual_arm_sim/test/objectives_integration_test.py
+++ b/src/dual_arm_sim/test/objectives_integration_test.py
@@ -56,12 +56,13 @@ cancel_objectives: set[str] = set()
 skip_objectives: set[str] = {
     "Teleoperate",  # Waits on UI teleoperation input.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     "Writing Demo",  # Long-running drawing objective times out on the CI backend.
     "Find Green Block",  # ML text-prompt segmentation.
     "Find Red Block",  # ML text-prompt segmentation.

--- a/src/factory_sim/test/objectives_integration_test.py
+++ b/src/factory_sim/test/objectives_integration_test.py
@@ -70,12 +70,13 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     # Factory demos are not deterministic as standalone success checks in
     # headless CI: planning-scene setup is not idempotent across the sweep,
     # reachability loops exceed the fixture timeout, and surface-planning demos

--- a/src/grinding_sim/test/objectives_integration_test.py
+++ b/src/grinding_sim/test/objectives_integration_test.py
@@ -57,12 +57,13 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     "Register Machined Part",  # Registration flow exceeds the fixture timeout headless.
 }
 

--- a/src/hangar_sim/test/objectives_integration_test.py
+++ b/src/hangar_sim/test/objectives_integration_test.py
@@ -113,12 +113,13 @@ skip_objectives = {
     # reasons.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     # Intermittent Jazzy CI-runner flakes. Skipped so the suite is deterministic.
     #
     # "Solution - Draw Picknik" is the suite's longest objective and sits on

--- a/src/kitchen_sim/test/objectives_integration_test.py
+++ b/src/kitchen_sim/test/objectives_integration_test.py
@@ -63,12 +63,13 @@ skip_objectives: set[str] = {
     # primary UI and cannot run in headless CI.
     "Teleoperate",  # DoTeleoperateAction rejects the goal with no UI subscribed.
     "Marker Visualization Example",  # GetTextFromUser server unavailable headless.
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     "Writing Demo",  # Long-running drawing objective times out on the CI backend.
 }
 

--- a/src/lab_sim/test/objectives_integration_test.py
+++ b/src/lab_sim/test/objectives_integration_test.py
@@ -275,12 +275,13 @@ cancel_objectives = {
 # Objectives to skip entirely from integration testing
 skip_objectives = {
     "AddBottlesToPlanningScene",
-    # Hand-eye calibration Objectives from moveit_pro_objectives: they move through
-    # taught `calibration_*` waypoints and detect a ChArUco board, which only
+    # Hand-eye calibration Objectives from moveit_pro_objectives: they generate or
+    # move through `calibration_*` waypoints and detect a ChArUco board, which only
     # hand_eye_calibration_sim provides.
     "Calibrate Eye In Hand Camera",
     "Calibrate Eye To Hand Camera",
     "Calibrate Multiple Cameras",
+    "Generate Calibration Waypoints",
     "Collect Training Data with Behaviors",  # Requires setup for data collection (recording infrastructure not available in CI)
     "Grasp Planning",
     "Joint Diagnostic",


### PR DESCRIPTION
[written by AI]

Skips the `Generate Calibration Waypoints` Objective in the config integration tests. Each config's test runs every runnable Objective the system config resolves, and this one moves the arm and saves waypoints into the config's waypoint file. The entry is inert until the Objective ships in the base image.
