### PR TITLE
Fix: Use Move to Named Waypoint (JTC) in hangar_sim Move to Arm Upright

### DIFF
--- a/src/hangar_sim/objectives/move_to_arm_upright.xml
+++ b/src/hangar_sim/objectives/move_to_arm_upright.xml
@@ -8,7 +8,7 @@
   >
     <Control ID="Sequence" name="TopLevelSequence">
       <SubTree
-        ID="Move to Waypoint (JTC)"
+        ID="Move to Named Waypoint (JTC)"
         _collapsed="true"
         acceleration_scale_factor="1.0"
         controller_action_server="/joint_trajectory_controller/follow_joint_trajectory"


### PR DESCRIPTION
[written by AI]

## Motivation

Tutorial 2 (`motion_planning.mdx`, "Joint-space planning to a joint goal") has the reader open `Move to Arm Upright` in `hangar_sim`, click **Expand All**, and look at its three Subtrees. The shipped Objective still wraps the deprecated `Move to Waypoint (JTC)` alias (`moveit_pro` commit 9eadcc8a08 renamed it to `Move to Named Waypoint (JTC)` on 2026-08-25), so the tree the reader sees has an extra alias level and a name the docs no longer use.

## Brief description

One-line change in `src/hangar_sim/objectives/move_to_arm_upright.xml`: the `SubTree` ID becomes `Move to Named Waypoint (JTC)`. The alias forwards every port unchanged (verified by diffing the port lists of `move_to_waypoint_jtc.xml` and `move_to_named_waypoint_jtc.xml` in `moveit_pro/src/core_objectives/objectives/motion/`), so behavior is identical; `hangar_sim/test/objectives_integration_test.py` keeps addressing the Objective by its unchanged name.

Pairs with PickNikRobotics/moveit_pro#22466, whose new Tutorial 2 screenshot shows this tree; that PR should merge after this one. The other deprecated `Move to Waypoint` uses in this repo (`grep -rn 'ID="Move to Waypoint' src/`) are not touched here.

## Release notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
