### PR TITLE
Add MPPI local plan publishing to hangar_sim

### DIFF
--- a/src/hangar_sim/config/frontend_settings.yaml
+++ b/src/hangar_sim/config/frontend_settings.yaml
@@ -1,0 +1,6 @@
+# MPPI publishes its chosen trajectory on /optimal_trajectory, not the
+# /local_plan that DWB uses, so point the Local Plan overlay there. It stays
+# silent unless FollowPath.visualize is true. Note it is stamped in odom while
+# /plan is in map, so an AMCL correction shifts the two overlays against
+# each other.
+nav2LocalPlanTopic: /optimal_trajectory

--- a/src/hangar_sim/params/nav2_params.yaml
+++ b/src/hangar_sim/params/nav2_params.yaml
@@ -134,7 +134,10 @@ controller_server:
       # above are inactive; they are retained for an easy switch to motion_model
       # "Omni" if holonomic strafing is wanted later.
       motion_model: "DiffDrive"
-      visualize: false
+      # The only switch that makes MPPI publish /optimal_trajectory, which the
+      # Desktop App draws as the Local Plan overlay. Its /trajectories markers
+      # are built only while something subscribes; `ros2 param set` toggles it live.
+      visualize: true
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 3


### PR DESCRIPTION
[written by AI]

## Motivation

Pairs with PickNikRobotics/moveit_pro#22492, which adds a Local Plan overlay to the 3D Visualizer (issue PickNikRobotics/moveit_pro#19683). Without this change the feature is dead in the one shipped configuration that runs Nav2: `hangar_sim` uses the MPPI controller, which publishes no local plan unless asked to.

## Brief description

Two settings so the overlay works in `hangar_sim` out of the box:

- `FollowPath.visualize: true` — the only switch that makes MPPI publish `/optimal_trajectory` at all.
- A shipped `config/frontend_settings.yaml` pointing `nav2LocalPlanTopic` at that topic, since MPPI does not use the `/local_plan` name DWB does.

## How it was tested

Ran `hangar_sim` and drove navigation:

- `/optimal_trajectory` publishes at 20 Hz during navigation and is subscribed by `foxglove_bridge`, so the app receives it through the shipped setting; the REST API serves `{"nav2LocalPlanTopic":"/optimal_trajectory"}`.
- The Local Plan overlay draws and updates in the 3D Visualizer while the robot drives.

## Notes for reviewers

- **`visualize` costs almost nothing here.** MPPI gates its visualization on subscriber count — `TrajectoryVisualizer::add` calls `get_subscription_count()` and returns before building a single marker when nobody is listening (verified in the disassembly of the shipped `libmppi_controller.so`, and by measurement: `/trajectories` carries 9.8 MB/s while something subscribes and nothing otherwise). `TrajectoryVisualizer` subsampling is therefore left at the nav2 default. It is also a dynamic parameter — `ros2 param set /controller_server FollowPath.visualize false` turns publishing off on a running system, which I confirmed stops `/optimal_trajectory` immediately.
- **`/optimal_trajectory` is stamped in `odom`**, while the global plan on `/plan` is in `map`. The overlays are re-rooted per header, so a localization correction shifts them against each other; the settings file says so, and the moveit_pro PR documents it.
- **An existing `~/.config/moveit_pro/hangar_sim/frontend_settings.yaml` shadows this file** — the loader picks one file rather than merging. Anyone who saved settings from the app before this ships needs to add the key by hand; documented in the paired PR.

## Release notes

- Enhancement: `hangar_sim` now publishes the MPPI local plan, so the Local Plan overlay works in the 3D Visualizer without extra configuration.

---

## Claude agent checks

- [x] `code-reviewer`
  - reviewed with the paired moveit_pro change; its finding that `visualize` enables more than the comment claimed is addressed
- [x] SKIPPED `documentation-bot`
  - the user-facing documentation for this lives in the paired moveit_pro PR, where it was reviewed
- [x] SKIPPED `licensing-privacy-bot`
  - configuration only; no vendored source, models, or data recipients
- [x] SKIPPED `platform-architect-bot`
  - no C++, ROS interfaces, launch, or build files; the nav2 parameter change was reviewed by `roboticist-bot`
- [x] `roboticist-bot`
  - established that MPPI gates visualization on subscriber count, which reverted the subsampling change and rewrote the rationale in the comment
- [x] SKIPPED `frontend-noah-bot`
  - no frontend code in this repo
- [x] `security-auditor`
  - reviewed with the paired change; the YAML is parsed with `safe_load` and the value is a topic name, never a path
- [x] `compatibility-bot`
  - no compatibility impact; the settings key is additive and the REST loader is a schema-agnostic passthrough
- [x] SKIPPED `sonar-bot`
  - no analyzed languages in this diff, YAML only
- [x] SKIPPED `test-runner`
  - no buildable or testable code; validated by running `hangar_sim` and measuring the topics

