### PR TITLE
Fix: Detect gripper stalls in Kinova simulation configs

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/config/control/picknik_kinova_gen3.ros2_control.yaml
@@ -38,6 +38,8 @@ robotiq_gripper_controller:
     joint: robotiq_85_left_knuckle_joint
     allow_stalling: true
     stall_timeout: 0.05
+    # MuJoCo contact jitter keeps the blocked knuckle's velocity near 0.012 rad/s, so the 0.001 rad/s default never detects a stall and a blocked close runs until MoveGripperAction times out. A free-air close approaches its goal at goal_tolerance * kp / kv of the MuJoCo gripper actuator (0.02 rad/s at kv=100, 0.1 at kv=20), so keep this value at or below that and rely on stall_timeout to keep a normal close from reporting a stall.
+    stall_velocity_threshold: 0.02
     goal_tolerance: 0.02
 
 force_torque_sensor_broadcaster:


### PR DESCRIPTION
[written by AI]

## Motivation

Closes PickNikRobotics/moveit_pro#22392. `Close Gripper` in `space_satellite_sim` fails every run after the full 10 s `MoveGripperAction` timeout. The RAFTI fingers collide with each other at a knuckle angle of 0.7375 rad, so the 0.77 target minus the 0.02 `goal_tolerance` is unreachable, and the stall path that `allow_stalling: true` is meant to provide never fires: `stall_velocity_threshold` is left at the jazzy `GripperActionController` default of 0.001 rad/s while the blocked fingers jitter at about 0.012 rad/s mean in MuJoCo. The longest window below 0.001 is a single 3 ms simulation step, so the stall timer never completes and the action never returns. Closed issue PickNikRobotics/moveit_pro#19850 reached the same diagnosis in June; #717 changed only `kinova_sim`'s target and left this config at 0.77.

## Brief description

Adds `stall_velocity_threshold: 0.02` to `robotiq_gripper_controller` in the `kinova_sim` ros2_control parameters, which `space_satellite_sim` inherits through `based_on_package: kinova_sim` (it has no `ros2_control` override of its own). `lab_sim` already carries this value. The close targets are left alone: with stall detection working, a target past the contact point is the right meaning for "close as far as possible", and it makes #909's target change unnecessary.

The threshold was chosen by replaying the controller's success and stall logic on headless MuJoCo runs of the shipped scene: 0.004 (the troubleshooting guide's example) and 0.01 succeed at the 0.77 target, but only 0.02 also covers the harder 0.7929 press, where the saturated actuator force produces more jitter. `stall_timeout` stays at 0.05 s. `kinova_gen3_base_config` (real hardware) is untouched; the Robotiq driver reports velocity differently from the simulator and this value was not validated against it. Hardware still runs `allow_stalling: true` with the 0.001 default, so a genuinely blocked close there has the same failure mode; measuring the real gripper's reported velocity under block is a follow-up.

## How it was tested

- Headless MuJoCo 3.6.0 (`moveit-pro-dev:10.1.0-jazzy`) with the shipped `space_satellite_sim` and `kinova_sim` scenes, emulating the jazzy `GripperActionController` at 1 kHz: with 0.001 the 0.77 and 0.7929 goals time out; with 0.02 both complete through the stall path in about 3 s.
- Live on a 10.0.0 stack (`moveit_pro run -c space_satellite_sim`), driving `/do_objective` and `/robotiq_gripper_controller/gripper_cmd` from the runtime container. Baseline on the same stack: `Close Gripper` aborts after 10.7 s and a raw 0.77 goal never returns. With this change: `Close Gripper` succeeds in 3.8 s, the raw result is `stalled: true` at 0.730 rad, 3 of 3 runs from the reset pose and 3 of 3 after `Move to Folded`. `Open Gripper` still succeeds.
- `kinova_sim` `Close Gripper` and `Open Gripper` still succeed with the same change.
- All of the above ran on the shipped gripper model (`kv=100`), which is the tightest margin this value sees: the free-air approach speed at the tolerance boundary is `goal_tolerance * kp / kv` = 0.02 rad/s, so the 50 ms `stall_timeout` is what separates a normal close from a false stall there. #923 lowers `kv` to 20 and widens that margin fivefold; with both applied, `Grapple Moving Satellite via Fiducial Tracking` succeeded 3 of 3.
- `stall_timeout` stays at 0.05 rather than `lab_sim`'s 0.2 on purpose: a longer dwell needs a longer jitter-free window and pushes detection toward the 10 s Behavior timeout. The measured 3.8 s is the deterministic first-order approach (`kv/kp` = 1 s time constant) plus dwell, not jitter luck.
- `ros2_control_node` logs show `robotiq_gripper_controller` deactivated and reactivated alongside `velocity_force_controller` at the end of `Compliant Grasp RAFTI VFC`, after its `Close Gripper` has returned, so no gripper goal is in flight across a controller switch.

- On a 10.1 runtime (`moveit_pro` at 10.1.0-rc6 in the dev container, `moveit_pro_example_ws` at the `v10.1` branch head with this change and #923 cherry-picked): `space_satellite_sim` `Close Gripper` at 0.77 succeeds 3 of 3 from the reset pose and after `Move to Folded` in 1.9 s, `Open Gripper` 3 of 3, the raw 0.77 goal returns `stalled: true` at 0.737 rad, and `Grapple Moving Satellite via Fiducial Tracking` succeeds 3 of 3 in 16 s to 17 s (its `BreakpointSubscriber` approved by publishing `std_msgs/Bool` on `/moveit_pro_breakpoint`). `kinova_sim` `Close Gripper` and `Open Gripper` 2 of 2 each, `Compliant Grasp RAFTI VFC` 6 of 6.

Neither config has an `objectives_integration_test.py`, so CI does not cover this; validation is the manual runs above.

One semantic consequence worth stating: with stall detection reachable in simulation, a close on nothing and a close on an object both return `stalled: true` and succeed. `Close Gripper` succeeding was never grasp verification, but it now cannot be mistaken for it; objectives that need to know they hold something must check it another way.

## Release notes

- Bug Fix: Fixed `Close Gripper` timing out in `space_satellite_sim` and other Kinova simulation configurations when the gripper is blocked before reaching its target.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these. See [`.claude/rules/agent-delegation.md`](../.claude/rules/agent-delegation.md) for when each agent is required.*

- [x] `code-reviewer`
  - comment wording findings applied
- [x] `documentation-bot`
  - no documentation impact; the troubleshooting guide's indented `goal_tolerance` is a pre-existing docs defect for its own PR
- [x] SKIPPED `licensing-privacy-bot`
  - no vendored code, models, or data flows touched
- [x] `platform-architect-bot`
  - free-air margin analysis and controller-switching check recorded above; hardware config left untouched by design
- [x] `roboticist-bot`
  - comment invariant reworded to match the value; grasp-detection semantics note added above
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] SKIPPED `compatibility-bot`
  - example workspace configuration only; no public API boundary or frontend-backend contract surface
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, JavaScript, or TypeScript changed
- [x] SKIPPED `test-runner`
  - no buildable or testable code; validated by the manual runs above


