### PR TITLE
Fix: Stop the Kinova simulation gripper chattering on grasped objects

### DIFF
--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof.xml
@@ -711,6 +711,7 @@
   </equality>
 
   <actuator>
+    <!-- kv=20 matches the vla_sim copy of this actuator (the shared picknik_accessories model uses 25). It was chosen empirically: at the 3 ms timestep the including scenes set, kv=100 puts the finger linkage in a timestep-rate limit cycle against a held object, which keeps the knuckle velocity above the GripperActionController stall_velocity_threshold (config/control/picknik_kinova_gen3.ros2_control.yaml) so MoveGripperAction never completes. The response is not monotone in kv, so re-validate rather than interpolate. -->
     <position
       class="2f85"
       name="robotiq_85_left_knuckle_joint"
@@ -718,7 +719,7 @@
       forcerange="-5 5"
       ctrlrange="0 .8"
       kp="100"
-      kv="100"
+      kv="20"
     />
   </actuator>
 

--- a/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof_rafti_fingers.xml
+++ b/src/moveit_pro_kinova_configs/kinova_sim/description/mujoco/gen3_7dof_rafti_fingers.xml
@@ -806,6 +806,7 @@
   </equality>
 
   <actuator>
+    <!-- kv=20 matches the vla_sim copy of this actuator (the shared picknik_accessories model uses 25). It was chosen empirically: at the 3 ms timestep the including scenes set, kv=100 puts the finger linkage in a timestep-rate limit cycle against a held object, which keeps the knuckle velocity above the GripperActionController stall_velocity_threshold (config/control/picknik_kinova_gen3.ros2_control.yaml) so MoveGripperAction never completes. The response is not monotone in kv, so re-validate rather than interpolate. -->
     <position
       class="2f85"
       name="robotiq_85_left_knuckle_joint"
@@ -813,7 +814,7 @@
       forcerange="-5 5"
       ctrlrange="0 .8"
       kp="100"
-      kv="100"
+      kv="20"
     />
   </actuator>
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/gen3_7dof_assets.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim/description/mujoco/gen3_7dof_assets.xml
@@ -290,6 +290,7 @@
   </equality>
 
   <actuator>
+    <!-- kv=20 matches the vla_sim copy of this actuator (the shared picknik_accessories model uses 25). It was chosen empirically: at the 3 ms timestep the including scenes set, kv=100 puts the finger linkage in a timestep-rate limit cycle against a held object, which keeps the knuckle velocity above the GripperActionController stall_velocity_threshold (config/control/picknik_kinova_gen3.ros2_control.yaml) so MoveGripperAction never completes. The response is not monotone in kv, so re-validate rather than interpolate. -->
     <position
       class="2f85"
       name="robotiq_85_left_knuckle_joint"
@@ -297,7 +298,7 @@
       forcerange="-5 5"
       ctrlrange="0 .8"
       kp="100"
-      kv="100"
+      kv="20"
     />
   </actuator>
 

--- a/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/gen3_7dof_assets.xml
+++ b/src/moveit_pro_kinova_configs/space_satellite_sim_camera_cal/description/mujoco/gen3_7dof_assets.xml
@@ -315,6 +315,7 @@
   </equality>
 
   <actuator>
+    <!-- kv=20 matches the vla_sim copy of this actuator (the shared picknik_accessories model uses 25). It was chosen empirically: at the 3 ms timestep the including scenes set, kv=100 puts the finger linkage in a timestep-rate limit cycle against a held object, which keeps the knuckle velocity above the GripperActionController stall_velocity_threshold (config/control/picknik_kinova_gen3.ros2_control.yaml) so MoveGripperAction never completes. The response is not monotone in kv, so re-validate rather than interpolate. -->
     <position
       class="2f85"
       name="robotiq_85_left_knuckle_joint"
@@ -322,7 +323,7 @@
       forcerange="-5 5"
       ctrlrange="0 .8"
       kp="100"
-      kv="100"
+      kv="20"
     />
   </actuator>
 


### PR DESCRIPTION
[written by AI]

## Motivation

Closes PickNikRobotics/moveit_pro#22499. `Compliant Grasp RAFTI VFC` in `kinova_sim` aborts in most runs with a `MoveGripperAction` timeout at its final `Close Gripper`. Recording `/joint_states` through failing runs shows the knuckle velocity flipping sign every simulation step at about ±0.6 rad/s while the fingers creep on the grasped body: a timestep-rate limit cycle of the tendon-driven finger mechanism whenever it squeezes an object the floor pins in place. No stall threshold can classify that, and the grasp sits on a stability edge, so controller timing decides each run.

## Brief description

Sets the `robotiq_85_left_knuckle_joint` position actuator's `kv` from 100 to 20 in the four Kinova MJCF files that define it (`kinova_sim` `gen3_7dof.xml` and `gen3_7dof_rafti_fingers.xml`, `space_satellite_sim` and `space_satellite_sim_camera_cal` `gen3_7dof_assets.xml`), with `kp` unchanged at 100.

20 is the value `vla_sim`'s copy of this actuator already uses; the shared `picknik_accessories` Robotiq model uses 25. Both remove the grasp chatter with 0 failures in the replay harness, and both close the gripper in under a second instead of 3.4 s. 20 was preferred because it is the only one that also settles cleanly at the full-close command (0.8 rad, hard finger self-contact): at 25 a residual limit cycle survives there, so a future objective closing to the limit would hit the same timeout. The response is not monotone in `kv` (100 chatters, 200 does not), so the value is a found working point and the comment says so. `vla_sim` keeps its own copy (`forcerange -40 40`, linkage damping 1.0) untouched. Raising the finger linkage joint damping to 1.0 as `vla_sim` does also removes the chatter without changing closing speed, but it makes free-air closes report `stalled: true` before reaching the goal, so it was not taken. That these four files each hand-roll the actuator instead of including the shared `robotiq2f85_globals.xml` definition is why the values drifted; consolidating them is a follow-up, not part of this fix. A 2 ms `timestep` removes the chatter equally well and is the alternative if the damping change is unwanted; scaling the grasped body's inertia by up to 250x, changing its `condim`, or softening its `solref` changes nothing, so the description's inertia hint on the issue was wrong.

## How it was tested

- Offline: replayed three recorded arm trajectories (one aborted live, two succeeded) in headless MuJoCo 3.6.0 with the shipped `rafti_fingers_scene.xml`, driving the arm actuators with the recorded positions and the gripper with 0.05 then 0.7 at the recorded close time, with 0, 2, and 5 mrad Gaussian offsets on the arm trajectory over 8 seeds. Over 34 perturbed replays per variant on the two recordings that showed failures: shipped scene 12 failures, `kv="20"` 0, `kv="25"` 0, `timestep="0.002"` 0, linkage damping 1.0 0. Free-air closes to 0.7, 0.77, 0.7929, and 0.8 with the #22392 threshold: `kv=20` completes all four in both scenes; `kv=25` times out at 0.7929 and 0.8. All three scenes compile.
- Live on a 10.0.0 stack together with #922: `Compliant Grasp RAFTI VFC` succeeded 8 of 8 consecutive cycles (each after `Reset MuJoCo Sim`, `Reset Planning Scene`, `Clear Snapshot`), 19.3 s each, against 5 of 15 on the shipped scene. `kinova_sim` `Close Gripper` and `Open Gripper` complete in 1.7 s. `space_satellite_sim` `Close Gripper` at its 0.77 target completes in 1.9 s with `stalled: true` at 0.737 rad, 6 of 6 from the reset pose and after `Move to Folded`. `Grapple Moving Satellite via Fiducial Tracking`, the one objective that pinches a free-floating body at zero gravity (the contact case the offline replays do not cover), succeeded 3 of 3 with resets in between.

- On a 10.1 runtime (`moveit_pro` at 10.1.0-rc6 in the dev container, `moveit_pro_example_ws` at the `v10.1` branch head with this change and #922 cherry-picked): `kinova_sim` `Compliant Grasp RAFTI VFC` 6 of 6 at 18.6 s each, `Close Gripper` and `Open Gripper` 2 of 2 each in 1.7 s; `space_satellite_sim` `Close Gripper` at 0.77 3 of 3 with `stalled: true` at 0.737 rad, `Open Gripper` 3 of 3, and the zero-gravity `Grapple Moving Satellite via Fiducial Tracking` 3 of 3 in 16 s to 17 s with the fingers holding the fixture at 0.65 rad (its `BreakpointSubscriber` approved by publishing `std_msgs/Bool` on `/moveit_pro_breakpoint`).

Neither config has an `objectives_integration_test.py`, so CI does not cover this; validation is the runs above. Which file each run exercised: `kinova_sim` ships `rafti_fingers_scene.xml` (`gen3_7dof_rafti_fingers.xml`); `space_satellite_sim` ships `scene.xml` (`gen3_7dof_assets.xml`). `gen3_7dof.xml` and the camera-calibration copy are edited to keep the four copies identical.

Follow-ups, not in this PR: consolidate the four inline Kinova copies onto the shared `robotiq2f85_globals.xml` definition so gains cannot drift again; `vla_sim` runs the same gripper with the default `stall_velocity_threshold` and its own actuator tuning.

## Release notes

- Bug Fix: Fixed `Compliant Grasp RAFTI VFC` in `kinova_sim` failing intermittently because the simulated gripper fingers chattered on the grasped object. The Kinova simulation gripper now closes in under a second.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these. See [`.claude/rules/agent-delegation.md`](../.claude/rules/agent-delegation.md) for when each agent is required.*

- [x] `code-reviewer`
  - comment wording findings applied
- [x] `documentation-bot`
  - no documentation impact; the troubleshooting guide's indented `goal_tolerance` is a pre-existing docs defect for its own PR
- [x] SKIPPED `licensing-privacy-bot`
  - no vendored code, models, or data flows touched
- [x] `platform-architect-bot`
  - zero-gravity grapple evidence added (3 of 3); files on shipped paths named above
- [x] `roboticist-bot`
  - full-close residual at kv=25 measured, value changed to 20; linkage-damping alternative evaluated and rejected
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] SKIPPED `compatibility-bot`
  - example workspace configuration only; no public API boundary or frontend-backend contract surface
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, JavaScript, or TypeScript changed
- [x] SKIPPED `test-runner`
  - no buildable or testable code; validated by the manual runs above


