### PR TITLE
chore(9.4): drop the moveit_pro_clipseg submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,9 +17,6 @@
 	path = src/external_dependencies/franka_config/franka_description
 	url = https://github.com/frankarobotics/franka_description.git
 	branch = main
-[submodule "src/moveit_pro_clipseg"]
-	path = src/moveit_pro_clipseg
-	url = https://github.com/PickNikRobotics/moveit_pro_clipseg.git
 [submodule "src/external_dependencies/phoebe_ws"]
 	path = src/external_dependencies/phoebe_ws
 	url = https://github.com/PickNikRobotics/phoebe_ws.git

--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ Several submodules (notably `picknik_accessories`) use git LFS. Install [git-lfs
 git submodule foreach --recursive git lfs pull
 ```
 
+## CLIPSeg models are no longer bundled
+
+Starting with the 9.4 patch release that includes this change, this workspace
+no longer vendors the `moveit_pro_clipseg` submodule.
+The `GetMasks2DFromTextQuery` Behavior still exists in MoveIt Pro 9.4, but the
+example configs no longer ship weights for it, so the following Objectives fail
+at run time with
+
+    The ONNX model path could not be resolved: Package 'moveit_pro_clipseg' was not found
+
+- kitchen_sim: Segment Image from Prompt
+- lab_sim: ML Segment Image, ML Segment Image Loop, ML Segment Point Cloud,
+  AddBottlesToPlanningScene
+- hangar_sim: Segment Image from Text Prompt, ML Move Boxes to Loading Zone,
+  Move Boxes Looping
+- dual_arm_sim: Sort Blocks, Find Red Block, Find Green Block
+
+To restore them, build a ROS package that installs CLIP and CLIPSeg ONNX models
+to `share/<your_package>/models/` and set `model_package` (and the
+`clip_model_path` / `clipseg_model_path` ports) on those Objectives to point at
+it. To move off CLIPSeg entirely, see the SAM3 equivalents in `lab_sim`
+(`ML Find Objects on Table`, `ML Segment Bottles from File`) and MoveIt Pro
+10.0, where these Objectives were migrated to `GetMasks2DFromExemplar`.
+
 ## Robot Configs
 
 - `april_tag_sim`

--- a/src/kitchen_sim/package.xml
+++ b/src/kitchen_sim/package.xml
@@ -15,7 +15,6 @@
   <exec_depend>franka_description</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
-  <exec_depend>moveit_pro_clipseg</exec_depend>
   <exec_depend>moveit_pro_sam2</exec_depend>
 
   <test_depend>ament_clang_format</test_depend>

--- a/src/lab_sim/package.xml
+++ b/src/lab_sim/package.xml
@@ -29,7 +29,6 @@
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_force_controller</exec_depend>
   <exec_depend>lab_sim_behaviors</exec_depend>
-  <exec_depend>moveit_pro_clipseg</exec_depend>
   <exec_depend>moveit_pro_sam2</exec_depend>
   <exec_depend>moveit_pro_sam3</exec_depend>
 


### PR DESCRIPTION
## Summary

Stop bundling the `moveit_pro_clipseg` submodule and its CLIPSeg/CLIP ONNX weights on 9.4. Eleven example Objectives that used `GetMasks2DFromTextQuery` are migrated to SAM3 separately; this PR only removes the submodule.

## What changed

- `.gitmodules`: removed the `moveit_pro_clipseg` entry.
- Removed the `src/moveit_pro_clipseg` gitlink.
- `src/kitchen_sim/package.xml`, `src/lab_sim/package.xml`: removed `<exec_depend>moveit_pro_clipseg</exec_depend>`.
- `README.md`: added a notice after the Cloning section listing the eleven affected Objectives, the run-time error they now hit, and pointers to the SAM3 equivalents.

No Objective XML or integration-test skip lists were touched — that's a separate migration.

## Why all five removals land together

`rosdep install --from-paths src --ignore-src` (used in the docker build) resolves `exec_depend` against packages present under `src/`. Dropping the gitlink while leaving either `exec_depend` in place leaves an unresolvable rosdep key and breaks the docker build. Keeping the gitlink while dropping the `.gitmodules` entry leaves a submodule commit reference nothing can populate. All five have to move in one commit.

## What breaks until the SAM3 migration lands

`GetMasks2DFromTextQuery` stays registered in MoveIt Pro 9.4, so these Objectives still list, open, and start — they fail at tick time with:

```
The ONNX model path could not be resolved: Package 'moveit_pro_clipseg' was not found
```

Affected: `kitchen_sim` (Segment Image from Prompt), `lab_sim` (ML Segment Image, ML Segment Image Loop, ML Segment Point Cloud, AddBottlesToPlanningScene), `hangar_sim` (Segment Image from Text Prompt, ML Move Boxes to Loading Zone, Move Boxes Looping), `dual_arm_sim` (Sort Blocks, Find Red Block, Find Green Block). This is a maintainer decision: bundle removal now, Objective migration to SAM3 as a separate follow-up.

## Test coverage

- `git ls-tree HEAD src/ | grep clipseg` and `grep -rn clipseg .gitmodules src/*/package.xml` are both empty.
- `colcon build` not required/run — `exec_depend` only, no `CMakeLists.txt` in this workspace `find_package`s `moveit_pro_clipseg`.
- `rosdep` was not available in the dev environment used for this change, so the docker-build claim above is reasoned from the Dockerfile's `rosdep install` step, not executed.
- CI (validate_objectives, integration tests, build) passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
