### PR TITLE
feat(so101_sim): swap the stock SO-101 jaws for the XLeRobot fin-ray gripper

### DIFF
--- a/src/so101_sim/NOTICE.md
+++ b/src/so101_sim/NOTICE.md
@@ -2,11 +2,14 @@
 
 ## Robot description meshes
 
-The SO-101 arm and camera-mount STL files under `description/assets/` are
-vendored from a third party under the Apache License 2.0. Their provenance,
-upstream commit and the list of files are recorded in
-[`description/assets/NOTICE.md`](description/assets/NOTICE.md), and the license
-text is `description/assets/LICENSE`.
+The STL files under `description/assets/` are vendored from two unrelated third
+parties, both under the Apache License 2.0: the SO-101 arm and camera-mount
+meshes from [`danwahl/vla-test`](https://github.com/danwahl/vla-test), and the
+soft fin-ray gripper meshes from
+[`Vector-Wangel/XLeRobot`](https://github.com/Vector-Wangel/XLeRobot). Their
+provenance, upstream commits and the list of files are recorded in
+[`description/assets/NOTICE.md`](description/assets/NOTICE.md);
+`description/assets/LICENSE` is the license text as carried by `vla-test`.
 
 ## MoveIt-layer configuration
 

--- a/src/so101_sim/README.md
+++ b/src/so101_sim/README.md
@@ -1,7 +1,7 @@
 # so101_sim
 
-A MoveIt Pro configuration for a stock LeRobot SO-101 follower arm on **mock
-hardware**. It brings up a digital twin of the arm in the MoveIt Pro UI, driven
+A MoveIt Pro configuration for a LeRobot SO-101 follower arm, fitted with the
+XLeRobot soft fin-ray gripper, on **mock hardware**. It brings up a digital twin of the arm in the MoveIt Pro UI, driven
 by a joint source outside the Runtime. There is no MuJoCo model and no physics.
 
 Run it:
@@ -45,7 +45,7 @@ When a live joint source is added (phase two), it publishes into the same
 
 | Path | What it is |
 |---|---|
-| `description/so101.urdf.xacro` | The arm, with a `hardware_interface: mock \| real` switch. Meshes are the upstream LeRobot description; see `description/assets/NOTICE.md`. |
+| `description/so101.urdf.xacro` | The arm, with a `hardware_interface: mock \| real` switch. The arm meshes are the upstream LeRobot description and the gripper meshes are XLeRobot's soft fin-ray parts; both are recorded in `description/assets/NOTICE.md`. |
 | `config/control/so101.ros2_control.yaml` | `joint_state_broadcaster`, a `joint_trajectory_controller` over all six joints (gripper included), and the two teleop jog controllers — `joint_velocity_controller` and `velocity_force_controller` — over the five arm joints. |
 | `config/moveit/` | SRDF, joint limits, IK (`PoseIKPlugin`, `optimize_distance` — the SO-101 is 5-DOF and cannot hit arbitrary 6-DOF poses), and the jog configs. |
 | `script/so101_arm_bridge.py` | The joint source. `--fake` publishes a sine; `--real` is a phase-two stub. |

--- a/src/so101_sim/description/assets/NOTICE.md
+++ b/src/so101_sim/description/assets/NOTICE.md
@@ -11,8 +11,9 @@ repository-level license of the source repository.
 description, which the mesh filenames preserve (`base_so101_v2.stl`,
 `sts3215_03a_v1.stl`, and so on).
 
-All 18 STL files in this directory are byte-for-byte unmodified upstream
-exports, verified by SHA-256 against the source tree at the commit above:
+The following 18 STL files are byte-for-byte unmodified upstream exports,
+verified by SHA-256 against the source tree at the commit above (the remaining
+STLs in this directory come from XLeRobot, see below):
 
 - `arm_base.stl`
 - `base_motor_holder_so101_v1.stl`
@@ -39,5 +40,55 @@ Upstream also ships an `assets/coacd/` directory: 72 convex parts produced by a
 CoACD decomposition of `wrist_roll_follower_so101_v1.stl` and
 `moving_jaw_so101_v1.stl`, for MuJoCo's contact solver. This config has no
 MuJoCo model, and MoveIt's collision checker takes the visual STLs directly, so
-those parts are omitted and `description/so101.urdf.xacro` uses the visual mesh
-for collision on both links.
+those parts are omitted. Both links now carry the XLeRobot fin jaws below, each
+with its own decimated `*_collision.stl`; only the fin finger reuses its visual
+mesh for collision.
+
+# XLeRobot soft fin-ray gripper meshes
+
+Source: [`Vector-Wangel/XLeRobot`](https://github.com/Vector-Wangel/XLeRobot)
+
+Upstream commit: `51ca0ec31bdb48713b94bacdba828bf8d889296b`
+
+License: Apache License 2.0, declared by `LICENSE` at the root of the upstream
+repository. That file is the stock Apache-2.0 text with the copyright appendix
+left as unfilled boilerplate (`Copyright [yyyy] [name of copyright owner]`), and
+the upstream repository ships no `NOTICE` file, so there is nothing further to
+reproduce here. The `LICENSE` in this directory is a separate copy carrying the
+`vla-test` copyright line and covers only the SO-101 meshes above.
+
+Upstream file: `hardware/SO101_soft_fin.stl`. That single binary STL holds three
+disconnected bodies laid out on a print plate, which split into the parts below.
+The fin-ray finger also ships as `hardware/step/soft_gripper_finger.step` and as
+four copies on plate 3 of `hardware/XLeRobot_0_3_0.3mf`; the copy here comes from
+the STL.
+
+| File | Upstream body | Replaces |
+|---|---|---|
+| `soft_fin_fixed_jaw.stl` | 52 x 48.6 x 65.2 mm body | `wrist_roll_follower_so101_v1.stl` |
+| `soft_fin_moving_jaw.stl` | 36.7 x 20.3 x 48 mm body | `moving_jaw_so101_v1.stl` |
+| `soft_fin_finger.stl` | 67.2 x 24.2 x 24.1 mm body | the moulded fingers on both stock parts |
+
+`soft_fin_finger.stl` is used twice, once per jaw. The two `*_collision.stl`
+files are decimated copies of the corresponding visual mesh.
+
+## These are not byte-identical exports
+
+Unlike the SO-101 meshes above, these were transformed on the way in:
+
+- scaled from millimetres to metres;
+- the two jaw bodies were rigidly registered onto the stock parts they replace,
+  so each is stored in that stock part's mesh frame and `so101.urdf.xacro`
+  reuses the visual origin the stock mesh already used. The registration is the
+  rigid transform aligning the servo bracket and the pivot yoke, which the fin
+  parts carry unchanged: 83% of the fin fixed-jaw surface and 64% of the fin
+  moving-jaw surface land within 0.1 mm of the stock part, the remainder being
+  the finger fork that replaces the moulded finger;
+- `soft_fin_finger.stl` is stored in a frame built from its own two screw bores:
+  origin at the bore midpoint, x along the bore pair, y along the bore axes;
+- decimated by vertex clustering to keep each file under 1 MB. Peak surface
+  deviation from the upstream geometry is 0.08 mm for the visual meshes and
+  0.6 mm for the collision meshes.
+
+The upstream STL is unmodified in every other respect; no geometry was added,
+removed or re-cut.

--- a/src/so101_sim/description/assets/soft_fin_finger.stl
+++ b/src/so101_sim/description/assets/soft_fin_finger.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34a16c891aa38b5e7a7b1a94b2fb27028619e2e2776b135546785a0c7c766d81
+size 91784

--- a/src/so101_sim/description/assets/soft_fin_fixed_jaw.stl
+++ b/src/so101_sim/description/assets/soft_fin_fixed_jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2044ef8bf208419fc5cb2668568806ddf59c1a24a6ca0bb4098879372a53ff4c
+size 956384

--- a/src/so101_sim/description/assets/soft_fin_fixed_jaw_collision.stl
+++ b/src/so101_sim/description/assets/soft_fin_fixed_jaw_collision.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88dc798627f01bd5f61283915eb95b43735f7478354c1e54be7aa29e6c9a178a
+size 207284

--- a/src/so101_sim/description/assets/soft_fin_moving_jaw.stl
+++ b/src/so101_sim/description/assets/soft_fin_moving_jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670ec0848316f40074534ebbeec961aeec4d3d4af66c9431d3f90d1f96c03e77
+size 778934

--- a/src/so101_sim/description/assets/soft_fin_moving_jaw_collision.stl
+++ b/src/so101_sim/description/assets/soft_fin_moving_jaw_collision.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:485e0ad22db81d40e288fb2c6ed3639af74fe04dc82b912980d20f49af3e3b41
+size 208284

--- a/src/so101_sim/description/so101.urdf.xacro
+++ b/src/so101_sim/description/so101.urdf.xacro
@@ -36,6 +36,9 @@
   <material name="sts3215">
     <color rgba="0.1 0.1 0.1 1.0"/>
   </material>
+  <material name="tpu_fin">
+    <color rgba="0.12 0.12 0.13 1.0"/>
+  </material>
   
   <!-- Link overhead camera mount --> 
   <link name="overhead_camera_mount_link">
@@ -389,18 +392,37 @@
         <mesh filename="package://so101_sim/description/assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
-    <!-- Part wrist_roll_follower_so101_v1 -->
+    <!-- Part soft_fin_fixed_jaw: the XLeRobot fin-gripper replacement for
+         wrist_roll_follower_so101_v1. Same servo bracket and the same mesh
+         frame as the stock part, so this keeps the stock part's origin; the
+         moulded fixed finger is gone, replaced by the fork below. -->
     <visual>
       <origin xyz="8.32667e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
       <geometry>
-        <mesh filename="package://so101_sim/description/assets/wrist_roll_follower_so101_v1.stl"/>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_fixed_jaw.stl"/>
       </geometry>
       <material name="3d_printed"><color rgba="0.05 0.05 0.05 1.0"/></material>
     </visual>
     <collision>
       <origin xyz="8.32667e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
       <geometry>
-        <mesh filename="package://so101_sim/description/assets/wrist_roll_follower_so101_v1.stl"/>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_fixed_jaw_collision.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part soft_fin_finger, fixed side. The finger mesh is stored in a frame
+         built from its own screw pair, so this origin is just the fixed jaw's
+         two-bore frame. -->
+    <visual>
+      <origin xyz="-0.02275 0.000781901 -0.0425503" rpy="2.66224e-06 -0.0806329 -2.14431e-07"/>
+      <geometry>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_finger.stl"/>
+      </geometry>
+      <material name="tpu_fin"><color rgba="0.12 0.12 0.13 1.0"/></material>
+    </visual>
+    <collision>
+      <origin xyz="-0.02275 0.000781901 -0.0425503" rpy="2.66224e-06 -0.0806329 -2.14431e-07"/>
+      <geometry>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_finger.stl"/>
       </geometry>
     </collision>
 </link>
@@ -477,18 +499,35 @@
       <mass value="0.012"/>
       <inertia ixx="6.61427e-06" ixy="-3.19807e-07" ixz="-5.90717e-09" iyy="1.89032e-06" iyz="-1.09945e-07" izz="5.28738e-06"/>
     </inertial>
-    <!-- Part moving_jaw_so101_v1 -->
+    <!-- Part soft_fin_moving_jaw: the XLeRobot fin-gripper replacement for
+         moving_jaw_so101_v1. Same pivot yoke and mesh frame as the stock part,
+         so this keeps the stock part's origin; the moulded blade is gone,
+         replaced by the fork below. -->
     <visual>
       <origin xyz="-5.55112e-17 -5.55112e-17 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
       <geometry>
-        <mesh filename="package://so101_sim/description/assets/moving_jaw_so101_v1.stl"/>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_moving_jaw.stl"/>
       </geometry>
       <material name="3d_printed"><color rgba="0.05 0.05 0.05 1.0"/></material>
     </visual>
     <collision>
       <origin xyz="-5.55112e-17 -5.55112e-17 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
       <geometry>
-        <mesh filename="package://so101_sim/description/assets/moving_jaw_so101_v1.stl"/>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_moving_jaw_collision.stl"/>
+      </geometry>
+    </collision>
+    <!-- Part soft_fin_finger, moving side: the moving jaw's two-bore frame. -->
+    <visual>
+      <origin xyz="-0.00115 -0.0222 0.0181" rpy="1.5708 -1.07812e-17 3.10121"/>
+      <geometry>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_finger.stl"/>
+      </geometry>
+      <material name="tpu_fin"><color rgba="0.12 0.12 0.13 1.0"/></material>
+    </visual>
+    <collision>
+      <origin xyz="-0.00115 -0.0222 0.0181" rpy="1.5708 -1.07812e-17 3.10121"/>
+      <geometry>
+        <mesh filename="package://so101_sim/description/assets/soft_fin_finger.stl"/>
       </geometry>
     </collision>
 </link>

--- a/src/so101_sim/package.xml
+++ b/src/so101_sim/package.xml
@@ -4,8 +4,8 @@
   <version>9.5.0</version>
 
   <description>
-    A MoveIt Pro configuration for a stock LeRobot SO-101 follower arm, running
-    on mock hardware.
+    A MoveIt Pro configuration for a LeRobot SO-101 follower arm, fitted with
+    the XLeRobot soft fin-ray gripper, running on mock hardware.
   </description>
 
   <maintainer email="support@picknik.ai">MoveIt Pro Maintainer</maintainer>


### PR DESCRIPTION
## Intent

The maintainer's bench SO-101 runs XLeRobot's soft fin-ray gripper, so the mock digital twin should show the same hand. Follow-up to #924. Mock-only: no MuJoCo, no compliance modelling — the fins are rigid meshes.

## What changed

- Vendored the XLeRobot gripper geometry into `description/assets/`. Upstream `hardware/SO101_soft_fin.stl` (Vector-Wangel/XLeRobot, Apache-2.0) is one binary STL holding three disconnected bodies: a fixed-jaw body, a moving-jaw body, and one fin-ray finger used twice. Each was scaled to metres, registered onto the stock part it replaces, stored in that part's mesh frame, and decimated, with a coarser `*_collision.stl` per jaw.
- `description/so101.urdf.xacro` renders and collides `gripper_link` and `moving_jaw_so101_v1_link` with the fin bodies instead of `wrist_roll_follower_so101_v1.stl` / `moving_jaw_so101_v1.stl`, and adds the shared finger mesh once per jaw under a new `tpu_fin` material.
- Provenance: `description/assets/NOTICE.md` gains an XLeRobot section (source repo, upstream commit, body-to-file mapping, transforms applied, and the note that upstream is Apache-2.0 with an unfilled copyright appendix and ships no `NOTICE`); the package `NOTICE.md` now names both upstreams; `README.md` and `package.xml` no longer describe the arm as stock with upstream-only meshes.

## Contract choices

- The single revolute `gripper` joint, its axis and limits, and the `gripper_frame_link` TCP are unchanged. On the stock geometry the TCP sat on the fixed jaw's inner face; with the fins it is 0.16 mm off that face, so the convention holds and moving it was not warranted.
- Both jaw bodies are the stock parts with the moulded finger cut off and a two-screw fork added; the servo bracket and pivot yoke are untouched, so the URDF reuses each stock mesh's visual origin.
- The finger is stored once in a frame built from its own screw bores. Those bores fix the pose up to a 180° spin about the finger's long axis; the two fins are mirrored, ribs facing inward across the grasp. Maintainer decision, confirmed against XLeRobot's assembled-gripper geometry.
- Waypoints were left alone: the fins do not interpenetrate anywhere in the joint range, so `Gripper Open` / `Gripper Closed` stay valid. Maintainer decision.
- Out of scope and untouched: the ros2_control block, controllers, `config.yaml`, the SRDF, and phase two (Feetech bus, udev, Dockerfile).
- `wrist_roll_follower_so101_v1.stl` and `moving_jaw_so101_v1.stl` are now unreferenced but stay vendored and counted in the NOTICE, which records what is vendored rather than what is used. Dropping them is a separate change. Maintainer decision.

## Testing

Offline proof only — per maintainer decision no live MoveIt Pro instance was started, so the visual evidence is URDF renders rather than UI screenshots.

- Expanded the base and target URDFs with `xacro` inside the workspace's ROS image and parsed both with `check_urdf`.
- Compared them as kinematic models: all 12 joints identical, gripper axis and limits untouched, `gripper_frame_link` TCP unchanged at every waypoint.
- Swept the gripper joint across its full range: the fins never interpenetrate — 55.3 mm open, 15.2 mm at the `Gripper Closed` waypoint, 1.7 mm at the lower joint limit.
- Validated every checkable claim in the provenance NOTICE against the real meshes: file list, SHA-256 identity of the 18 unmodified arm exports, table dimensions, metre scaling, size budget, collision decimation, and the registration fit.
- Re-ran the package's existing pytest as a collateral check.

Renders are attached to the pipeline evidence directory rather than embedded here — GitHub image upload needs an interactive session, which this run did not have:

- `gripper_compare_sheet.png` — stock jaws vs fin gripper, side by side, at both gripper waypoints
- `xlerobot_side_by_side.png` — XLeRobot's TPU fin-ray finger (3MF plate 3) next to the same finger in this URDF
- `arm_open_target.png` / `arm_closed_target.png` — full arm with the fin gripper fitted
- `gripper_grasp_open_target.png` — down-the-grasp-axis view showing ribs facing inward

All under `~/.no-mistakes/evidence/01M26G77F3SW0PVRG5PGMAB4QZ/`.

<details>
<summary>Evidence: Full offline check transcript (xacro/check_urdf, kinematics, TCP, fins, provenance)</summary>

```text
--- check_urdf (base) ---
robot name is: so101
---------- Successfully Parsed XML ---------------
root Link: world has 1 child(ren)
    child(1):  overhead_camera_mount_link
        child(1):  base_link
            child(1):  shoulder_link
                child(1):  upper_arm_link
                    child(1):  lower_arm_link
                        child(1):  wrist_link
                            child(1):  gripper_link

   exit=0
--- check_urdf (target) ---
robot name is: so101
---------- Successfully Parsed XML ---------------
root Link: world has 1 child(ren)
    child(1):  overhead_camera_mount_link
        child(1):  base_link
            child(1):  shoulder_link
                child(1):  upper_arm_link
                    child(1):  lower_arm_link
                        child(1):  wrist_link
                            child(1):  gripper_link

   exit=0

=== 1. kinematic tree identical (joints, origins, axes, limits) ===
   12 joints identical, including:
     gripper: axis=[0.0, 0.0, 1.0] limits=(-0.174533, 1.74533) type=revolute
     wrist_roll: axis=[0.0, 0.0, 1.0] limits=(-2.74385, 2.84121) type=revolute

=== 2. geometry changes are confined to the two gripper links ===
   links with changed geometry: ['gripper_link', 'moving_jaw_so101_v1_link']
     gripper_link                 visual    sts3215_03a_v1.stl                 (was sts3215_03a_v1.stl)
     gripper_link                 visual    soft_fin_fixed_jaw.stl             (was sts3215_03a_v1.stl)
     gripper_link                 visual    soft_fin_finger.stl                (was sts3215_03a_v1.stl)
     gripper_link                 collision sts3215_03a_v1.stl                 (was sts3215_03a_v1.stl)
     gripper_link                 collision soft_fin_fixed_jaw_collision.stl   (was sts3215_03a_v1.stl)
     gripper_link                 collision soft_fin_finger.stl                (was sts3215_03a_v1.stl)
     gripper_link                 jaw-body visual origin unchanged vs stock: OK
     moving_jaw_so101_v1_link     visual    soft_fin_moving_jaw.stl            (was moving_jaw_so101_v1.stl)
     moving_jaw_so101_v1_link     visual    soft_fin_finger.stl                (was moving_jaw_so101_v1.stl)
     moving_jaw_so101_v1_link     collision soft_fin_moving_jaw_collision.stl  (was moving_jaw_so101_v1.stl)
     moving_jaw_so101_v1_link     collision soft_fin_finger.stl                (was moving_jaw_so101_v1.stl)
     moving_jaw_so101_v1_link     jaw-body visual origin unchanged vs stock: OK

=== 3. TCP (gripper_frame_link) unchanged at every waypoint ===
   Home             gripper=+0.490  TCP xyz=[0.421428, 0.007441, 0.042835]  |delta|=0.00e+00
   Ready            gripper=+1.200  TCP xyz=[0.421933, -0.108351, 0.062625]  |delta|=0.00e+00
   Reach Forward    gripper=+1.200  TCP xyz=[0.458794, 0.007825, 0.087717]  |delta|=0.00e+00
   Gripper Open     gripper=+1.500  TCP xyz=[0.456397, 0.007825, 0.206266]  |delta|=0.00e+00
   Gripper Closed   gripper=+0.000  TCP xyz=[0.456397, 0.007825, 0.206266]  |delta|=0.00e+00

=== 4. fin meshes: metres, decimated collision, finger reused twice ===
   sts3215_03a_v1.stl                 visual    faces= 19080 extent_mm=[45.4, 24.8, 39.6]
   soft_fin_fixed_jaw.stl             visual    faces= 19126 extent_mm=[65.2, 52.0, 48.6]
   soft_fin_finger.stl                visual    faces=  1834 extent_mm=[24.2, 24.1, 67.2]
   sts3215_03a_v1.stl                 collision faces= 19080 extent_mm=[45.4, 24.8, 39.6]
   soft_fin_fixed_jaw_collision.stl   collision faces=  4144 extent_mm=[65.2, 52.0, 48.6]
   soft_fin_finger.stl                collision faces=  1834 extent_mm=[24.2, 24.1, 67.2]
   soft_fin_moving_jaw.stl            visual    faces= 15577 extent_mm=[20.3, 36.7, 48.0]
   soft_fin_finger.stl                visual    faces=  1834 extent_mm=[24.2, 24.1, 67.2]
   soft_fin_moving_jaw_collision.stl  collision faces=  4164 extent_mm=[20.3, 36.7, 48.0]
   soft_fin_finger.stl                collision faces=  1834 extent_mm=[24.2, 24.1, 67.2]
   soft_fin_fixed_jaw_collision.stl   4144 faces < visual soft_fin_fixed_jaw.stl 19126 faces  (22%): OK
   soft_fin_moving_jaw_collision.stl  4164 faces < visual soft_fin_moving_jaw.stl 15577 faces  (27%): OK
   soft_fin_finger.stl instanced on both jaws: ['gripper_link', 'moving_jaw_so101_v1_link']

=== 5. the two fins close on each other (grasp check) ===
   gripper=+1.745 rad -> fin-to-fin closest approach =   55.3 mm (upper limit)
   gripper=+1.500 rad -> fin-to-fin closest approach =   52.5 mm (Gripper Open wp)
   gripper=+0.750 rad -> fin-to-fin closest approach =   39.7 mm
   gripper=+0.000 rad -> fin-to-fin closest approach =   15.2 mm (Gripper Closed wp)
   gripper=-0.175 rad -> fin-to-fin closest approach =    1.7 mm (lower limit)

=== 6. renders ===
   wrote /ev/arm_open_base.png
   wrote /ev/gripper_iso_open_base.png
   wrote /ev/gripper_grasp_open_base.png
   wrote /ev/arm_open_target.png
   wrote /ev/gripper_iso_open_target.png
   wrote /ev/gripper_grasp_open_target.png
   wrote /ev/arm_closed_base.png
   wrote /ev/gripper_iso_closed_base.png
   wrote /ev/gripper_grasp_closed_base.png
   wrote /ev/arm_closed_target.png
   wrote /ev/gripper_iso_closed_target.png
   wrote /ev/gripper_grasp_closed_target.png
   wrote /ev/gripper_compare_sheet.png

ALL CHECKS PASSED

=== 7. NOTICE.md provenance record vs the directory it documents ===
   "18 STL files ... unmodified upstream exports": 18 listed, all present on disk
   all 18 are byte-identical to the pre-change tree (this change vendored no new arm meshes)
   the remaining 5 STLs are exactly what the XLeRobot section accounts for:
     named in the table:      ['soft_fin_finger.stl', 'soft_fin_fixed_jaw.stl', 'soft_fin_moving_jaw.stl']
     covered by `*_collision.stl`: ['soft_fin_fixed_jaw_collision.stl', 'soft_fin_moving_jaw_collision.stl']
   table dimensions vs actual mesh bounds:
     soft_fin_fixed_jaw.stl       claimed [48.6, 52.0, 65.2] mm == actual [np.float64(48.6), np.float64(52.0), np.float64(65.2)] mm
     soft_fin_moving_jaw.stl      claimed [20.3, 36.7, 48.0] mm == actual [np.float64(20.3), np.float64(36.7), np.float64(48.0)] mm
     soft_fin_finger.stl          claimed [24.1, 24.2, 67.2] mm == actual [np.float64(24.1), np.float64(24.2), np.float64(67.2)] mm
   all XLeRobot meshes are in metres (max extent 0.02-0.07 m, not 20-70)
     soft_fin_finger.stl                   89.6 KiB  < 1 MB
     soft_fin_fixed_jaw.stl               934.0 KiB  < 1 MB
     soft_fin_fixed_jaw_collision.stl     202.4 KiB  < 1 MB
     soft_fin_moving_jaw.stl              760.7 KiB  < 1 MB
     soft_fin_moving_jaw_collision.stl    203.4 KiB  < 1 MB
     soft_fin_fixed_jaw_collision.stl   same bounds as soft_fin_fixed_jaw.stl, 4144 vs 19126 faces, max deviation 0.20 mm
     soft_fin_moving_jaw_collision.stl  same bounds as soft_fin_moving_jaw.stl, 4164 vs 15577 faces, max deviation 0.15 mm
   registration claim (surface fraction within 0.1 mm of the stock part):
     soft_fin_fixed_jaw.stl   vs stock wrist_roll_follower_so101_v1.stl    83.1% (NOTICE says 83%)
     soft_fin_moving_jaw.stl  vs stock moving_jaw_so101_v1.stl             63.8% (NOTICE says 64%)

PROVENANCE CHECKS PASSED
```
</details>
<details>
<summary>Evidence: Key offline check results</summary>

```text
=== 1. kinematic tree identical (joints, origins, axes, limits) ===
12 joints identical, including:
gripper: axis=[0.0, 0.0, 1.0] limits=(-0.174533, 1.74533) type=revolute

=== 2. geometry changes are confined to the two gripper links ===
links with changed geometry: ['gripper_link', 'moving_jaw_so101_v1_link']
gripper_link jaw-body visual origin unchanged vs stock: OK
moving_jaw_so101_v1_link jaw-body visual origin unchanged vs stock: OK

=== 3. TCP (gripper_frame_link) unchanged at every waypoint ===
Home gripper=+0.490 TCP xyz=[0.421428, 0.007441, 0.042835] |delta|=0.00e+00
Ready gripper=+1.200 TCP xyz=[0.421933, -0.108351, 0.062625] |delta|=0.00e+00
Reach Forward gripper=+1.200 TCP xyz=[0.458794, 0.007825, 0.087717] |delta|=0.00e+00
Gripper Open gripper=+1.500 TCP xyz=[0.456397, 0.007825, 0.206266] |delta|=0.00e+00
Gripper Closed gripper=+0.000 TCP xyz=[0.456397, 0.007825, 0.206266] |delta|=0.00e+00

=== 5. the two fins close on each other (grasp check) ===
gripper=+1.745 rad -> fin-to-fin closest approach = 55.3 mm (upper limit)
gripper=+1.500 rad -> fin-to-fin closest approach = 52.5 mm (Gripper Open wp)
gripper=+0.750 rad -> fin-to-fin closest approach = 39.7 mm
gripper=+0.000 rad -> fin-to-fin closest approach = 15.2 mm (Gripper Closed wp)
gripper=-0.175 rad -> fin-to-fin closest approach = 1.7 mm (lower limit)

=== 7. NOTICE.md provenance record vs the directory it documents ===
"18 STL files ... unmodified upstream exports": 18 listed, all present on disk
all 18 are byte-identical to the pre-change tree
the remaining 5 STLs are exactly what the XLeRobot section accounts for
registration claim (surface fraction within 0.1 mm of the stock part):
soft_fin_fixed_jaw.stl vs stock wrist_roll_follower_so101_v1.stl 83.0% (NOTICE says 83%)
soft_fin_moving_jaw.stl vs stock moving_jaw_so101_v1.stl 63.8% (NOTICE says 64%)

ALL CHECKS PASSED / PROVENANCE CHECKS PASSED
```
</details>
<details>
<summary>Evidence: Reproduction scripts (URDF model + software rasteriser, checks, provenance checks)</summary>

```text
"""Driver: expand both URDFs, compare them semantically, FK at the package's
waypoints, and render Gripper Open / Gripper Closed for base vs target."""
import json, os, subprocess, sys, math
import numpy as np, yaml
from PIL import Image, ImageDraw
sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
from so101_render import Robot, render

OUT = os.path.dirname(os.path.abspath(__file__))
TREES = {'base': '/base/src/so101_sim', 'target': '/ws/src/so101_sim'}
NEW = {'soft_fin_fixed_jaw.stl', 'soft_fin_moving_jaw.stl', 'soft_fin_finger.stl',
       'soft_fin_fixed_jaw_collision.stl', 'soft_fin_moving_jaw_collision.stl'}

def expand(tree, tag):
    p = f'/tmp/{tag}.urdf'
    xml = subprocess.run(['xacro', f'{tree}/description/so101.urdf.xacro',
                          f'initial_positions_file:={tree}/config/initial_positions.yaml'],
                         capture_output=True, text=True, check=True).stdout
    open(p, 'w').write(xml)
    r = subprocess.run(['check_urdf', p], capture_output=True, text=True)
    print(f'--- check_urdf ({tag}) ---\n{r.stdout.strip()[:400]}\n   exit={r.returncode}')
    assert r.returncode == 0, r.stderr
    return p

def main():
    bots = {}
    for tag, tree in TREES.items():
        bots[tag] = Robot(expand(tree, tag), tree)

    print('\n=== 1. kinematic tree identical (joints, origins, axes, limits) ===')
    kb, kt = bots['base'].kinematics(), bots['target'].kinematics()
    assert kb == kt, [n for n in kb if kb[n] != kt.get(n)]
    print(f'   {len(kt)} joints identical, including:')
    for n in ('gripper', 'wrist_roll'):
        print(f'     {n}: axis={kt[n]["axis"]} limits={kt[n]["limit"]} type={kt[n]["type"]}')

    print('\n=== 2. geometry changes are confined to the two gripper links ===')
    gb, gt = bots['base'].geometry(), bots['target'].geometry()
    changed = sorted(l for l in set(gb) | set(gt) if gb.get(l) != gt.get(l))
    print(f'   links with changed geometry: {changed}')
    assert changed == ['gripper_link', 'moving_jaw_so101_v1_link'], changed
    for l in changed:
        for kind, mesh, org in gt[l]:
            was = [m for k, m, _ in gb[l] if k == kind]
            print(f'     {l:28s} {kind:9s} {mesh:34s} (was {was[0] if was else "-"})')
        # visual origin of the jaw body is the stock origin
        stock_vis = [o for k, m, o in gb[l] if k == 'visual'][0]
        new_vis = [o for k, m, o in gt[l] if k == 'visual'][0]
        assert np.allclose(stock_vis, new_vis), l
        print(f'     {l:28s} jaw-body visual origin unchanged vs stock: OK')

    print('\n=== 3. TCP (gripper_frame_link) unchanged at every waypoint ===')
    wps = yaml.safe_load(open(f'{TREES["target"]}/waypoints/so101_waypoints.yaml'))
    worst = 0.0
    for w in wps:
        js = w['joint_state']; q = dict(zip(js['name'], js['position']))
        Tb = bots['base'].fk(q)['gripper_frame_link']
        Tt = bots['target'].fk(q)['gripper_frame_link']
        d = np.abs(Tb - Tt).max(); worst = max(worst, d)
        print(f'   {w["name"]:16s} gripper={q["gripper"]:+.3f}  TCP xyz={np.round(Tt[:3,3],6).tolist()}  |delta|={d:.2e}')
    assert worst == 0.0

    print('\n=== 4. fin meshes: metres, decimated collision, finger reused twice ===')
    import trimesh
    for l in changed:
        for kind, mesh, _ in gt[l]:
            m = trimesh.load(f'{TREES["target"]}/description/assets/{mesh}', force='mesh')
            ext = (m.bounds[1] - m.bounds[0]) * 1000
            print(f'   {mesh:34s} {kind:9s} faces={len(m.faces):6d} extent_mm={np.round(ext,1).tolist()}')
    for col in ('soft_fin_fixed_jaw_collision.stl', 'soft_fin_moving_jaw_collision.stl'):
        vis = col.replace('_collision', '')
        nv = len(trimesh.load(f'{TREES["target"]}/description/assets/{vis}', force='mesh').faces)
        nc = len(trimesh.load(f'{TREES["target"]}/description/assets/{col}', force='mesh').faces)
        assert nc < nv, (col, nv, nc)
        print(f'   {col:34s} {nc} faces < visual {vis} {nv} faces  ({nc/nv:.0%}): OK')
    fingers = [(l, o) for l in changed for k, m, o in gt[l] if k == 'visual' and m == 'soft_fin_finger.stl']
    assert len(fingers) == 2, fingers
    print(f'   soft_fin_finger.stl instanced on both jaws: {[l for l,_ in fingers]}')

    # --- fin ribs face inward: finger tip separation shrinks as gripper closes
    print('\n=== 5. the two fins close on each other (grasp check) ===')
    def fin_tips(bot, gq):
        q = {'gripper': gq}
        poses = bot.fk(q)
        out = {}
        for ln in ('gripper_link', 'moving_jaw_so101_v1_link'):
            for g in bot.links[ln]:
                if g['kind'] == 'visual' and g['mesh'].endswith('soft_fin_finger.stl'):
                    m = trimesh.load(bot.resolve(g['mesh']), force='mesh')
                    T = poses[ln] @ g['origin']
                    v = m.vertices @ T[:3, :3].T + T[:3, 3]
                    out[ln] = v
        return out
    for gq in (1.74533, 1.5, 0.75, 0.0, -0.174533):
        t = fin_tips(bots['target'], gq)
        a, b = t['gripper_link'], t['moving_jaw_so101_v1_link']
        # min distance between the two fin point clouds (sampled)
        d = np.linalg.norm(a[None, ::7] - b[::7, None], axis=-1).min()
        tagtxt = {1.74533: ' (upper limit)', 1.5: ' (Gripper Open wp)', 0.0: ' (Gripper Closed wp)',
                  -0.174533: ' (lower limit)'}.get(gq, '')
        print(f'   gripper={gq:+.3f} rad -> fin-to-fin closest approach = {d*1000:6.1f} mm{tagtxt}')
        assert d > 0, 'fins interpenetrate'

    print('\n=== 6. renders ===')
    COL = {'fin': (222, 108, 52), 'jaw': (86, 92, 104), 'arm': (172, 176, 182), 'servo': (58, 60, 66)}
    def colors_for(owner, meshes):
        out = []
        for (ln, mat), mesh in zip(owner, meshes):
            if mesh == 'soft_fin_finger.stl':
                out.append(COL['fin'])
            elif mesh in NEW or mesh in ('wrist_roll_follower_so101_v1.stl', 'moving_jaw_so101_v1.stl'):
                out.append(COL['jaw'])
            elif mat == 'sts3215':
                out.append(COL['servo'])
            else:
                out.append(COL['arm'])
        return out

    def tri_and_color(bot, q, links=None):
        poses = bot.fk(q); tris = []; cols = []
        import trimesh as tm
        for ln, gs in sorted(bot.links.items()):
            if links is not None and ln not in links:
                continue
            for g in gs:
                if g['kind'] != 'visual':
                    continue
                m = tm.load(bot.resolve(g['mesh']), force='mesh')
                T = poses[ln] @ g['origin']
                v = m.vertices @ T[:3, :3].T + T[:3, 3]
                tris.append(v[m.faces])
                mesh = os.path.basename(g['mesh'])
                cols += colors_for([(ln, g['material'])] * len(m.faces), [mesh] * len(m.faces))
        return np.concatenate(tris, 0), cols

    def caption(img, text, sub=''):
        d = ImageDraw.Draw(img)
        d.rectangle([0, 0, img.width, 46], fill=(28, 30, 34))
        d.text((12, 8), text, fill=(245, 245, 245))
        if sub:
            d.text((12, 26), sub, fill=(170, 200, 225))
        return img

    scenes = []
    for wpname, gq in (('Gripper Open', 1.5), ('Gripper Closed', 0.0)):
        w = [x for x in wps if x['name'] == wpname][0]
        js = w['joint_state']; q = dict(zip(js['name'], js['position']))
        for tag in ('base', 'target'):
            bot = bots[tag]
            tris, cols = tri_and_color(bot, q)
            tcp = bot.fk(q)['gripper_frame_link'][:3, 3]
            # full arm
            pts_a = tris.reshape(-1, 3)
            ca = (pts_a.min(0) + pts_a.max(0)) / 2
            ra = np.linalg.norm(pts_a - ca, axis=1).max()
            da = np.array([0.60, -0.66, 0.45]); da /= np.linalg.norm(da)
            img = render(tris, cols, eye=ca + da * (1.15 * ra / math.tan(math.radians(42) / 2)),
                         target=ca, W=760, H=620, fov=42)
            caption(img, f'{wpname} - {"stock SO-101 jaws (base)" if tag=="base" else "XLeRobot soft fin gripper (this change)"}',
                    f'so101_sim, mock URDF, joints from waypoints/so101_waypoints.yaml (gripper={q["gripper"]:.2f} rad)')
            p = f'{OUT}/arm_{wpname.split()[-1].lower()}_{tag}.png'; img.save(p); print('   wrote', p)
            # gripper close-ups, auto-framed
            gl = ['gripper_link', 'moving_jaw_so101_v1_link']
            tris2, cols2 = tri_and_color(bot, q, links=gl)
            pts = tris2.reshape(-1, 3)
            c = (pts.min(0) + pts.max(0)) / 2
            r = np.linalg.norm(pts - c, axis=1).max()
            fov2 = 38.0
            dist = 1.25 * r / math.tan(math.radians(fov2) / 2)
            views = {'iso': np.array([0.62, -0.70, 0.36]), 'grasp': np.array([0.05, -0.20, 0.98])}
            for vname, d in views.items():
                d = d / np.linalg.norm(d)
                img2 = render(tris2, cols2, eye=c + d * dist, target=c, W=700, H=580, fov=fov2)
                caption(img2, f'{wpname} - gripper {vname} view - {"stock jaws (base)" if tag=="base" else "fin gripper (this change)"}',
                        'orange = soft_fin_finger.stl (x2), slate = jaw bodies, dark = wrist servo')
                p2 = f'{OUT}/gripper_{vname}_{wpname.split()[-1].lower()}_{tag}.png'
                img2.save(p2); print('   wrote', p2)
                if vname == 'iso':
                    scenes.append((wpname, tag, p2))

    # side-by-side sheet
    sheet = Image.new('RGB', (1400, 1160), (255, 255, 255))
    for i, (wpname, tag, p) in enumerate(scenes):
        sheet.paste(Image.open(p), (700 * (i % 2), 580 * (i // 2)))
    sp = f'{OUT}/gripper_compare_sheet.png'; sheet.save(sp); print('   wrote', sp)
    print('\nALL CHECKS PASSED')

main()
```
</details>


## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b496238c5f15f4062454af557e9a61a991c38a41","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/so101_sim/README.md:48` - Required-and-absent. The intent states: &#34;src/so101_sim/README.md still describes the arm as a stock LeRobot SO-101 with upstream-only meshes, which is false for the two gripper links&#34; and lists it among the four findings that &#34;remain unaddressed and should be fixed in this run&#34;. README.md is untouched by both commits on this branch. Line 48 still reads &#34;Meshes are the upstream LeRobot description; see `description/assets/NOTICE.md`.&#34;, and line 3 still reads &#34;A MoveIt Pro configuration for a stock LeRobot SO-101 follower arm&#34;. Verified false: so101.urdf.xacro:399, 415, 505, 519 now reference soft_fin_fixed_jaw.stl, soft_fin_finger.stl and soft_fin_moving_jaw.stl, which description/assets/NOTICE.md itself documents as XLeRobot parts that are explicitly not byte-identical upstream exports. Wording-only fix: say the arm meshes are the upstream LeRobot description and the gripper meshes are XLeRobot&#39;s soft fin-ray parts, both recorded in description/assets/NOTICE.md, and drop &#34;stock&#34; from line 3.
- ⚠️ `src/so101_sim/NOTICE.md:6` - Required-and-absent. The intent states: &#34;src/so101_sim/NOTICE.md scopes its vendoring statement to one third party and omits the second upstream (Vector-Wangel/XLeRobot, Apache-2.0)&#34; and lists it among the findings to fix in this run. NOTICE.md is untouched by both commits. Line 5-6 still reads &#34;The SO-101 arm and camera-mount STL files under `description/assets/` are vendored from a third party under the Apache License 2.0&#34;, while the directory now also carries five meshes from a second, unrelated upstream. This is the top-level provenance record, so a reader auditing third-party content from this file alone misses XLeRobot entirely. Wording-only fix: name both upstreams in that paragraph; the detail already lives in description/assets/NOTICE.md.
- ⚠️ `src/so101_sim/description/assets/NOTICE.md:53` - Required-and-absent. The intent states: &#34;the XLeRobot section of description/assets/NOTICE.md must state that XLeRobot is licensed Apache-2.0 with an unfilled copyright appendix upstream and that the upstream repo ships no NOTICE file, rather than pointing at this directory&#39;s LICENSE file whose appendix names an unrelated copyright holder.&#34; The fix commit ee69cf20 added the XLeRobot section but wrote the forbidden wording instead: line 53-55 says &#34;License: Apache License 2.0, the same license as the rest of this directory; see `LICENSE`. The upstream repository-level license file is `hardware/../LICENSE` in that tree.&#34; Verified: description/assets/LICENSE ends with the appendix line &#34;Copyright 2026 Dan Wahl&#34;, the vla-test holder, who has nothing to do with XLeRobot, so the cross-reference attributes XLeRobot content to an unrelated copyright holder. Fix per the intent: state that XLeRobot is Apache-2.0, that its upstream LICENSE carries an unfilled copyright appendix, and that the upstream repo ships no NOTICE file; do not point at this directory&#39;s LICENSE. While there, `hardware/../LICENSE` on line 55 is just `LICENSE` at the upstream repo root.

🔧 Fix: correct stale mesh provenance in README and NOTICEs
1 info still open:

- ℹ️ `src/so101_sim/description/assets/NOTICE.md:91` - The NOTICE states &#34;Peak surface deviation from the upstream geometry is 0.08 mm for the visual meshes and 0.6 mm for the collision meshes.&#34; A uniform 6000-sample exact point-to-triangle Hausdorff between soft_fin_fixed_jaw_collision.stl and its visual mesh reproduces the stated figure (0.62 mm), but a targeted dense search of the worst region finds a true peak of 0.76 mm, and deviation from upstream can only be larger since the visual mesh is itself ~0.08 mm off. Noting this for the record only: the difference is measurement-method variation at the tail (different decimators and sampling densities legitimately report &#34;peak&#34; differently), it has no functional consequence because MoveIt pads links by 0.01 m, and the two other numeric claims in this section (83% and 64% within 0.1 mm) reproduce exactly. No change required unless the maintainer wants the bound restated as a sampled peak.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`docker run moveit-pro-base:10.1.0-rc7-jazzy-so101_sim_ws` -- ran all offline checks inside the workspace&#39;s own ROS Jazzy image, no MoveIt Pro instance brought up</code>
- <code>`xacro src/so101_sim/description/so101.urdf.xacro` + `check_urdf` on both the base commit (a343737f) and the target (89b915e5) -- both parse, identical link tree</code>
- <code>`so101_check.py` section 1: parsed both expanded URDFs into a joint model and asserted all 12 joints (type/parent/child/origin/axis/limits) are identical, incl. the `gripper` revolute joint axis [0,0,1] and limits (-0.174533, 1.74533)</code>
- <code>`so101_check.py` section 2: asserted changed visual/collision geometry is confined to `gripper_link` and `moving_jaw_so101_v1_link`, and that both jaw bodies reuse the stock part&#39;s visual origin</code>
- <code>`so101_check.py` section 3: forward kinematics of `gripper_frame_link` at all five waypoints in `waypoints/so101_waypoints.yaml`, base vs target -- max delta 0.00e+00</code>
- <code>`so101_check.py` section 4: mesh load of every gripper-link mesh via trimesh -- metres, extents, collision face counts 22%/27% of visual, `soft_fin_finger.stl` instanced on both jaws</code>
- <code>`so101_check.py` section 5: fin-to-fin closest approach swept over the gripper joint&#39;s full range (+1.745 upper limit -&gt; -0.175 lower limit), asserting no interpenetration at any pose incl. both gripper waypoints</code>
- <code>`so101_check.py` section 6: software-rasterised renders (z-buffered, headless, no OpenGL) of the arm and of the gripper close-up at Gripper Open and Gripper Closed, for both the stock base geometry and the fin gripper, from an iso and a down-the-grasp-axis viewpoint</code>
- <code>`so101_provenance_check.py`: validated description/assets/NOTICE.md&#39;s checkable claims against the artifacts -- 18-file list vs directory listing, SHA-256 identity of those 18 against the pre-change tree, the 5 remaining STLs vs the XLeRobot section, table mm dimensions vs mesh bounds, metre scaling, &lt;1 MB file sizes, collision meshes as decimated copies (same bounds, lower face count, sub-mm deviation), and the 83%/64% rigid-registration surface-fraction claim against the stock parts they replace</code>
- <code>`python3 -m pytest test/test_so101_arm_bridge.py -q` in src/so101_sim -- 11 passed (bridge untouched by this change, run as a collateral check)</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `src/so101_sim/description/assets/NOTICE.md:14` - Follow-up, out of scope here (deleting assets is a code change, not a doc edit). After this change `wrist_roll_follower_so101_v1.stl` and `moving_jaw_so101_v1.stl` are no longer referenced by `description/so101.urdf.xacro` — the fin jaws replaced both — but they remain vendored LFS objects and are still counted in the NOTICE&#39;s list of 18 upstream exports. The NOTICE is not wrong (it records what is vendored, not what is used), so nothing was edited. Worth a separate change deciding whether to drop the two dead meshes and re-count the list, or keep them as reference geometry for the stock configuration.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

