### PR TITLE
Fix: Port kitchen_sim Segment Image from Prompt to SAM3 on 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ at run time with
 
     The ONNX model path could not be resolved: Package 'moveit_pro_clipseg' was not found
 
-- kitchen_sim: Segment Image from Prompt
 - lab_sim: ML Segment Image, ML Segment Image Loop, ML Segment Point Cloud,
   AddBottlesToPlanningScene
 - hangar_sim: Segment Image from Text Prompt, ML Move Boxes to Loading Zone,
@@ -40,8 +39,9 @@ To restore them, build a ROS package that installs CLIP and CLIPSeg ONNX models
 to `share/<your_package>/models/` and set `model_package` (and the
 `clip_model_path` / `clipseg_model_path` ports) on those Objectives to point at
 it. To move off CLIPSeg entirely, see the SAM3 equivalents in `lab_sim`
-(`ML Find Objects on Table`, `ML Segment Bottles from File`) and MoveIt Pro
-10.0, where these Objectives were migrated to `GetMasks2DFromExemplar`.
+(`ML Find Objects on Table`, `ML Segment Bottles from File`), `kitchen_sim`
+(`Segment Image from Prompt`), and MoveIt Pro 10.0, where these Objectives
+were migrated to `GetMasks2DFromExemplar`.
 
 ## Robot Configs
 

--- a/src/kitchen_sim/objectives/segment_image_from_prompt.xml
+++ b/src/kitchen_sim/objectives/segment_image_from_prompt.xml
@@ -15,15 +15,16 @@
         topic_name="/scene_camera/color"
       />
       <Action
-        ID="GetMasks2DFromTextQuery"
-        erosion_size="0"
-        image="{image}"
+        ID="GetMasks2DFromExemplar"
+        model_package="moveit_pro_sam3"
+        encoder_model_path="models/sam3_vision_encoder.onnx"
+        decoder_model_path="models/sam3_decoder.onnx"
+        geometry_encoder_model_path="models/sam3_geometry_encoder.onnx"
+        text_encoder_model_path="models/sam3_text_encoder.onnx"
+        confidence_threshold="0.5"
+        target_image="{image}"
+        text_prompt="a stove circular burner"
         masks2d="{masks2d}"
-        prompts="a stove circular burner"
-        threshold="0.7"
-        clip_model_path="models/clip.onnx"
-        clipseg_model_path="models/clipseg.onnx"
-        model_package="moveit_pro_clipseg"
       />
       <Action
         ID="PublishMask2D"
@@ -31,7 +32,7 @@
         masks="{masks2d}"
         masks_visualization_topic="/masks_visualization"
         opacity="0.500000"
-        bounding_box_labels="stove"
+        bounding_box_detection_class="burner"
       />
       <Action
         ID="SwitchUIPrimaryView"

--- a/src/kitchen_sim/package.xml
+++ b/src/kitchen_sim/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>moveit_pro_behavior</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_sam2</exec_depend>
+  <exec_depend>moveit_pro_sam3</exec_depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_clang_tidy</test_depend>


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#22567 (part of epic PickNikRobotics/moveit_pro#22564).

## Motivation

PR #927 removed the `moveit_pro_clipseg` submodule from `v9.4` because its weights had no license grant, so `kitchen_sim`'s favourited Objective **Segment Image from Prompt** now fails at run time with `The ONNX model path could not be resolved: Package 'moveit_pro_clipseg' was not found`. This is the first of the epic's per-Objective ports to SAM3, and the only `kitchen_sim` caller.

## Brief description

- `src/kitchen_sim/objectives/segment_image_from_prompt.xml`: replace the `GetMasks2DFromTextQuery` Action with `GetMasks2DFromExemplar`, using the four explicit `*_model_path` ports and `model_package="moveit_pro_sam3"` that MoveIt Pro 9.4 supports (9.4 has no `model_bundle_manifest` port, so this is modelled on `bb0d53c0`, not on today's `main`). The prompt text is unchanged; `threshold="0.7"` becomes `confidence_threshold="0.5"` because the two Behaviors score on different scales, and `erosion_size`, `clip_model_path`, and `clipseg_model_path` have no SAM3 equivalent. `PublishMask2D` switches from `bounding_box_labels="stove"` to `bounding_box_detection_class="burner"`: CLIPSeg returned one mask per prompt, SAM3 returns one per detected instance, and a single label only annotates the first mask, so the class port enumerates `burner 0` to `burner 3`, named for what the prompt segments. Everything else in the tree, including the favourite flag, is untouched.
- `src/kitchen_sim/package.xml`: add `<exec_depend>moveit_pro_sam3</exec_depend>`. PR #927 already dropped the CLIPSeg line, so this is an addition, not a swap.
- `README.md`: drop this Objective from the list of Objectives that fail without CLIPSeg and add it to the pointer to SAM3 examples. The rest of that section stays until the epic's other ports land.

One semantic difference to be aware of, shared with the existing `lab_sim` SAM3 Objectives: CLIPSeg failed the Objective when nothing passed the threshold, while `GetMasks2DFromExemplar` returns success with zero masks, so a total detection miss now shows as a green Objective with an unannotated frame. Nothing in this tree branches on the masks, so no control flow changes.

The `moveit_pro_sam3` submodule pinned on `v9.4` already ships all four weights; no pin bump or download step is needed.

## How it was tested

- `colcon build --packages-select kitchen_sim` in the 9.4.2 base container.
- `pre-commit run` on both files (prettier, codespell, objective-favourites check) passes.
- Ran **Segment Image from Prompt** headlessly against a 9.4.2 Runtime (`picknikciuser/moveit-studio:9.4.2-humble`) on CPU-only ONNX Runtime: the Objective succeeds in 27.5 s, and `/masks_visualization` shows all four burners masked with no false positives at `confidence_threshold="0.5"`, so no retuning from the `main` value was needed. Verification is manual by necessity: the objectives integration test matrix in `.github/workflows/ci.yaml` covers only `lab_sim` and `hangar_sim`, and those skip every ML Objective on CPU runners.

The lab_sim, hangar_sim, and dual_arm_sim Objectives and the README section that PR #927 added are handled by the epic's other sub-issues.

## Release notes

- `Bug Fix:` Fixed the `kitchen_sim` Objective `Segment Image from Prompt`, which failed after the CLIPSeg weights were removed; it now segments with SAM3 (`GetMasks2DFromExemplar`).

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these.*

- [x] `code-reviewer`
  - no findings; ports verified against 9.4 `GetMasks2DFromExemplar`
- [x] `documentation-bot`
  - one stale-correction applied: README no longer lists this Objective as failing
- [x] `licensing-privacy-bot`
  - no new exposure; noted separately that the `moveit_pro_sam3` pin predates upstream's SAM License file
- [x] `platform-architect-bot`
  - applied: `bounding_box_detection_class` so every SAM3 instance is annotated; manual-verification note added
- [x] `roboticist-bot`
  - applied: class name `burner`, README pointer; zero-mask semantics documented above rather than changed, to stay consistent with the `lab_sim` SAM3 Objectives
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] SKIPPED `compatibility-bot`
  - this Objective's own ports are unchanged and it has no SubTree callers; no public interface touched
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, or TypeScript changed
- [x] `test-runner`
  - `colcon build` and `colcon test` for `kitchen_sim` in the 9.4.2 base container: 2 lint tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
