### PR TITLE
feat(lunar_sim): drive the Husky base over /cmd_vel during teleoperation

### DIFF
--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -170,8 +170,29 @@ frame above `odom` is MuJoCo's `mj_world`, published as identity so the world-fi
 `scene_camera_optical_frame` resolves in `odom`, and `config/frontend_settings.yaml` sets
 `referenceFrame: odom` to override the frontend's `world` default.
 
-The Pose Jog and Joint Jog UI panels are wired to the `base` group only to avoid a MoveIt Pro
-launch crash on an empty jog config; neither is functionally usable on this robot (no IK-capable
-group, no per-joint velocity controller).
+## Teleoperation
+
+The Pose Jog and Joint Jog UI panels are wired to the `base` group to avoid a MoveIt Pro launch
+crash on an empty jog config. Joint Jog stays unusable on this armless base (no per-joint velocity
+controller), but Pose Jog drives the Husky base: the Pose tab's jog pad, a connected gamepad, and
+the Quest headset all publish a `VelocityForceCommand` on `/pose_jog/base`, and the
+`TeleoperateBase` Behavior (`lunar_sim_behaviors`) forwards `linear.x`/`angular.z` from that stream
+into a `TwistStamped` on `/cmd_vel` for `platform_velocity_controller`.
+
+The Pose tab's controls are labeled for an end-effector, since that is what the panel is designed
+for; on this base the labels map to driving as follows:
+
+- Jog pad: `X +` drives forward, `X -` reverses; `Roll +` turns left, `Roll -` turns right. The
+  `Y`, `Z`, `Pitch`, and `Yaw` buttons do nothing.
+- Gamepad: the left stick left/right drives forward/reverse; the bumpers turn left/right. The right
+  stick and triggers do nothing.
+
+The Joint, IMarker, and Waypoints tabs do nothing on this base - they operate on wheel joints or
+wheel-link poses, which have no meaningful teleoperation behavior for a differential-drive base.
+
+Speed is capped in two places: the Pose tab's speed slider (0.25 m/s max by default, since this
+config has no Cartesian velocity limit parameter for the slider to read), and the
+`TeleoperateBase` Behavior's own clamp ports (0.8 m/s linear, 2.0 rad/s angular, matching
+`platform_velocity_controller`'s limits).
 
 For detailed documentation see: [MoveIt Pro Documentation](https://docs.picknik.ai/)

--- a/src/lunar_sim/README.md
+++ b/src/lunar_sim/README.md
@@ -4,8 +4,9 @@ A MoveIt Pro configuration for a Clearpath Husky A300 running under MuJoCo physi
 procedurally cratered lunar regolith heightfield. The only sensor is `husky_scene.xml`'s
 mast-mounted, world-fixed `scene_camera`, an overview of the start area and demo route published
 as an image stream at the xacro's `render_publish_rate` of 10 Hz; the robot itself carries none
-(see the roadmap below). No Nav2 stack either - the only way to drive the base is the
-`Dead Reckon Square` objective's open-loop `/cmd_vel` commands.
+(see the roadmap below). No Nav2 stack either - the base is driven only by open-loop `/cmd_vel`
+commands, from the `Dead Reckon Square` objective or the Desktop App's Pose tab (see
+[Teleoperation](#teleoperation)).
 
 The base spawns at `husky_scene.xml`'s `default` keyframe rather than the world origin
 (`config.yaml`'s `mujoco_keyframe`); that keyframe's own comment records the pose and why it was

--- a/src/lunar_sim/config/config.yaml
+++ b/src/lunar_sim/config/config.yaml
@@ -83,8 +83,9 @@ ros2_control:
   controllers_not_managed: []
   # platform_velocity_controller's topics are namespaced under its own controller name (Jazzy
   # default). Remap them to the plain names each end already uses: /cmd_vel, which the
-  # `Dead Reckon Square` objective publishes to, and /odom, which the controller itself publishes
-  # (see husky_a300.ros2_control.yaml's odom_frame_id/publish_rate). No rework downstream.
+  # `Dead Reckon Square` and `Request Teleoperation` objectives publish to, and /odom, which the
+  # controller itself publishes (see husky_a300.ros2_control.yaml's odom_frame_id/publish_rate).
+  # No rework downstream.
   # [Optional, default=[]]
   controller_shared_topics:
     /cmd_vel:

--- a/src/lunar_sim/config/moveit/joint_jog.yaml
+++ b/src/lunar_sim/config/moveit/joint_jog.yaml
@@ -1,8 +1,7 @@
 # diff_drive_controller is a kinematics controller, not a per-joint velocity controller, so the
-# "base" group's wheel joints are not joint-joggable - the base is only ever driven by the
-# `Dead Reckon Square` objective's open-loop /cmd_vel commands.
-# An empty planning_groups/controllers pair crashes MoveIt Pro's launch (evaluates to an untyped
-# empty parameter tuple), so this points at "base" inertly instead - Joint Jog is never invoked
-# for this robot.
+# "base" group's wheel joints are not joint-joggable; unlike Pose Jog, Joint Jog stays unusable on
+# this base (see src/lunar_sim/README.md). An empty planning_groups/controllers pair crashes
+# MoveIt Pro's launch (evaluates to an untyped empty parameter tuple), so this points at "base"
+# inertly instead - Joint Jog is never invoked for this robot.
 planning_groups: ["base"]
 controllers: ["platform_velocity_controller"]

--- a/src/lunar_sim/config/moveit/pose_jog.yaml
+++ b/src/lunar_sim/config/moveit/pose_jog.yaml
@@ -1,8 +1,9 @@
 # The base has no arm and no IK-capable group, so MoveIt Pro's Cartesian Pose Jog Behavior does not
-# apply here. This config is still read, though: `request_teleoperation.xml`'s Pose tab branch
-# reports these planning_groups/controllers to the Desktop App, whose jog pad, gamepad, and Quest
-# headset then publish VelocityForceCommand on /pose_jog/base for `TeleoperateBase` to forward to
-# /cmd_vel. An empty planning_groups/controllers pair would also crash MoveIt Pro's launch
-# (evaluates to an untyped empty parameter tuple).
+# apply here. This config is still read, though: the Desktop App fetches it over REST to choose
+# the /pose_jog/<planning_group> topic its jog pad, gamepad, and Quest headset publish
+# VelocityForceCommand on, and `request_teleoperation.xml`'s `TeleoperateBase` subscribes to the
+# same /pose_jog/base name to forward those commands to /cmd_vel. An empty
+# planning_groups/controllers pair would also crash MoveIt Pro's launch (evaluates to an untyped
+# empty parameter tuple).
 planning_groups: ["base"]
 controllers: ["platform_velocity_controller"]

--- a/src/lunar_sim/config/moveit/pose_jog.yaml
+++ b/src/lunar_sim/config/moveit/pose_jog.yaml
@@ -1,7 +1,8 @@
-# The base has no arm and no IK-capable group, so Cartesian pose jogging does not apply here -
-# the base is only ever driven by the `Dead Reckon Square` objective's open-loop /cmd_vel
-# commands. An empty planning_groups/controllers pair crashes MoveIt Pro's launch (evaluates to
-# an untyped empty parameter tuple), so this points at "base" inertly instead - Pose Jog is never
-# invoked for this robot.
+# The base has no arm and no IK-capable group, so MoveIt Pro's Cartesian Pose Jog Behavior does not
+# apply here. This config is still read, though: `request_teleoperation.xml`'s Pose tab branch
+# reports these planning_groups/controllers to the Desktop App, whose jog pad, gamepad, and Quest
+# headset then publish VelocityForceCommand on /pose_jog/base for `TeleoperateBase` to forward to
+# /cmd_vel. An empty planning_groups/controllers pair would also crash MoveIt Pro's launch
+# (evaluates to an untyped empty parameter tuple).
 planning_groups: ["base"]
 controllers: ["platform_velocity_controller"]

--- a/src/lunar_sim/objectives/request_teleoperation.xml
+++ b/src/lunar_sim/objectives/request_teleoperation.xml
@@ -4,23 +4,49 @@
        A300 has no arm, so none of core's teleoperation branches apply: no joint or Cartesian jog,
        no waypoint, interactive-marker or joint-slider moves, no gripper. Those branches are also
        what pulls the objectives/motion library in, which this config deliberately does not load.
-       Base driving over /cmd_vel is not wired up yet either, so instead of accepting the UI
-       handshake and silently doing nothing, this tree fails on purpose with a message that
-       reaches the failure toast. `Teleoperate` still builds, so the Teleoperation workspace can
-       start it by name; it just fails at once until base teleoperation lands in a follow-up. -->
+       Instead, the Pose tab's mode (CARTESIAN_JOG, teleop_mode 2) drives TeleoperateBase, which
+       forwards the same VelocityForceCommand stream the jog pad, gamepad, and Quest headset already
+       publish on /pose_jog/base into a TwistStamped on /cmd_vel for platform_velocity_controller.
+       See src/lunar_sim/README.md for the resulting (arm-shaped) control layout. -->
   <BehaviorTree
     ID="Request Teleoperation"
-    _description="Fails on purpose: the Husky A300 has no arm, none of the arm teleoperation modes apply, and base driving over /cmd_vel is not wired up yet. Used as a subtree by Teleoperate so it fails visibly instead of silently doing nothing."
+    _description="Drives the Husky A300 base over /cmd_vel from the Pose tab's jog pad, gamepad, or Quest headset input. The Joint, IMarker, and Waypoints tabs do nothing on this armless base."
     _favorite="false"
     _hardcoded="false"
   >
-    <Decorator ID="ForceFailure">
-      <Action
-        ID="LogMessage"
-        log_level="error"
-        message="Teleoperation is not wired for this base yet: the Husky A300 has no arm and the Desktop App teleop modes drive arms only. Base driving over /cmd_vel lands in a follow-up."
-      />
-    </Decorator>
+    <Control ID="Sequence">
+      <Action ID="Script" code="teleop_mode := 0" />
+      <Control ID="Parallel" success_count="1" failure_count="1">
+        <Action
+          ID="DoTeleoperateAction"
+          enable_user_interaction="{enable_user_interaction}"
+          user_interaction_prompt="{user_interaction_prompt}"
+          initial_teleop_mode="{initial_teleop_mode}"
+          current_teleop_mode="{teleop_mode}"
+          planning_groups="{planning_groups}"
+          controllers="{controllers}"
+          tip_links="{tip_links}"
+          skip_collision_checks="{skip_collision_checks}"
+          velocity_scale_factor="{velocity_scale_factor}"
+          require_user_approval="{require_user_approval}"
+        />
+        <Decorator ID="RepeatUnlessFailureEachTick" num_cycles="-1">
+          <Control ID="Sequence">
+            <!-- Pose tab: jog pad, gamepad, and Quest all publish /pose_jog/base. -->
+            <Decorator ID="ForceSuccess" _while="teleop_mode == 2">
+              <Action
+                ID="TeleoperateBase"
+                planning_group="base"
+                cmd_vel_topic="/cmd_vel"
+                frame_id="footprint"
+                max_linear_velocity="0.8"
+                max_angular_velocity="2.0"
+              />
+            </Decorator>
+          </Control>
+        </Decorator>
+      </Control>
+    </Control>
   </BehaviorTree>
   <TreeNodesModel>
     <SubTree ID="Request Teleoperation">

--- a/src/lunar_sim_behaviors/CMakeLists.txt
+++ b/src/lunar_sim_behaviors/CMakeLists.txt
@@ -8,6 +8,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   geometry_msgs
   moveit_pro_behavior
   moveit_pro_behavior_interface
+  moveit_pro_controllers_msgs
   pluginlib)
 foreach(package IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${package} REQUIRED)
@@ -17,6 +18,7 @@ add_library(
   lunar_sim_behaviors
   SHARED
   src/publish_twist_stamped.cpp
+  src/teleoperate_base.cpp
   src/register_behaviors.cpp)
 target_include_directories(
   lunar_sim_behaviors

--- a/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
+++ b/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
@@ -44,7 +44,9 @@ namespace lunar_sim_behaviors
 
 /**
  * @brief Converts a VelocityForceCommand into a clamped planar Twist (linear.x, angular.z only).
- * @details Pure function, no ROS dependency, so it can be unit tested directly.
+ * @details Each component is first multiplied by its `velocity_controlled_axes` flag (x, rz), as core `PoseJog` does,
+ * so a disabled axis yields zero regardless of the commanded value. Pure function, no ROS dependency, so it can be
+ * unit tested directly.
  */
 [[nodiscard]] geometry_msgs::msg::Twist clampTwistCommand(
     const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command, double max_linear_velocity,

--- a/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
+++ b/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <mutex>
 #include <string>
 
@@ -94,7 +95,24 @@ public:
   // Publishes one zero twist, then drops the subscription and publisher.
   void onHalted() override;
 
+  // Test-only seam for the regression test in test_teleoperate_base_ros.cpp: lets a test simulate a subscription
+  // callback landing with a generation from a previous (halted) activation, without a real ROS timing race.
+  void handleCommandForTesting(std::uint64_t callback_generation,
+                               const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command)
+  {
+    handleCommand(callback_generation, command);
+  }
+  std::uint64_t activationGenerationForTesting() const
+  {
+    return activation_generation_;
+  }
+
 private:
+  // Applies a command received by the subscription callback, unless it belongs to a since-superseded
+  // activation (a callback still in flight from a previous onStart/onHalted cycle).
+  void handleCommand(std::uint64_t callback_generation,
+                     const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command);
+
   std::string frame_id_;
   double max_linear_velocity_ = 0.0;
   double max_angular_velocity_ = 0.0;
@@ -105,6 +123,9 @@ private:
   std::mutex command_mutex_;
   moveit_pro_controllers_msgs::msg::VelocityForceCommand latest_command_;
   bool has_new_command_ = false;
+  // Bumped on every onStart, so a callback from a previous activation can recognize itself as stale and
+  // no-op instead of racing a fresh onStart's state reset.
+  std::uint64_t activation_generation_ = 0;
 };
 
 }  // namespace lunar_sim_behaviors

--- a/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
+++ b/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
@@ -48,9 +48,9 @@ namespace lunar_sim_behaviors
  * so a disabled axis yields zero regardless of the commanded value. Pure function, no ROS dependency, so it can be
  * unit tested directly.
  */
-[[nodiscard]] geometry_msgs::msg::Twist clampTwistCommand(
-    const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command, double max_linear_velocity,
-    double max_angular_velocity);
+[[nodiscard]] geometry_msgs::msg::Twist
+clampTwistCommand(const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command, double max_linear_velocity,
+                  double max_angular_velocity);
 
 /**
  * @brief Drives a differential-drive base's `/cmd_vel` from the same VelocityForceCommand stream the Desktop App's

--- a/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
+++ b/src/lunar_sim_behaviors/include/lunar_sim_behaviors/teleoperate_base.hpp
@@ -1,0 +1,108 @@
+// Copyright 2026 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+#include <behaviortree_cpp/action_node.h>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/subscription.hpp>
+
+#include <moveit_pro_behavior_interface/shared_resources_node.hpp>
+#include <moveit_pro_controllers_msgs/msg/velocity_force_command.hpp>
+
+namespace lunar_sim_behaviors
+{
+
+/**
+ * @brief Converts a VelocityForceCommand into a clamped planar Twist (linear.x, angular.z only).
+ * @details Pure function, no ROS dependency, so it can be unit tested directly.
+ */
+[[nodiscard]] geometry_msgs::msg::Twist clampTwistCommand(
+    const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command, double max_linear_velocity,
+    double max_angular_velocity);
+
+/**
+ * @brief Drives a differential-drive base's `/cmd_vel` from the same VelocityForceCommand stream the Desktop App's
+ * Pose tab, gamepad, and Quest headset already publish for teleoperated jogging.
+ *
+ * @details Subscribes to `/pose_jog/<planning_group>` and forwards `linear.x`/`angular.z`, clamped to the configured
+ * limits, as a freshly-restamped `geometry_msgs::msg::TwistStamped` on `cmd_vel_topic`. All other twist components are
+ * dropped. Modeled on the forward-with-restamp half of `PoseJog`; unlike `PoseJog` this Behavior does no collision
+ * checking and controls a single planning group directly by topic name.
+ *
+ * | Data Port Name       | Port Type | Object Type |
+ * |-----------------------|-----------|-------------|
+ * | planning_group        | Input     | std::string |
+ * | cmd_vel_topic         | Input     | std::string |
+ * | frame_id              | Input     | std::string |
+ * | max_linear_velocity   | Input     | double      |
+ * | max_angular_velocity  | Input     | double      |
+ */
+class TeleoperateBase : public moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>
+{
+public:
+  static constexpr auto kPortIdPlanningGroup = "planning_group";
+  static constexpr auto kPortIdCmdVelTopic = "cmd_vel_topic";
+  static constexpr auto kPortIdFrameId = "frame_id";
+  static constexpr auto kPortIdMaxLinearVelocity = "max_linear_velocity";
+  static constexpr auto kPortIdMaxAngularVelocity = "max_angular_velocity";
+
+  TeleoperateBase(const std::string& name, const BT::NodeConfiguration& config,
+                  const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources);
+
+  static BT::PortsList providedPorts();
+
+  static BT::KeyValueVector metadata();
+
+  // Creates the VelocityForceCommand subscription and the TwistStamped publisher. Returns RUNNING.
+  BT::NodeStatus onStart() override;
+
+  // Forwards the latest command to cmd_vel, restamped, whenever a new one has arrived since the last forward.
+  BT::NodeStatus onRunning() override;
+
+  // Publishes one zero twist, then drops the subscription and publisher.
+  void onHalted() override;
+
+private:
+  std::string frame_id_;
+  double max_linear_velocity_ = 0.0;
+  double max_angular_velocity_ = 0.0;
+
+  rclcpp::Subscription<moveit_pro_controllers_msgs::msg::VelocityForceCommand>::SharedPtr command_subscription_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_publisher_;
+
+  std::mutex command_mutex_;
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand latest_command_;
+  bool has_new_command_ = false;
+};
+
+}  // namespace lunar_sim_behaviors

--- a/src/lunar_sim_behaviors/package.xml
+++ b/src/lunar_sim_behaviors/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>moveit_pro_behavior</depend>
   <depend>moveit_pro_behavior_interface</depend>
+  <depend>moveit_pro_controllers_msgs</depend>
   <depend>pluginlib</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/lunar_sim_behaviors/src/register_behaviors.cpp
+++ b/src/lunar_sim_behaviors/src/register_behaviors.cpp
@@ -31,6 +31,7 @@
 #include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
 
 #include <lunar_sim_behaviors/publish_twist_stamped.hpp>
+#include <lunar_sim_behaviors/teleoperate_base.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 
@@ -43,6 +44,7 @@ public:
                          const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources) override
   {
     moveit_pro::behaviors::registerBehavior<PublishTwistStamped>(factory, "PublishTwistStamped", shared_resources);
+    moveit_pro::behaviors::registerBehavior<TeleoperateBase>(factory, "TeleoperateBase", shared_resources);
   }
 };
 }  // namespace lunar_sim_behaviors

--- a/src/lunar_sim_behaviors/src/teleoperate_base.cpp
+++ b/src/lunar_sim_behaviors/src/teleoperate_base.cpp
@@ -94,14 +94,15 @@ BT::NodeStatus TeleoperateBase::onStart()
 {
   has_new_command_ = false;
 
-  const auto ports = moveit_pro::behaviors::getRequiredInputs(
-      getInput<std::string>(kPortIdPlanningGroup), getInput<std::string>(kPortIdCmdVelTopic),
-      getInput<std::string>(kPortIdFrameId), getInput<double>(kPortIdMaxLinearVelocity),
-      getInput<double>(kPortIdMaxAngularVelocity));
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdPlanningGroup),
+                                                              getInput<std::string>(kPortIdCmdVelTopic),
+                                                              getInput<std::string>(kPortIdFrameId),
+                                                              getInput<double>(kPortIdMaxLinearVelocity),
+                                                              getInput<double>(kPortIdMaxAngularVelocity));
   if (!ports.has_value())
   {
-    getBehaviorContext()->logger->publishFailureMessage(
-        name(), "Failed to get required value from input data port: " + ports.error());
+    getBehaviorContext()->logger->publishFailureMessage(name(), "Failed to get required value from input data port: " +
+                                                                    ports.error());
     return BT::NodeStatus::FAILURE;
   }
   const auto& [planning_group, cmd_vel_topic, frame_id, max_linear_velocity, max_angular_velocity] = ports.value();

--- a/src/lunar_sim_behaviors/src/teleoperate_base.cpp
+++ b/src/lunar_sim_behaviors/src/teleoperate_base.cpp
@@ -58,8 +58,10 @@ geometry_msgs::msg::Twist clampTwistCommand(const moveit_pro_controllers_msgs::m
                                             const double max_linear_velocity, const double max_angular_velocity)
 {
   geometry_msgs::msg::Twist twist;
-  twist.linear.x = std::clamp(command.twist.linear.x, -max_linear_velocity, max_linear_velocity);
-  twist.angular.z = std::clamp(command.twist.angular.z, -max_angular_velocity, max_angular_velocity);
+  twist.linear.x = std::clamp(command.twist.linear.x * static_cast<double>(command.velocity_controlled_axes.x),
+                              -max_linear_velocity, max_linear_velocity);
+  twist.angular.z = std::clamp(command.twist.angular.z * static_cast<double>(command.velocity_controlled_axes.rz),
+                               -max_angular_velocity, max_angular_velocity);
   return twist;
 }
 

--- a/src/lunar_sim_behaviors/src/teleoperate_base.cpp
+++ b/src/lunar_sim_behaviors/src/teleoperate_base.cpp
@@ -29,6 +29,7 @@
 #include <lunar_sim_behaviors/teleoperate_base.hpp>
 
 #include <algorithm>
+#include <cmath>
 
 #include <fmt/format.h>
 
@@ -92,7 +93,12 @@ BT::KeyValueVector TeleoperateBase::metadata()
 
 BT::NodeStatus TeleoperateBase::onStart()
 {
-  has_new_command_ = false;
+  std::uint64_t generation = 0;
+  {
+    const std::scoped_lock lock(command_mutex_);
+    has_new_command_ = false;
+    generation = ++activation_generation_;
+  }
 
   const auto ports = moveit_pro::behaviors::getRequiredInputs(getInput<std::string>(kPortIdPlanningGroup),
                                                               getInput<std::string>(kPortIdCmdVelTopic),
@@ -106,6 +112,13 @@ BT::NodeStatus TeleoperateBase::onStart()
     return BT::NodeStatus::FAILURE;
   }
   const auto& [planning_group, cmd_vel_topic, frame_id, max_linear_velocity, max_angular_velocity] = ports.value();
+  if (!std::isfinite(max_linear_velocity) || max_linear_velocity < 0.0 || !std::isfinite(max_angular_velocity) ||
+      max_angular_velocity < 0.0)
+  {
+    getBehaviorContext()->logger->publishFailureMessage(
+        name(), "max_linear_velocity and max_angular_velocity must be finite and non-negative.");
+    return BT::NodeStatus::FAILURE;
+  }
   frame_id_ = frame_id;
   max_linear_velocity_ = max_linear_velocity;
   max_angular_velocity_ = max_angular_velocity;
@@ -114,16 +127,27 @@ BT::NodeStatus TeleoperateBase::onStart()
   command_subscription_ =
       getBehaviorContext()->node->create_subscription<moveit_pro_controllers_msgs::msg::VelocityForceCommand>(
           command_topic, kQoSProfile,
-          [this](const moveit_pro_controllers_msgs::msg::VelocityForceCommand::SharedPtr msg) {
-            const std::scoped_lock lock(command_mutex_);
-            latest_command_ = *msg;
-            has_new_command_ = true;
+          [this, generation](const moveit_pro_controllers_msgs::msg::VelocityForceCommand::SharedPtr msg) {
+            handleCommand(generation, *msg);
           });
 
   cmd_vel_publisher_ =
       getBehaviorContext()->node->create_publisher<geometry_msgs::msg::TwistStamped>(cmd_vel_topic, kQoSProfile);
 
   return BT::NodeStatus::RUNNING;
+}
+
+void TeleoperateBase::handleCommand(const std::uint64_t callback_generation,
+                                    const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command)
+{
+  const std::scoped_lock lock(command_mutex_);
+  if (callback_generation != activation_generation_)
+  {
+    // A callback still in flight from a halted/superseded activation; drop it rather than resurrect stale state.
+    return;
+  }
+  latest_command_ = command;
+  has_new_command_ = true;
 }
 
 BT::NodeStatus TeleoperateBase::onRunning()

--- a/src/lunar_sim_behaviors/src/teleoperate_base.cpp
+++ b/src/lunar_sim_behaviors/src/teleoperate_base.cpp
@@ -1,0 +1,163 @@
+// Copyright 2026 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <lunar_sim_behaviors/teleoperate_base.hpp>
+
+#include <algorithm>
+
+#include <fmt/format.h>
+
+#include <moveit_pro_behavior_interface/get_required_ports.hpp>
+#include <moveit_pro_behavior_interface/metadata_fields.hpp>
+
+namespace lunar_sim_behaviors
+{
+namespace
+{
+inline constexpr auto kDescriptionTeleoperateBase = R"(
+                <p>
+                    Drives a differential-drive base's <code>cmd_vel</code> from the VelocityForceCommand stream
+                    published on <code>/pose_jog/&lt;planning_group&gt;</code> by the Desktop App's Pose tab,
+                    gamepad, and Quest headset teleoperation sources.
+                </p>
+            )";
+
+constexpr auto kCommandTopicPrefix = "/pose_jog/";
+
+// Use system-defaults QoS, matching PoseJog's VelocityForceCommand subscription.
+const auto kQoSProfile = rclcpp::SystemDefaultsQoS();
+
+}  // namespace
+
+geometry_msgs::msg::Twist clampTwistCommand(const moveit_pro_controllers_msgs::msg::VelocityForceCommand& command,
+                                            const double max_linear_velocity, const double max_angular_velocity)
+{
+  geometry_msgs::msg::Twist twist;
+  twist.linear.x = std::clamp(command.twist.linear.x, -max_linear_velocity, max_linear_velocity);
+  twist.angular.z = std::clamp(command.twist.angular.z, -max_angular_velocity, max_angular_velocity);
+  return twist;
+}
+
+TeleoperateBase::TeleoperateBase(const std::string& name, const BT::NodeConfiguration& config,
+                                 const std::shared_ptr<moveit_pro::behaviors::BehaviorContext>& shared_resources)
+  : moveit_pro::behaviors::SharedResourcesNode<BT::StatefulActionNode>(name, config, shared_resources)
+{
+}
+
+BT::PortsList TeleoperateBase::providedPorts()
+{
+  return {
+    BT::InputPort<std::string>(kPortIdPlanningGroup, "base",
+                               "Planning group whose jog commands to follow. Subscribes to "
+                               "/pose_jog/<planning_group>."),
+    BT::InputPort<std::string>(kPortIdCmdVelTopic, "/cmd_vel", "Topic to publish the resulting TwistStamped to."),
+    BT::InputPort<std::string>(kPortIdFrameId, "footprint", "Frame ID to stamp the published TwistStamped with."),
+    BT::InputPort<double>(kPortIdMaxLinearVelocity, 0.8, "Maximum magnitude, in m/s, for the forwarded linear.x."),
+    BT::InputPort<double>(kPortIdMaxAngularVelocity, 2.0, "Maximum magnitude, in rad/s, for the forwarded angular.z."),
+  };
+}
+
+BT::KeyValueVector TeleoperateBase::metadata()
+{
+  return { { moveit_pro::behaviors::kSubcategoryMetadataKey, "MuJoCo Simulation" },
+           { moveit_pro::behaviors::kDescriptionMetadataKey, kDescriptionTeleoperateBase } };
+}
+
+BT::NodeStatus TeleoperateBase::onStart()
+{
+  has_new_command_ = false;
+
+  const auto ports = moveit_pro::behaviors::getRequiredInputs(
+      getInput<std::string>(kPortIdPlanningGroup), getInput<std::string>(kPortIdCmdVelTopic),
+      getInput<std::string>(kPortIdFrameId), getInput<double>(kPortIdMaxLinearVelocity),
+      getInput<double>(kPortIdMaxAngularVelocity));
+  if (!ports.has_value())
+  {
+    getBehaviorContext()->logger->publishFailureMessage(
+        name(), "Failed to get required value from input data port: " + ports.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& [planning_group, cmd_vel_topic, frame_id, max_linear_velocity, max_angular_velocity] = ports.value();
+  frame_id_ = frame_id;
+  max_linear_velocity_ = max_linear_velocity;
+  max_angular_velocity_ = max_angular_velocity;
+
+  const std::string command_topic = fmt::format("{}{}", kCommandTopicPrefix, planning_group);
+  command_subscription_ =
+      getBehaviorContext()->node->create_subscription<moveit_pro_controllers_msgs::msg::VelocityForceCommand>(
+          command_topic, kQoSProfile,
+          [this](const moveit_pro_controllers_msgs::msg::VelocityForceCommand::SharedPtr msg) {
+            const std::scoped_lock lock(command_mutex_);
+            latest_command_ = *msg;
+            has_new_command_ = true;
+          });
+
+  cmd_vel_publisher_ =
+      getBehaviorContext()->node->create_publisher<geometry_msgs::msg::TwistStamped>(cmd_vel_topic, kQoSProfile);
+
+  return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus TeleoperateBase::onRunning()
+{
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand command;
+  {
+    const std::scoped_lock lock(command_mutex_);
+    if (!has_new_command_)
+    {
+      return BT::NodeStatus::RUNNING;
+    }
+    command = latest_command_;
+    has_new_command_ = false;
+  }
+
+  // Jazzy diff_drive_controller drops commands older than its cmd_vel_timeout (0.5s), so this message must be
+  // created here, with the current time, rather than forwarding the browser's original stamp.
+  geometry_msgs::msg::TwistStamped twist_stamped;
+  twist_stamped.header.stamp = getBehaviorContext()->node->now();
+  twist_stamped.header.frame_id = frame_id_;
+  twist_stamped.twist = clampTwistCommand(command, max_linear_velocity_, max_angular_velocity_);
+  cmd_vel_publisher_->publish(twist_stamped);
+
+  return BT::NodeStatus::RUNNING;
+}
+
+void TeleoperateBase::onHalted()
+{
+  if (cmd_vel_publisher_)
+  {
+    geometry_msgs::msg::TwistStamped zero_twist_stamped;
+    zero_twist_stamped.header.stamp = getBehaviorContext()->node->now();
+    zero_twist_stamped.header.frame_id = frame_id_;
+    cmd_vel_publisher_->publish(zero_twist_stamped);
+  }
+  command_subscription_.reset();
+  cmd_vel_publisher_.reset();
+}
+
+}  // namespace lunar_sim_behaviors

--- a/src/lunar_sim_behaviors/test/CMakeLists.txt
+++ b/src/lunar_sim_behaviors/test/CMakeLists.txt
@@ -8,4 +8,5 @@ target_link_libraries(test_teleoperate_base_twist_mapping lunar_sim_behaviors)
 ament_target_dependencies(test_teleoperate_base_twist_mapping ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 ament_add_gtest(test_teleoperate_base_ros test_teleoperate_base_ros.cpp)
+target_link_libraries(test_teleoperate_base_ros lunar_sim_behaviors)
 ament_target_dependencies(test_teleoperate_base_ros ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/lunar_sim_behaviors/test/CMakeLists.txt
+++ b/src/lunar_sim_behaviors/test/CMakeLists.txt
@@ -2,3 +2,7 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(test_behavior_plugins test_behavior_plugins.cpp)
 ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_add_gtest(test_teleoperate_base_twist_mapping test_teleoperate_base_twist_mapping.cpp)
+target_link_libraries(test_teleoperate_base_twist_mapping lunar_sim_behaviors)
+ament_target_dependencies(test_teleoperate_base_twist_mapping ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/lunar_sim_behaviors/test/CMakeLists.txt
+++ b/src/lunar_sim_behaviors/test/CMakeLists.txt
@@ -6,3 +6,6 @@ ament_target_dependencies(test_behavior_plugins ${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_add_gtest(test_teleoperate_base_twist_mapping test_teleoperate_base_twist_mapping.cpp)
 target_link_libraries(test_teleoperate_base_twist_mapping lunar_sim_behaviors)
 ament_target_dependencies(test_teleoperate_base_twist_mapping ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_add_gtest(test_teleoperate_base_ros test_teleoperate_base_ros.cpp)
+ament_target_dependencies(test_teleoperate_base_ros ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/lunar_sim_behaviors/test/test_behavior_plugins.cpp
+++ b/src/lunar_sim_behaviors/test/test_behavior_plugins.cpp
@@ -53,6 +53,8 @@ TEST(BehaviorTests, test_load_behavior_plugins)
   // Test that ClassLoader is able to find and instantiate each Behavior using the package's plugin description info.
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "PublishTwistStamped", BT::NodeConfiguration()));
+  EXPECT_NO_THROW(
+      (void)factory.instantiateTreeNode("test_behavior_name", "TeleoperateBase", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)

--- a/src/lunar_sim_behaviors/test/test_behavior_plugins.cpp
+++ b/src/lunar_sim_behaviors/test/test_behavior_plugins.cpp
@@ -53,8 +53,7 @@ TEST(BehaviorTests, test_load_behavior_plugins)
   // Test that ClassLoader is able to find and instantiate each Behavior using the package's plugin description info.
   EXPECT_NO_THROW(
       (void)factory.instantiateTreeNode("test_behavior_name", "PublishTwistStamped", BT::NodeConfiguration()));
-  EXPECT_NO_THROW(
-      (void)factory.instantiateTreeNode("test_behavior_name", "TeleoperateBase", BT::NodeConfiguration()));
+  EXPECT_NO_THROW((void)factory.instantiateTreeNode("test_behavior_name", "TeleoperateBase", BT::NodeConfiguration()));
 }
 
 int main(int argc, char** argv)

--- a/src/lunar_sim_behaviors/test/test_teleoperate_base_ros.cpp
+++ b/src/lunar_sim_behaviors/test/test_teleoperate_base_ros.cpp
@@ -1,0 +1,192 @@
+// Copyright 2026 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <behaviortree_cpp/bt_factory.h>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
+#include <moveit_pro_controllers_msgs/msg/velocity_force_command.hpp>
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+/**
+ * @brief Runs the real TeleoperateBase Behavior over ROS: a VelocityForceCommand on /pose_jog/base must come out as a
+ * clamped, freshly-stamped TwistStamped on /cmd_vel, nothing is re-published until a new command arrives, and halting
+ * publishes a single zero twist.
+ */
+class TeleoperateBaseRosTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    behavior_node_ = std::make_shared<rclcpp::Node>("behavior_node");
+    test_node_ = std::make_shared<rclcpp::Node>("test_node");
+    executor_.add_node(behavior_node_);
+    executor_.add_node(test_node_);
+    spin_thread_ = std::thread([this] { executor_.spin(); });
+
+    command_publisher_ = test_node_->create_publisher<moveit_pro_controllers_msgs::msg::VelocityForceCommand>(
+        "/pose_jog/base", rclcpp::SystemDefaultsQoS());
+    cmd_vel_subscription_ = test_node_->create_subscription<geometry_msgs::msg::TwistStamped>(
+        "/cmd_vel", rclcpp::SystemDefaultsQoS(), [this](const geometry_msgs::msg::TwistStamped& msg) {
+          const std::scoped_lock lock(mutex_);
+          received_.push_back(msg);
+        });
+
+    shared_resources_ = std::make_shared<moveit_pro::behaviors::BehaviorContext>(behavior_node_, false);
+    class_loader_ = std::make_unique<pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase>>(
+        "moveit_pro_behavior_interface", "moveit_pro::behaviors::SharedResourcesNodeLoaderBase");
+    plugin_ = class_loader_->createUniqueInstance("lunar_sim_behaviors::LunarSimBehaviorsLoader");
+    plugin_->registerBehaviors(factory_, shared_resources_);
+    tree_ = factory_.createTreeFromText(R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="Test">
+          <Action ID="TeleoperateBase" planning_group="base" cmd_vel_topic="/cmd_vel" frame_id="footprint"
+                  max_linear_velocity="0.8" max_angular_velocity="2.0" />
+        </BehaviorTree>
+      </root>)");
+  }
+
+  void TearDown() override
+  {
+    executor_.cancel();
+    spin_thread_.join();
+  }
+
+  // Ticks the tree until /cmd_vel has delivered `count` messages, or the deadline passes.
+  bool tickUntilReceived(const std::size_t count, const std::chrono::milliseconds timeout = 5s)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      tree_.tickOnce();
+      {
+        const std::scoped_lock lock(mutex_);
+        if (received_.size() >= count)
+        {
+          return true;
+        }
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return false;
+  }
+
+  std::size_t receivedCount()
+  {
+    const std::scoped_lock lock(mutex_);
+    return received_.size();
+  }
+
+  geometry_msgs::msg::TwistStamped received(const std::size_t index)
+  {
+    const std::scoped_lock lock(mutex_);
+    return received_.at(index);
+  }
+
+  rclcpp::Node::SharedPtr behavior_node_;
+  rclcpp::Node::SharedPtr test_node_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
+  std::thread spin_thread_;
+  rclcpp::Publisher<moveit_pro_controllers_msgs::msg::VelocityForceCommand>::SharedPtr command_publisher_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_subscription_;
+  std::mutex mutex_;
+  std::vector<geometry_msgs::msg::TwistStamped> received_;
+
+  std::shared_ptr<moveit_pro::behaviors::BehaviorContext> shared_resources_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_pro::behaviors::SharedResourcesNodeLoaderBase>> class_loader_;
+  pluginlib::UniquePtr<moveit_pro::behaviors::SharedResourcesNodeLoaderBase> plugin_;
+  BT::BehaviorTreeFactory factory_;
+  BT::Tree tree_;
+};
+
+TEST_F(TeleoperateBaseRosTest, ForwardsRestampedClampedTwistAndZeroesOnHalt)
+{
+  // onStart: subscription + publisher come up, Behavior stays RUNNING and publishes nothing on its own.
+  ASSERT_EQ(tree_.tickOnce(), BT::NodeStatus::RUNNING);
+  const auto discovery_deadline = std::chrono::steady_clock::now() + 5s;
+  while (command_publisher_->get_subscription_count() == 0 && std::chrono::steady_clock::now() < discovery_deadline)
+  {
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_GT(command_publisher_->get_subscription_count(), 0u);
+  EXPECT_FALSE(tickUntilReceived(1, 300ms));
+
+  // A command with a stale stamp (the browser's clock) and an over-limit linear.x.
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand command;
+  command.header.stamp = behavior_node_->now() - rclcpp::Duration(100s);
+  command.velocity_controlled_axes.x = true;
+  command.velocity_controlled_axes.rz = true;
+  command.twist.linear.x = 5.0;
+  command.twist.angular.z = -0.5;
+  command.twist.linear.y = 1.0;
+  command_publisher_->publish(command);
+
+  ASSERT_TRUE(tickUntilReceived(1));
+  const auto forwarded = received(0);
+  EXPECT_EQ(forwarded.header.frame_id, "footprint");
+  EXPECT_DOUBLE_EQ(forwarded.twist.linear.x, 0.8);
+  EXPECT_DOUBLE_EQ(forwarded.twist.angular.z, -0.5);
+  EXPECT_DOUBLE_EQ(forwarded.twist.linear.y, 0.0);
+  EXPECT_LT((behavior_node_->now() - rclcpp::Time(forwarded.header.stamp)).seconds(), 1.0);
+
+  // No new command -> nothing more is published, however many ticks happen.
+  EXPECT_FALSE(tickUntilReceived(2, 300ms));
+  EXPECT_EQ(receivedCount(), 1u);
+
+  // Halting stops the base with exactly one zero twist.
+  tree_.haltTree();
+  const auto halt_deadline = std::chrono::steady_clock::now() + 5s;
+  while (receivedCount() < 2 && std::chrono::steady_clock::now() < halt_deadline)
+  {
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_EQ(receivedCount(), 2u);
+  const auto zero = received(1);
+  EXPECT_EQ(zero.header.frame_id, "footprint");
+  EXPECT_DOUBLE_EQ(zero.twist.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(zero.twist.angular.z, 0.0);
+  EXPECT_LT((behavior_node_->now() - rclcpp::Time(zero.header.stamp)).seconds(), 1.0);
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/src/lunar_sim_behaviors/test/test_teleoperate_base_ros.cpp
+++ b/src/lunar_sim_behaviors/test/test_teleoperate_base_ros.cpp
@@ -35,6 +35,7 @@
 
 #include <behaviortree_cpp/bt_factory.h>
 #include <geometry_msgs/msg/twist_stamped.hpp>
+#include <lunar_sim_behaviors/teleoperate_base.hpp>
 #include <moveit_pro_behavior_interface/shared_resources_node_loader.hpp>
 #include <moveit_pro_controllers_msgs/msg/velocity_force_command.hpp>
 #include <pluginlib/class_loader.hpp>
@@ -180,6 +181,55 @@ TEST_F(TeleoperateBaseRosTest, ForwardsRestampedClampedTwistAndZeroesOnHalt)
   EXPECT_DOUBLE_EQ(zero.twist.linear.x, 0.0);
   EXPECT_DOUBLE_EQ(zero.twist.angular.z, 0.0);
   EXPECT_LT((behavior_node_->now() - rclcpp::Time(zero.header.stamp)).seconds(), 1.0);
+}
+
+// Regression test for a callback still in flight from a halted activation landing after a restart: it must not
+// resurrect latest_command_/has_new_command_ for the new activation, and must never reach /cmd_vel.
+TEST_F(TeleoperateBaseRosTest, StaleGenerationCallbackIsIgnoredAfterRestart)
+{
+  ASSERT_EQ(tree_.tickOnce(), BT::NodeStatus::RUNNING);
+  auto* const behavior = dynamic_cast<lunar_sim_behaviors::TeleoperateBase*>(tree_.rootNode());
+  ASSERT_NE(behavior, nullptr);
+  const std::uint64_t stale_generation = behavior->activationGenerationForTesting();
+
+  // Halting on its own publishes one zero twist; that is the baseline the stale callback must not add to.
+  tree_.haltTree();
+  const auto halt_deadline = std::chrono::steady_clock::now() + 5s;
+  while (receivedCount() < 1 && std::chrono::steady_clock::now() < halt_deadline)
+  {
+    std::this_thread::sleep_for(10ms);
+  }
+  const std::size_t baseline_count = receivedCount();
+  ASSERT_EQ(baseline_count, 1u);
+
+  ASSERT_EQ(tree_.tickOnce(), BT::NodeStatus::RUNNING);
+  EXPECT_NE(behavior->activationGenerationForTesting(), stale_generation);
+
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand stale_command;
+  stale_command.velocity_controlled_axes.x = true;
+  stale_command.twist.linear.x = 0.5;
+  // Simulates a callback from the pre-restart subscription delivering after the restart already happened.
+  behavior->handleCommandForTesting(stale_generation, stale_command);
+
+  EXPECT_FALSE(tickUntilReceived(baseline_count + 1, 300ms));
+  EXPECT_EQ(receivedCount(), baseline_count);
+}
+
+// Regression test for invalid velocity limit ports: a negative, NaN, or infinite max must fail onStart instead of
+// being handed to std::clamp, which requires lower <= upper and finite bounds.
+TEST_F(TeleoperateBaseRosTest, RejectsInvalidVelocityLimits)
+{
+  BT::BehaviorTreeFactory factory;
+  plugin_->registerBehaviors(factory, shared_resources_);
+  for (const std::string max_linear_velocity : { "-0.1", "nan", "inf" })
+  {
+    const std::string xml = "<root BTCPP_format=\"4\"><BehaviorTree ID=\"Test\">"
+                            "<Action ID=\"TeleoperateBase\" planning_group=\"base\" cmd_vel_topic=\"/cmd_vel\" "
+                            "frame_id=\"footprint\" max_linear_velocity=\"" +
+                            max_linear_velocity + "\" max_angular_velocity=\"2.0\" /></BehaviorTree></root>";
+    BT::Tree tree = factory.createTreeFromText(xml);
+    EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE) << "max_linear_velocity=" << max_linear_velocity;
+  }
 }
 
 int main(int argc, char** argv)

--- a/src/lunar_sim_behaviors/test/test_teleoperate_base_twist_mapping.cpp
+++ b/src/lunar_sim_behaviors/test/test_teleoperate_base_twist_mapping.cpp
@@ -40,6 +40,8 @@ moveit_pro_controllers_msgs::msg::VelocityForceCommand makeCommand(double linear
   moveit_pro_controllers_msgs::msg::VelocityForceCommand command;
   command.twist.linear.x = linear_x;
   command.twist.angular.z = angular_z;
+  command.velocity_controlled_axes.x = true;
+  command.velocity_controlled_axes.rz = true;
   return command;
 }
 
@@ -84,6 +86,21 @@ TEST(TeleoperateBaseTwistMapping, DropsAllOtherAxes)
   EXPECT_DOUBLE_EQ(twist.linear.z, 0.0);
   EXPECT_DOUBLE_EQ(twist.angular.x, 0.0);
   EXPECT_DOUBLE_EQ(twist.angular.y, 0.0);
+}
+
+TEST(TeleoperateBaseTwistMapping, DisabledAxisFlagZeroesComponent)
+{
+  auto command = makeCommand(0.5, 1.5);
+  command.velocity_controlled_axes.x = false;
+  const auto linear_disabled = clampTwistCommand(command, 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(linear_disabled.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(linear_disabled.angular.z, 1.5);
+
+  command = makeCommand(0.5, 1.5);
+  command.velocity_controlled_axes.rz = false;
+  const auto angular_disabled = clampTwistCommand(command, 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(angular_disabled.linear.x, 0.5);
+  EXPECT_DOUBLE_EQ(angular_disabled.angular.z, 0.0);
 }
 
 }  // namespace

--- a/src/lunar_sim_behaviors/test/test_teleoperate_base_twist_mapping.cpp
+++ b/src/lunar_sim_behaviors/test/test_teleoperate_base_twist_mapping.cpp
@@ -1,0 +1,90 @@
+// Copyright 2026 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <lunar_sim_behaviors/teleoperate_base.hpp>
+
+namespace lunar_sim_behaviors
+{
+namespace
+{
+
+moveit_pro_controllers_msgs::msg::VelocityForceCommand makeCommand(double linear_x, double angular_z)
+{
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand command;
+  command.twist.linear.x = linear_x;
+  command.twist.angular.z = angular_z;
+  return command;
+}
+
+TEST(TeleoperateBaseTwistMapping, PassesThroughWithinLimits)
+{
+  const auto twist = clampTwistCommand(makeCommand(0.3, -1.0), 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(twist.linear.x, 0.3);
+  EXPECT_DOUBLE_EQ(twist.angular.z, -1.0);
+}
+
+TEST(TeleoperateBaseTwistMapping, ClampsLinearVelocityToMax)
+{
+  const auto twist = clampTwistCommand(makeCommand(5.0, 0.0), 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(twist.linear.x, 0.8);
+}
+
+TEST(TeleoperateBaseTwistMapping, ClampsLinearVelocityToMin)
+{
+  const auto twist = clampTwistCommand(makeCommand(-5.0, 0.0), 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(twist.linear.x, -0.8);
+}
+
+TEST(TeleoperateBaseTwistMapping, ClampsAngularVelocityToLimits)
+{
+  const auto positive = clampTwistCommand(makeCommand(0.0, 10.0), 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(positive.angular.z, 2.0);
+
+  const auto negative = clampTwistCommand(makeCommand(0.0, -10.0), 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(negative.angular.z, -2.0);
+}
+
+TEST(TeleoperateBaseTwistMapping, DropsAllOtherAxes)
+{
+  moveit_pro_controllers_msgs::msg::VelocityForceCommand command = makeCommand(0.1, 0.1);
+  command.twist.linear.y = 1.0;
+  command.twist.linear.z = 1.0;
+  command.twist.angular.x = 1.0;
+  command.twist.angular.y = 1.0;
+
+  const auto twist = clampTwistCommand(command, 0.8, 2.0);
+  EXPECT_DOUBLE_EQ(twist.linear.y, 0.0);
+  EXPECT_DOUBLE_EQ(twist.linear.z, 0.0);
+  EXPECT_DOUBLE_EQ(twist.angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(twist.angular.y, 0.0);
+}
+
+}  // namespace
+}  // namespace lunar_sim_behaviors


### PR DESCRIPTION
Follow-up to PR 869 (merged).

## What changed

- New `TeleoperateBase` Behavior in `lunar_sim_behaviors`. It subscribes to `/pose_jog/base`, the topic the Desktop App's Pose tab, gamepad and Quest headset already publish jog commands on, and forwards each new command to `/cmd_vel` as a `TwistStamped` with a fresh stamp and the `footprint` frame. `linear.x` and `angular.z` are gated by the command's enabled-axis flags, clamped to the configured limits, and every other axis is dropped.
- `Request Teleoperation` in `lunar_sim` no longer fails on purpose. It runs core's `DoTeleoperateAction` in parallel with `TeleoperateBase`, which is active only while the Pose tab is selected. Ports and metadata are unchanged so core's `Teleoperate` still resolves.
- README teleoperation section rewritten for base driving; comments in `pose_jog.yaml`, `joint_jog.yaml` and `config.yaml` corrected to match the real dataflow.

## Controls

The base is driven through the arm-shaped jog controls, so the mapping is by frame axis:

- Jog pad: `X+` / `X-` forward and reverse, `Roll+` / `Roll-` turn left and right.
- Gamepad: left stick left/right forward and reverse, bumpers turn.
- Joint, Interactive Marker and Waypoints tabs do nothing on this base.
- Speed: the Pose tab slider caps at 0.25 m/s by default; the Behavior clamps to 0.8 m/s and 2.0 rad/s regardless.

## Safety

- Leaving the Pose tab or ending teleoperation publishes one zero twist before the Behavior tears down its publisher and subscription.
- Commands are restamped with the current time so `diff_drive_controller` does not drop them, and its 0.5 s `cmd_vel_timeout` stops the base if commands stop arriving.

## Testing

- gtest on the clamp mapping: pass-through, both linear and angular clamps, dropped axes, disabled axis flags.
- Plugin instantiation test and a ROS-level test that runs the Behavior end to end (forwarding, no republish without a new command, zero twist on halt).
- The full `Teleoperate` tree run against a scripted Desktop App session: commands reach `/cmd_vel` restamped and clamped, nothing is forwarded from other tabs, the objective finishes SUCCESS.
- CI green.
