### PR TITLE
Fix: Label every SAM3 burner mask in kitchen_sim Segment Image from Prompt

### DIFF
--- a/src/kitchen_sim/objectives/segment_image_from_prompt.xml
+++ b/src/kitchen_sim/objectives/segment_image_from_prompt.xml
@@ -29,7 +29,7 @@
         masks="{masks2d}"
         masks_visualization_topic="/masks_visualization"
         opacity="0.500000"
-        bounding_box_labels="stove"
+        bounding_box_detection_class="burner"
       />
       <Action
         ID="SwitchUIPrimaryView"


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#22611.

## Motivation

`kitchen_sim`'s favourited Objective **Segment Image from Prompt** segments the stove burners with SAM3, which returns one mask per detected burner, but visualises them with `bounding_box_labels="stove"`, a single entry for a per-mask vector port. `PublishMask2D` pads the missing labels with empty strings and draws no box or text for those, so only the first burner is annotated and the other three are bare coloured overlays. The Objective still succeeds, so nothing flags it. The label predates the SAM3 port (`bb0d53c0`): CLIPSeg returned one mask per prompt, so a single label used to be enough.

## Brief description

One attribute in `src/kitchen_sim/objectives/segment_image_from_prompt.xml`: `bounding_box_labels="stove"` becomes `bounding_box_detection_class="burner"`, which stamps `burner 0` to `burner 3` on every mask and names what the prompt actually segments. Same change as the 9.4 line in #935, so both release lines match.

## How it was tested

- `pre-commit run` on the file passes (prettier, codespell, objective-favourites check).
- Ran **Segment Image from Prompt** before and after the change on a local 10.1 Runtime with GPU rendering and captured `/masks_visualization`. Before: one `stove` box. After: four `burner N` boxes. Frames attached below.
- `src/kitchen_sim/test/objectives_integration_test.py` runs this Objective as a smoke test in CI, but it does not assert on the rendered annotations, so the frames are the evidence for the visual change.

## Release notes

- `Bug Fix:` Fixed the `kitchen_sim` Objective `Segment Image from Prompt` labelling only the first detected burner; every SAM3 mask now gets a numbered `burner` label.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these.*

- [x] `code-reviewer`
  - no findings; port semantics verified against `publish_mask2d.cpp` on `main`
- [x] SKIPPED `documentation-bot`
  - no documented user-facing behaviour changes; the Objective name, prompt, and outputs are unchanged, only the overlay labels
- [x] SKIPPED `licensing-privacy-bot`
  - no new components, models, or data flows
- [x] SKIPPED `platform-architect-bot`
  - one XML attribute on an existing visualisation Behavior; the equivalent 9.4 change in #935 was reviewed by this bot, which proposed it
- [x] SKIPPED `roboticist-bot`
  - same: this bot reviewed and named the `burner` class on #935
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] SKIPPED `compatibility-bot`
  - the Objective's ports and outputs are unchanged; only rendered annotation text differs
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, or TypeScript changed
- [x] `test-runner`
  - `colcon build --packages-up-to kitchen_sim` and `colcon test --packages-select kitchen_sim` in the 10.1.0-rc5 Jazzy workspace image: `objectives_integration_test`, `copyright`, `lint_cmake` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
