### PR TITLE
Fix: Port the UR and Franka base-config text-prompt SubTrees to SAM3 on 9.4

### DIFF
--- a/src/moveit_pro_franka_configs/franka_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/moveit_pro_franka_configs/franka_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -6,7 +6,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Image from No Negative Text Prompt Subtree"
-    _description="Run text based segmentation and visualize the masks."
+    _description="Run SAM3 text-based segmentation and visualize the masks. Returns SUCCESS with an empty masks2d and mask_count 0 when no detection passes confidence_threshold, a per-detection confidence in [0, 1]."
     _favorite="false"
   >
     <Control ID="Sequence">
@@ -17,15 +17,17 @@
         message_out="{image}"
       />
       <Action
-        ID="GetMasks2DFromTextQuery"
-        image="{image}"
-        masks2d="{masks2d}"
-        clipseg_model_path="{clipseg_model_path}"
-        clip_model_path="{clip_model_path}"
+        ID="GetMasks2DFromExemplar"
         model_package="{model_package}"
-        prompts="{prompts}"
-        erosion_size="{erosion_size}"
-        threshold="{threshold}"
+        encoder_model_path="{encoder_model_path}"
+        decoder_model_path="{decoder_model_path}"
+        geometry_encoder_model_path="{geometry_encoder_model_path}"
+        text_encoder_model_path="{text_encoder_model_path}"
+        confidence_threshold="{confidence_threshold}"
+        target_image="{image}"
+        text_prompt="{text_prompt}"
+        masks2d="{masks2d}"
+        mask_count="{mask_count}"
       />
       <Action
         ID="PublishMask2D"
@@ -33,7 +35,7 @@
         masks="{masks2d}"
         masks_visualization_topic="{masks_visualization_topic}"
         opacity="0.500000"
-        bounding_box_detection_class="{prompts}"
+        bounding_box_detection_class="{text_prompt}"
       />
     </Control>
   </BehaviorTree>
@@ -43,22 +45,32 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <MetadataFields>
-        <Metadata runnable="false" />
-        <Metadata subcategory="Perception - ML" />
-      </MetadataFields>
-      <inout_port name="clip_model_path" default="{clip_model_path}" />
-      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="confidence_threshold" default="0.5" />
+      <inout_port
+        name="decoder_model_path"
+        default="models/sam3_decoder.onnx"
+      />
+      <inout_port
+        name="encoder_model_path"
+        default="models/sam3_vision_encoder.onnx"
+      />
+      <inout_port
+        name="geometry_encoder_model_path"
+        default="models/sam3_geometry_encoder.onnx"
+      />
       <inout_port name="image_topic_name" default="{image_topic_name}" />
       <inout_port
         name="masks_visualization_topic"
-        default="{masks_visualization_topic}"
+        default="/masks_visualization"
       />
       <inout_port name="masks2d" default="{masks2d}" />
-      <inout_port name="model_package" default="{model_package}" />
-      <inout_port name="prompts" default="{prompts}" />
-      <inout_port name="threshold" default="{threshold}" />
+      <inout_port name="mask_count" default="{mask_count}" />
+      <inout_port name="model_package" default="moveit_pro_sam3" />
+      <inout_port
+        name="text_encoder_model_path"
+        default="models/sam3_text_encoder.onnx"
+      />
+      <inout_port name="text_prompt" default="{text_prompt}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_franka_configs/franka_base_config/package.xml
+++ b/src/moveit_pro_franka_configs/franka_base_config/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
+  <exec_depend>moveit_pro_sam3</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -6,7 +6,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Image from No Negative Text Prompt Subtree"
-    _description="Run text based segmentation and visualize the masks."
+    _description="Run SAM3 text-based segmentation and visualize the masks. Returns SUCCESS with an empty masks2d and mask_count 0 when no detection passes confidence_threshold, a per-detection confidence in [0, 1]."
     _favorite="false"
   >
     <Control ID="Sequence">
@@ -17,15 +17,17 @@
         message_out="{image}"
       />
       <Action
-        ID="GetMasks2DFromTextQuery"
-        image="{image}"
-        masks2d="{masks2d}"
-        clipseg_model_path="{clipseg_model_path}"
-        clip_model_path="{clip_model_path}"
+        ID="GetMasks2DFromExemplar"
         model_package="{model_package}"
-        prompts="{prompts}"
-        erosion_size="{erosion_size}"
-        threshold="{threshold}"
+        encoder_model_path="{encoder_model_path}"
+        decoder_model_path="{decoder_model_path}"
+        geometry_encoder_model_path="{geometry_encoder_model_path}"
+        text_encoder_model_path="{text_encoder_model_path}"
+        confidence_threshold="{confidence_threshold}"
+        target_image="{image}"
+        text_prompt="{text_prompt}"
+        masks2d="{masks2d}"
+        mask_count="{mask_count}"
       />
       <Action
         ID="PublishMask2D"
@@ -33,7 +35,7 @@
         masks="{masks2d}"
         masks_visualization_topic="{masks_visualization_topic}"
         opacity="0.500000"
-        bounding_box_detection_class="{prompts}"
+        bounding_box_detection_class="{text_prompt}"
       />
     </Control>
   </BehaviorTree>
@@ -43,22 +45,32 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <MetadataFields>
-        <Metadata runnable="false" />
-        <Metadata subcategory="Perception - ML" />
-      </MetadataFields>
-      <inout_port name="clip_model_path" default="{clip_model_path}" />
-      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="confidence_threshold" default="0.5" />
+      <inout_port
+        name="decoder_model_path"
+        default="models/sam3_decoder.onnx"
+      />
+      <inout_port
+        name="encoder_model_path"
+        default="models/sam3_vision_encoder.onnx"
+      />
+      <inout_port
+        name="geometry_encoder_model_path"
+        default="models/sam3_geometry_encoder.onnx"
+      />
       <inout_port name="image_topic_name" default="{image_topic_name}" />
       <inout_port
         name="masks_visualization_topic"
-        default="{masks_visualization_topic}"
+        default="/masks_visualization"
       />
       <inout_port name="masks2d" default="{masks2d}" />
-      <inout_port name="model_package" default="{model_package}" />
-      <inout_port name="prompts" default="{prompts}" />
-      <inout_port name="threshold" default="{threshold}" />
+      <inout_port name="mask_count" default="{mask_count}" />
+      <inout_port name="model_package" default="moveit_pro_sam3" />
+      <inout_port
+        name="text_encoder_model_path"
+        default="models/sam3_text_encoder.onnx"
+      />
+      <inout_port name="text_prompt" default="{text_prompt}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_image_from_text_prompt_subtree.xml
@@ -6,7 +6,7 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Image from Text Prompt Subtree"
-    _description="Run text based segmentation and visualize the masks."
+    _description="Run SAM3 text-based segmentation and visualize the masks. Returns SUCCESS with an empty masks2d and mask_count 0 when no detection passes confidence_threshold, a per-detection confidence in [0, 1]."
     _favorite="false"
   >
     <Control ID="Sequence">
@@ -17,16 +17,17 @@
         message_out="{image}"
       />
       <Action
-        ID="GetMasks2DFromTextQuery"
-        image="{image}"
-        masks2d="{masks2d}"
-        clipseg_model_path="{clipseg_model_path}"
-        clip_model_path="{clip_model_path}"
+        ID="GetMasks2DFromExemplar"
         model_package="{model_package}"
-        negative_prompts="{negative_prompts}"
-        prompts="{prompts}"
-        erosion_size="{erosion_size}"
-        threshold="{threshold}"
+        encoder_model_path="{encoder_model_path}"
+        decoder_model_path="{decoder_model_path}"
+        geometry_encoder_model_path="{geometry_encoder_model_path}"
+        text_encoder_model_path="{text_encoder_model_path}"
+        confidence_threshold="{confidence_threshold}"
+        target_image="{image}"
+        text_prompt="{text_prompt}"
+        masks2d="{masks2d}"
+        mask_count="{mask_count}"
       />
       <Action
         ID="PublishMask2D"
@@ -42,19 +43,32 @@
         <Metadata runnable="false" />
         <Metadata subcategory="Perception - ML" />
       </MetadataFields>
-      <inout_port name="clip_model_path" default="{clip_model_path}" />
-      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="confidence_threshold" default="0.5" />
+      <inout_port
+        name="decoder_model_path"
+        default="models/sam3_decoder.onnx"
+      />
+      <inout_port
+        name="encoder_model_path"
+        default="models/sam3_vision_encoder.onnx"
+      />
+      <inout_port
+        name="geometry_encoder_model_path"
+        default="models/sam3_geometry_encoder.onnx"
+      />
       <inout_port name="image_topic_name" default="{image_topic_name}" />
       <inout_port
         name="masks_visualization_topic"
-        default="{masks_visualization_topic}"
+        default="/masks_visualization"
       />
       <inout_port name="masks2d" default="{masks2d}" />
-      <inout_port name="model_package" default="{model_package}" />
-      <inout_port name="negative_prompts" default="{negative_prompts}" />
-      <inout_port name="prompts" default="{prompts}" />
-      <inout_port name="threshold" default="{threshold}" />
+      <inout_port name="mask_count" default="{mask_count}" />
+      <inout_port name="model_package" default="moveit_pro_sam3" />
+      <inout_port
+        name="text_encoder_model_path"
+        default="models/sam3_text_encoder.onnx"
+      />
+      <inout_port name="text_prompt" default="{text_prompt}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml
@@ -6,18 +6,15 @@
   <!--//////////-->
   <BehaviorTree
     ID="Segment Point Cloud from Text Prompt Subtree"
-    _description="Captures a point cloud and runs text-based segmentation on the camera image using the given text prompts. The point cloud is then filtered to only include the regions matching the prompts."
+    _description="Captures a point cloud and runs text-based segmentation on the camera image using the given text prompt. The point cloud is then filtered to only include the regions matching the prompt. Returns SUCCESS with empty masks3d and point_cloud_vector and mask_count 0 when no detection passes confidence_threshold, a per-detection confidence in [0, 1]."
     _favorite="false"
     camera_topic_name="/wrist_camera/camera_info"
     image_topic_name="/wrist_camera/color"
     masks_visualization_topic="/masks_visualization"
-    model_package="moveit_pro_clipseg"
+    model_package="moveit_pro_sam3"
     points_topic_name="/wrist_camera/points"
-    clip_model_path="{clip_model_path}"
-    clipseg_model_path="{clipseg_model_path}"
-    erosion_size="{erosion_size}"
-    prompts="{prompts}"
-    threshold="{threshold}"
+    text_prompt="{text_prompt}"
+    confidence_threshold="{confidence_threshold}"
     masks3d="{masks3d}"
     point_cloud="{point_cloud}"
   >
@@ -26,16 +23,17 @@
       <SubTree
         ID="Segment Image from No Negative Text Prompt Subtree"
         _collapsed="true"
-        clip_model_path="{clip_model_path}"
-        clipseg_model_path="{clipseg_model_path}"
-        erosion_size="{erosion_size}"
         masks_visualization_topic="{masks_visualization_topic}"
         model_package="{model_package}"
-        prompts="{prompts}"
-        threshold="{threshold}"
-        topic_name="{topic_name}"
+        encoder_model_path="{encoder_model_path}"
+        decoder_model_path="{decoder_model_path}"
+        geometry_encoder_model_path="{geometry_encoder_model_path}"
+        text_encoder_model_path="{text_encoder_model_path}"
+        text_prompt="{text_prompt}"
+        confidence_threshold="{confidence_threshold}"
         image_topic_name="{image_topic_name}"
         masks2d="{masks2d}"
+        mask_count="{mask_count}"
       />
       <Action
         ID="GetPointCloud"
@@ -87,21 +85,35 @@
         name="camera_topic_name"
         default="/wrist_camera/camera_info"
       />
-      <inout_port name="clip_model_path" default="{clip_model_path}" />
-      <inout_port name="clipseg_model_path" default="{clipseg_model_path}" />
-      <inout_port name="erosion_size" default="{erosion_size}" />
+      <inout_port name="confidence_threshold" default="0.5" />
+      <inout_port
+        name="decoder_model_path"
+        default="models/sam3_decoder.onnx"
+      />
+      <inout_port
+        name="encoder_model_path"
+        default="models/sam3_vision_encoder.onnx"
+      />
+      <inout_port
+        name="geometry_encoder_model_path"
+        default="models/sam3_geometry_encoder.onnx"
+      />
       <inout_port name="image_topic_name" default="/wrist_camera/color" />
       <inout_port
         name="masks_visualization_topic"
         default="/masks_visualization"
       />
       <inout_port name="masks3d" default="{masks3d}" />
-      <inout_port name="model_package" default="moveit_pro_clipseg" />
+      <inout_port name="mask_count" default="{mask_count}" />
+      <inout_port name="model_package" default="moveit_pro_sam3" />
       <inout_port name="point_cloud" default="{point_cloud}" />
       <inout_port name="point_cloud_vector" default="{point_cloud_vector}" />
       <inout_port name="points_topic_name" default="/wrist_camera/points" />
-      <inout_port name="prompts" default="{prompts}" />
-      <inout_port name="threshold" default="{threshold}" />
+      <inout_port
+        name="text_encoder_model_path"
+        default="models/sam3_text_encoder.onnx"
+      />
+      <inout_port name="text_prompt" default="{text_prompt}" />
     </SubTree>
   </TreeNodesModel>
 </root>

--- a/src/moveit_pro_ur_configs/picknik_ur_base_config/package.xml
+++ b/src/moveit_pro_ur_configs/picknik_ur_base_config/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_pro_behavior</exec_depend>
+  <exec_depend>moveit_pro_sam3</exec_depend>
   <exec_depend>picknik_accessories</exec_depend>
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>realsense2_description</exec_depend>


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#22565 (part of epic PickNikRobotics/moveit_pro#22564).

## Motivation

PR #927 removed the `moveit_pro_clipseg` submodule from `v9.4`, so the three text-prompt segmentation SubTrees shipped in `picknik_ur_base_config` and the one in `franka_base_config` fail at run time. Every `lab_sim` and `hangar_sim` Objective that segments from text reaches CLIPSeg through these SubTrees, so they have to move first; the callers follow in their own PRs (#22568, #22570, #22571, #22572).

## Brief description

The four SubTrees call `GetMasks2DFromExemplar` (SAM3) instead of `GetMasks2DFromTextQuery`, using the four explicit `*_model_path` ports MoveIt Pro 9.4 supports (9.4 has no `model_bundle_manifest` port, so the hunks are taken from `bb0d53c0`, the commit that made this port on `main`, not from today's `main`). Both `package.xml` files gain `<exec_depend>moveit_pro_sam3</exec_depend>`. The `moveit_pro_sam3` submodule pinned on `v9.4` already ships the weights.

- `picknik_ur_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml`
- `picknik_ur_base_config/objectives/segment_image_from_text_prompt_subtree.xml`
- `picknik_ur_base_config/objectives/segment_point_cloud_from_text_prompt_subtree.xml`
- `franka_base_config/objectives/segment_image_from_no_negative_text_prompt_subtree.xml` (identical to the UR copy)
- both `package.xml`

## Breaking change to three shipped SubTree interfaces

Any customer Objective calling `Segment Image from Text Prompt Subtree`, `Segment Image from No Negative Text Prompt Subtree`, or `Segment Point Cloud from Text Prompt Subtree` with the old ports breaks on upgrade to the 9.4 patch that ships this.

| Old port | New port |
|---|---|
| `prompts` | `text_prompt` |
| `threshold` | `confidence_threshold` (default `0.5`; a per-detection score, not comparable to CLIPSeg's per-pixel threshold) |
| `negative_prompts` | removed, no SAM3 equivalent |
| `erosion_size` | removed |
| `clip_model_path`, `clipseg_model_path` | replaced by `encoder_model_path`, `decoder_model_path`, `geometry_encoder_model_path`, `text_encoder_model_path`, all defaulting to the `moveit_pro_sam3` weights |
| `model_package` | kept, default now `moveit_pro_sam3` |
| (new) `mask_count` | output, the number of masks that passed the threshold, so a caller can branch on "nothing detected" now that the SubTree no longer fails in that case; a 9.4 addition beyond `bb0d53c0` |

`masks_visualization_topic` now defaults to `/masks_visualization` instead of being a required remap, as on `main`; every in-repo caller already passes that literal.

Under `docs_nonpublic/API-Boundary.md` this is a breaking change in a patch release. It is the maintainer decision recorded in PickNikRobotics/moveit_pro#22564 and #22565: the old interface is replaced rather than deprecated, because a deprecation shim would preserve only the ability to load a tree that cannot run, the CLIPSeg weights being gone from `v9.4` since #927. `GetMasks2DFromTextQuery` itself stays registered in MoveIt Pro 9.4, so a customer who vendors their own CLIPSeg weights keeps the Behavior and loses only these wrapper SubTrees. The 9.4 patch release note must name the removed ports.

Two further contract changes callers should know about:

- **Return state.** `GetMasks2DFromTextQuery` failed the SubTree when nothing matched. `GetMasks2DFromExemplar` returns SUCCESS with an empty `masks2d`, and the point-cloud SubTree then returns SUCCESS with empty `masks3d` and `point_cloud_vector` (its `ResetVector` keeps the vector defined, so the `ForEach` exits cleanly). Each SubTree's `_description` now says so, and the new `mask_count` output is the branchable signal. A caller that used the old FAILURE as control flow now proceeds with empty vectors and fails later, for example at `GetElementOfVector`, unless it checks `mask_count`.
- **`confidence_threshold` is not a rename of `threshold`.** CLIPSeg's value was a per-pixel probability cutoff; SAM3's is a per-detection score. Carry-over values such as 0.15 or 0.7 would be wrong in both directions; the caller PRs start from the `0.5` default.

Because these SubTrees live in the base configs, every derived config (`lab_sim`, `hangar_sim`, `mock_sim`, `picknik_ur_site_config`, `kitchen_sim`) now depends on the `moveit_pro_sam3` submodule, about 590 MB of LFS weights, whether or not it segments anything. `dual_arm_sim` inherits neither base config and ports its own copies in #22566.

## How it was tested

- `colcon build --packages-select picknik_ur_base_config franka_base_config` in the 9.4.2 base container.
- `pre-commit run` on all six files passes.
- No shipped Objective calls these SubTrees with the new ports until the caller PRs land, so I exercised all three UR SubTrees from a 9.4.2 Runtime by temporarily applying the caller edits from #22568, #22570, and #22571 (not committed here) and running `ML Segment Image`, `ML Segment Point Cloud`, and `AddBottlesToPlanningScene` in `lab_sim` on CPU-only ONNX Runtime. Results below.
- Those callers omit every `*_model_path` port, so the runs exercise the SubTrees' default model paths, including the point-cloud SubTree forwarding its own defaults to the inner image SubTree.
- The `franka_base_config` copy has no caller in the shipped configs; it is byte-identical to the UR copy, so the UR run covers its XML.
- Not checked here: whether dropping `erosion_size` leaves boundary halo in the projected point-cloud fragments. MuJoCo depth has no mixed pixels, so sim cannot show it either way; `ErodeMask2D` exists on 9.4 and can be inserted before `GetMasks3DFromMasks2D` without a port change if hardware validation calls for it. Recorded on the epic as a follow-up rather than added blind here.
- Also pre-existing and unchanged: the point-cloud SubTree captures the image before the cloud, so on the first run the two are separated by the SAM3 model load. Fine for static scenes; `GetSyncedImageAndPointCloud` would remove the assumption. Noted on the epic.

The port hunks match `bb0d53c0` so the 9.4 and 10.x SubTrees stay in step; the deviations are the description clauses and the `mask_count` output, both additive. Two things reviewers may ask about were left as on `main` on purpose: the two image SubTrees are now near-duplicates (only `negative_prompts` distinguished them), and the point-cloud SubTree's root-tag attribute list no longer mirrors its port model. Collapsing the SubTrees would be a second interface break, and both are cosmetic otherwise.

The caller PRs (#22568, #22570, #22571, #22572) should merge into the same 9.4.4 release as this one so no shipped `v9.4` revision has base-config SubTrees that no in-repo caller can load.
- Verification is manual by necessity: the objectives integration test skips every ML Objective on CPU runners.

| Objective (temporary caller edit) | SubTree exercised | Result |
|---|---|---|
| `ML Segment Image` | `Segment Image from No Negative Text Prompt Subtree` | succeeds in 23 s; 19 per-instance masks over the table objects, labelled from `text_prompt` |
| `ML Segment Point Cloud` | `Segment Point Cloud from Text Prompt Subtree` (which calls the no-negative SubTree internally with the new ports) | succeeds in 43 s; masked point clouds published |
| `AddBottlesToPlanningScene` | `Segment Image from Text Prompt Subtree` | succeeds in 56 s; the three conical flasks are masked, the box is not, at the default `confidence_threshold="0.5"` |

The `/masks_visualization` frames for all three are attached below.

## Release notes

- `Bug Fix:` Fixed the text-prompt segmentation SubTrees in `picknik_ur_base_config` and `franka_base_config`, which failed after the CLIPSeg weights were removed; they now segment with SAM3. Breaking: their ports are now `text_prompt` and `confidence_threshold`, and `negative_prompts`, `erosion_size`, `clip_model_path`, and `clipseg_model_path` are gone.

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these.*

- [x] `code-reviewer`
  - no required changes; two cosmetic notes on the point-cloud SubTree's root tag deferred to keep the file identical to `bb0d53c0`
- [x] `documentation-bot`
  - no documentation impact; the SubTree IDs appear only in frozen versioned docs
- [x] `licensing-privacy-bot`
  - no new exposure; the `moveit_pro_sam3` pin is unchanged
- [x] `platform-architect-bot`
  - applied: return-state clause in every `_description`; confirmed the default model-path route is what the sim runs exercised
- [x] `roboticist-bot`
  - applied: `mask_count` output on all three SubTrees, singular "text prompt" wording, threshold semantics in the descriptions; erosion and image/cloud sync recorded as follow-ups on the epic
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] `compatibility-bot`
  - one `Breaking` finding, the accepted port rename described above; no code change
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, or TypeScript changed
- [x] `test-runner`
  - `colcon build` and `colcon test` for both packages in the 9.4.2 base container: 12 lint results, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
