### PR TITLE
Fix: Describe the SAM3 end condition of dual_arm_sim Sort Blocks on 9.4

### DIFF
--- a/src/dual_arm_sim/objectives/sort_blocks.xml
+++ b/src/dual_arm_sim/objectives/sort_blocks.xml
@@ -2,7 +2,7 @@
 <root BTCPP_format="4" main_tree_to_execute="Sort Blocks">
   <BehaviorTree
     ID="Sort Blocks"
-    _description="Clears colored blocks off the table by color, right arm for red and left for green. A CLIPSeg no-masks error is expected when a color runs out of blocks."
+    _description="Clears colored blocks off the table by color, right arm for red and left for green. An error is expected when a color runs out of blocks: segmentation returns no masks, and the downstream point cloud lookup then fails on the empty result."
     _favorite="true"
   >
     <Control ID="Sequence">


### PR DESCRIPTION
[written by AI]

Closes PickNikRobotics/moveit_pro#22575 (part of epic PickNikRobotics/moveit_pro#22564).

## Motivation

`Sort Blocks`, a `dual_arm_sim` favourite, reaches segmentation through `Find Red Block` / `Find Green Block` and the SubTree chain ported in #939. It contains no CLIPSeg call itself, but its `_description` tells the operator that "A CLIPSeg no-masks error is expected when a color runs out of blocks." After the port there is no CLIPSeg in the path and no no-masks error: SAM3 returns SUCCESS with zero masks, and the loop ends when `Find with prompt` fails on the empty point-cloud vector. The description renders in the Desktop App, so it has to describe the failure the operator will actually see.

## Brief description

One attribute in `src/dual_arm_sim/objectives/sort_blocks.xml`: the `_description`, using the wording `main` adopted in `a9c4abf4`: "An error is expected when a color runs out of blocks: segmentation returns no masks, and the downstream point cloud lookup then fails on the empty result."

## How it was tested

- `pre-commit run` on the file passes (prettier, objective-favourites check).
- Ran **Sort Blocks** to completion on a 9.4.2 Runtime with the #939 chain in place, CPU-only ONNX Runtime. It succeeds in 191 s after four pick-and-place cycles (42 s, 35 s, 51 s, 31 s by the Objective's own stopwatch), and the only error in the log is the terminating one the new description names: `GetMasks2DFromExemplar Info: No masks passed confidence threshold (0.500)` followed by `GetElementOfVector Error: Index 0 out of range for vector of size 0`.
- End state: all three green blocks and one red block cleared, two red blocks left on the table. That is the tree's existing design, not a port regression: a `BiasedCoinFlip` chooses the red branch, so once green is exhausted the loop ends on the first tick that skips red, and the Objective's own opening `LogMessage` warns "the robot may miss blocks". CLIPSeg terminated the same way, one Behavior earlier.
- Verification is manual by necessity: `dual_arm_sim` has no objectives integration test on `v9.4`.

Depends on #939 (dual_arm_sim SubTree port) for the behaviour it describes. The wording is engine-agnostic, so it is also accurate on `v9.4` today, where the same empty-vector failure ends the loop.

## Release notes

None (covered by the #939 bullet; this is a description string).

---

## Claude agent checks

*Autofilled by Claude when it opens or updates this PR. Each agent that was actually run gets ticked; path-gated agents that don't apply are ticked with `SKIPPED` on the checkbox line, before the agent name. Any note about what was done (or, for a skip, why) goes on its own indented detail line below the agent's checkbox line. `code-reviewer` always runs on every PR of every type and is never `SKIPPED`. Humans rarely need to touch these.*

- [x] `code-reviewer`
  - no required changes; commit body reworded so the SAM3 port is attributed to #939 rather than stated as already merged; the 154-character sentence was reviewed against the diagnostics rule and kept, since it is one sentence stating cause and evidence
- [x] SKIPPED `documentation-bot`
  - no public doc documents Sort Blocks; the README's dual_arm_sim entries were handled in #939
- [x] SKIPPED `licensing-privacy-bot`
  - description string only
- [x] SKIPPED `platform-architect-bot`
  - this wording change is the one that bot and the roboticist bot requested in their #939 reviews, and it matches `main`
- [x] SKIPPED `roboticist-bot`
  - same
- [x] SKIPPED `frontend-noah-bot`
  - no frontend files changed
- [x] SKIPPED `security-auditor`
  - no security-sensitive paths changed
- [x] SKIPPED `compatibility-bot`
  - no interface change; a description attribute
- [x] SKIPPED `sonar-bot`
  - no C, C++, Python, or TypeScript changed
- [x] `test-runner`
  - `colcon build` and `colcon test` for `dual_arm_sim` in the 9.4.2 base container: 16 lint results, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
